### PR TITLE
Feat: Better Lone and Scatterbrained cards, merged Solitary into Lone

### DIFF
--- a/Games/core/Meeting.js
+++ b/Games/core/Meeting.js
@@ -61,6 +61,7 @@ module.exports = class Meeting {
       player: player,
       leader: options.leader,
       voteWeight: options.voteWeight || 1,
+      alive: player.alive,
       canVote:
         options.canVote != false && (player.alive || !options.passiveDead),
       canUpdateVote:
@@ -108,7 +109,7 @@ module.exports = class Meeting {
       this.game.setup.whispers &&
       this.name != "Pregame" &&
       // disable whispers for anonymous meetings that are not the village meeting
-      !(this.anonymous && this.name != "Village")
+      !(this.anonymous && this.name != "Village") && member.alive
     ) {
       member.speechAbilities.unshift({
         name: "Whisper",
@@ -251,6 +252,7 @@ module.exports = class Meeting {
       canUpdateVote: member.canUpdateVote,
       canUnvote: member.canUnvote,
       canTalk: member.canTalk,
+      alive: member.alive,
       speechAbilities: this.getSpeechAbilityInfo(member),
       // vcToken:
       //   this.speech && !this.anonymous && member.canTalk && member.vcToken,
@@ -756,6 +758,12 @@ module.exports = class Meeting {
 
     if (message.recipients.length == 0) return;
 
+    if (defaultRecipients) {
+      message.modified = true;
+  }
+
+  let anonymize = member.alive ? this.anonymous : false
+
     message = new Message({
       sender: message.sender,
       content: message.content,
@@ -765,7 +773,7 @@ module.exports = class Meeting {
       prefix: message.prefix,
       abilityName: message.abilityName,
       abilityTarget: message.abilityTarget,
-      anonymous: this.anonymous,
+      anonymous: anonymize,
     });
 
     message.send();
@@ -793,7 +801,7 @@ module.exports = class Meeting {
       meeting: this,
       fromMeetingId: quote.fromMeetingId,
       fromState: quote.fromState,
-      anonymous: this.anonymous,
+      anonymous: anonymize,
     });
 
     quote.send();

--- a/Games/core/Message.js
+++ b/Games/core/Message.js
@@ -83,7 +83,7 @@ module.exports = class Message {
     if (!version) version = this;
 
     if (version.isServer) senderId = "server";
-    else if (version.anonymous) senderId = "anonymous";
+    else if (version.anonymous && (player.alive || (!player.alive && version.sender.alive))) senderId = "anonymous";
     else if (version.sender) senderId = version.sender.id;
     else return;
 

--- a/Games/types/Mafia/roles/cards/Lone.js
+++ b/Games/types/Mafia/roles/cards/Lone.js
@@ -11,6 +11,12 @@ module.exports = class Lone extends Card {
       Cult: {
         disabled: true,
       },
+      "Templar Meeting": {
+          disabled: true
+      },
+      "Learn Alignment": {
+          flags: ["voting"],
+      },
     };
   }
-};
+}

--- a/Games/types/Mafia/roles/cards/Scatterbrained.js
+++ b/Games/types/Mafia/roles/cards/Scatterbrained.js
@@ -10,7 +10,7 @@ module.exports = class Scatterbrained extends Card {
     };
 
     var appearance;
-    if (this.role.alignment === "Village" || this.role.winCount === "Village") {
+    if (this.role.alignment === "Village") {
       appearance = "Visitor";
     } else if (this.role.alignment === "Mafia") {
       appearance = "Trespasser";

--- a/Games/types/Mafia/roles/cards/Solitary.js
+++ b/Games/types/Mafia/roles/cards/Solitary.js
@@ -1,16 +1,8 @@
 const Card = require("../../Card");
 
-module.exports = class Solitary extends Card {
+module.exports = class Solitary extends Lone {
   constructor(role) {
     super(role);
 
-    this.meetingMods = {
-      "Templar Meeting": {
-        disabled: true,
-      },
-      "Learn Alignment": {
-        flags: ["voting"],
-      },
-    };
   }
-};
+}

--- a/react_main/src/pages/Learn/LearnMafia.jsx
+++ b/react_main/src/pages/Learn/LearnMafia.jsx
@@ -203,12 +203,12 @@ export default function LearnMafia(props) {
     },
     {
       name: "Lone",
-      text: "Does not attend the Mafia or Cult meeting.",
+      text: "Does not attend the Mafia/Cult/Templar/Cult meeting.",
       icon: <div className="icon modifier modifier-Mafia-Lone" />,
     },
     {
       name: "Solitary",
-      text: "Does not attend the Cop or Templar meetings.",
+      text: "Same as Lone (backwards compatibility).",
       icon: <div className="icon modifier modifier-Mafia-Solitary" />,
     },
     {


### PR DESCRIPTION
Ported from /v/ and largely provided by Vastined. I made minor changes where relevant. Scatterbrained now covers all four alignments. Werewolf is considered the default visitor of the Cult; Fool the default visitor of the Independents. Lone covers Mafia/Cult/Templars/Cops altogether, and Solitary extends Lone for backwards compatibility purposes. May precede larger changes to meetings for Village roles.