### PR TITLE
fix(mafia): add aliveness checks for jailor

### DIFF
--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -845,6 +845,14 @@ module.exports = class Player {
         return this.items.filter(i => i.name == itemName)
     }
 
+    getItemProp(itemName, prop, value) {
+        for (let item of this.items)
+            if (item.name == itemName && String(item[prop]) == value)
+                return item;
+
+        return
+    }
+
     hasEffect(effectName) {
         for (let effect of this.effects)
             if (effect.name == effectName)

--- a/Games/types/Mafia/items/Handcuffs.js
+++ b/Games/types/Mafia/items/Handcuffs.js
@@ -3,10 +3,11 @@ const { MEETING_PRIORITY_JAIL } = require("../const/MeetingPriority");
 
 module.exports = class Handcuffs extends Item {
 
-    constructor(meetingName) {
+    constructor(meetingName, jailor) {
         super("Handcuffs");
 
         this.meetingName = meetingName;
+        this.jailor = jailor;
         this.lifespan = 1;
         this.cannotBeStolen = true;
         this.meetings[meetingName] = {
@@ -17,6 +18,10 @@ module.exports = class Handcuffs extends Item {
             inputType: "boolean",
             canVote: false,
             priority: MEETING_PRIORITY_JAIL,
+            shouldMeet: function(meetingName) {
+                let handcuff = this.player.getItemProp("Handcuffs", "meetingName", meetingName);
+                return handcuff?.jailor.alive;
+            }
         };
     }
 }

--- a/Games/types/Mafia/roles/cards/JailTarget.js
+++ b/Games/types/Mafia/roles/cards/JailTarget.js
@@ -28,7 +28,7 @@ module.exports = class JailTarget extends Card {
                     priority: PRIORITY_DAY_DEFAULT,
                     run: function () {
                         if (this.dominates()) {
-                            this.target.holdItem("Handcuffs", this.actor.role.data.meetingName);
+                            this.target.holdItem("Handcuffs", this.actor.role.data.meetingName, this.actor);
                             this.actor.role.data.prisoner = this.target;
                         }
                     }


### PR DESCRIPTION
- [x] jailed person does not go to jail if jailer died (check jailor alive)
- [x] jailor does not get a meeting if the target died (check handcuff holder alive)
- [x] if jailor NLs when another jailor jails, jailor no longer gets a meeting (check handcuff owner)