### PR TITLE
fix(mafia): maid is able to do oneshot actions

### DIFF
--- a/Games/types/Mafia/roles/cards/OneShot.js
+++ b/Games/types/Mafia/roles/cards/OneShot.js
@@ -5,7 +5,7 @@ module.exports = class OneShot extends Card {
     constructor(role) {
         super(role);
 
-        this.metCount = {};
+        role.metCount = {};
         this.meetingMods = {
             "*": {
                 shouldMeet: function (meetingName) {


### PR DESCRIPTION
I think it's a question of whether we WANT to fix this or not

The way I made it now, maided completely resets one shot state --> a one shot cop can get unlimited abilities using maid

I can toggle it such that each user can only do the one shot once, so after you're maided back the ability state is preserved (by saving data in player.data)