### PR TITLE
feat: scatterbrained improvements

### DIFF
--- a/Games/types/Mafia/roles/cards/Scatterbrained.js
+++ b/Games/types/Mafia/roles/cards/Scatterbrained.js
@@ -14,6 +14,10 @@ module.exports = class Scatterbrained extends Card {
       appearance = "Visitor";
     } else if (this.role.alignment === "Mafia") {
       appearance = "Trespasser";
+    } else if (this.role.alignment === "Cult") {
+      appearance = "Werewolf";
+    } else if (this.role.alignment === "Independent") {
+      appearance = "Fool";
     }
 
     if (!appearance) {
@@ -36,5 +40,17 @@ module.exports = class Scatterbrained extends Card {
         actionName: "Village Vote",
       },
     };
+
+    if (this.role.alignment === "Independent") {
+      this.meetingMods["*"] = {
+          actionName: "Fool Around"
+      }
+  }
+
+  if (this.role.alignment === "Monsters") {
+      this.meetingMods["*"] = {
+          actionName: "Wolf Bite"
+      }
+    }
   }
 };

--- a/data/roles.js
+++ b/data/roles.js
@@ -1107,6 +1107,7 @@ const roleData = {
         "Each night, bites a non-Cult player and turns them into a Lycan.",
         "Lycans retain their original roles, but they unknowingly kill a random non-Cult player on full moons.",
         "Invincible during full moons, except for when visiting the Priest.",
+        "Cult roles with the Scatterbrained modifier appear as this role to self.",
       ],
     },
     Witch: {
@@ -1205,6 +1206,7 @@ const roleData = {
         "Wins if executed by the town.",
         "No one else wins if the Fool wins.",
         "Clown appears as this role to self.",
+        "Independent roles with the Scatterbrained modifier appear as this role to self.",
       ],
     },
     Executioner: {


### PR DESCRIPTION
Not using any /v/illage code but inspired by it: Scatterbrained modifier now designates Cult players as Werewolf and Independent players as Fool. Code changes were negligent.