### PR TITLE
fix: force kick meeting to always generate target

### DIFF
--- a/Games/core/VegKickMeeting.js
+++ b/Games/core/VegKickMeeting.js
@@ -19,6 +19,11 @@ module.exports = class VegKickMeeting extends Meeting {
         this.hasFrozenOtherMeetings = false;
     }
 
+    generateTargets() {
+        // overrides the check for dawn's noAct
+        this.targets = ["Kick"];
+    }
+
     getMeetingInfo(player) {
         let info = super.getMeetingInfo(player);
         info.canUnvote = false;


### PR DESCRIPTION
This is to fix the bug where dawnstart games do not have a kick option. It will show "None".

The user reported the bug with the JFK setup
