### PR TITLE
fix: wills persist but not editable during the day

### DIFF
--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -2204,6 +2204,7 @@ export function Timer(props) {
 
 export function LastWillEntry(props) {
   const [lastWill, setLastWill] = useState(props.lastWill);
+  const cannotModifyLastWill = props.cannotModifyLastWill;
 
   function onWillChange(e) {
     var newWill = e.target.value.slice(0, MaxWillLength);
@@ -2221,7 +2222,7 @@ export function LastWillEntry(props) {
       title="Last Will"
       content={
         <div className="last-will-wrapper">
-          <textarea
+          <textarea readOnly={cannotModifyLastWill}
             className="last-will-entry"
             value={lastWill}
             onChange={onWillChange}

--- a/react_main/src/pages/Game/MafiaGame.jsx
+++ b/react_main/src/pages/Game/MafiaGame.jsx
@@ -259,9 +259,11 @@ export default function MafiaGame() {
             {!game.review &&
               !isSpectator &&
               history.currentState >= 0 &&
-              game.setup.lastWill &&
-              !history.states[stateViewing].name.startsWith("Day") && (
-                <LastWillEntry lastWill={game.lastWill} socket={game.socket} />
+              game.setup.lastWill && (
+                <LastWillEntry 
+                  lastWill={game.lastWill} 
+                  cannotModifyLastWill={history.states[stateViewing].name.startsWith("Day")}
+                  socket={game.socket} />
               )}
             {!game.review && !isSpectator && (
               <Notes stateViewing={stateViewing} />


### PR DESCRIPTION
quick and dirty fix to make wills persist night to night

wills are editable during the night and read only during the day. tested locally

resolves #615 