### PR TITLE
fix(ui): move typing bubbles further right

### DIFF
--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -583,7 +583,7 @@
 }
 
 .game .player-list .player .typing-icon.has-role {
-	left: 80px;
+	left: 120px;
 }
 
 .game .player-list .section-title {


### PR DESCRIPTION
![image](https://github.com/BeyonderMafia/BeyonderMafia/assets/24848927/d6869b6b-7068-44de-8dda-39acaf96ad88)

Fixes #84 