### PR TITLE
fix: prevent double sending result when no permission to review priva…

### DIFF
--- a/routes/game.js
+++ b/routes/game.js
@@ -199,7 +199,7 @@ router.get("/:id/review/data", async function (req, res) {
     if (
       game &&
       (!game.private ||
-        (userId && (await routeUtils.verifyPermission(res, userId, perm))))
+        (userId && (await routeUtils.verifyPermission(userId, perm))))
     ) {
       game = game.toJSON();
       game.users = game.users.map((user) => ({


### PR DESCRIPTION
…te games


```
2023-06-24T03:50:14.624Z error: Cannot set headers after they are sent to the client 
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (_http_outgoing.js:558:11)
    at ServerResponse.header (/home/ec2-user/um/node_modules/express/lib/response.js:767:10)
    at ServerResponse.send (/home/ec2-user/um/node_modules/express/lib/response.js:170:12)
    at /home/ec2-user/um/routes/game.js:220:9
    at runMicrotasks (<anonymous>)
```