### PR TITLE
Temporary server deprecating fix

### DIFF
--- a/Games/games.js
+++ b/Games/games.js
@@ -213,17 +213,17 @@ var deprecated = false;
         });
 
         // The main server marking deprecating this process
-        socket.on("deprecated", async (data) => {
-          try {
-            if (!socket.isServer)
-              throw new Error("Not authenticated as server.");
+        // socket.on("deprecated", async (data) => {
+        //   try {
+        //     if (!socket.isServer)
+        //       throw new Error("Not authenticated as server.");
 
-            deprecated = true;
-            await deprecationCheck();
-          } catch (e) {
-            logger.error(e);
-          }
-        });
+        //     deprecated = true;
+        //     await deprecationCheck();
+        //   } catch (e) {
+        //     logger.error(e);
+        //   }
+        // });
       } catch (e) {
         logger.error(e);
       }


### PR DESCRIPTION
For some reason the deprecation of the server is happening, and I'm not sure why. So I'm disabling it in the games.js script for now.