### PR TITLE
fix pie chart

### DIFF
--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -502,9 +502,8 @@ export default function Profile() {
                 <PieChart
                   wins={mafiaStats.wins.count}
                   losses={
-                    mafiaStats.totalGames -
-                    mafiaStats.wins.count -
-                    mafiaStats.abandons.total
+                    mafiaStats.wins.total -
+                    mafiaStats.wins.count
                   }
                   abandons={mafiaStats.abandons.total}
                 />


### PR DESCRIPTION
Following up on discussion from [discord](https://discord.com/channels/1102713221711925339/1117728202366918717/1124867794186534982):

Currently pie charts are calculating losses from `totalGames`, which includes games that were abandoned by others: 

`losses = totalGames - wins.count - abandons.total` which basically just includes abandoned games in losses.


Within stats, `totalGames` is recalculated (as `totalGamesUnabandoned`) as `wins.total + abandons.total`.

totalGamesUnabandoned - wins - abandons => `(wins.total + abandons.total) - wins.count - abandons.total` => `wins.total - wins.count`

# **THIS IS UNTESTED**