### PR TITLE
feat: Dedicated Rolestopper roles, Guard (Village) and Bouncer (Mafia)

### DIFF
--- a/Games/types/Mafia/roles/Mafia/Bouncer.js
+++ b/Games/types/Mafia/roles/Mafia/Bouncer.js
@@ -1,0 +1,15 @@
+const Role = require("../../Role");
+
+module.exports = class Bouncer extends Role {
+  constructor(player, data) {
+    super("Bouncer", player, data);
+
+    this.alignment = "Mafia";
+    this.cards = [
+      "VillageCore",
+      "WinWithMafia",
+      "MeetingMafia",
+      "Rolestopper",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/Village/Guard.js
+++ b/Games/types/Mafia/roles/Village/Guard.js
@@ -4,7 +4,7 @@ module.exports = class Guard extends Role {
   constructor(player, data) {
     super("Guard", player, data);
 
-    this.alignment = "Mafia";
+    this.alignment = "Village";
     this.cards = [
       "VillageCore",
       "WinsWithVillage",

--- a/Games/types/Mafia/roles/Village/Guard.js
+++ b/Games/types/Mafia/roles/Village/Guard.js
@@ -1,0 +1,14 @@
+const Role = require("../../Role");
+
+module.exports = class Guard extends Role {
+  constructor(player, data) {
+    super("Guard", player, data);
+
+    this.alignment = "Mafia";
+    this.cards = [
+      "VillageCore",
+      "WinsWithVillage",
+      "Rolestopper",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/cards/Rolestopper.js
+++ b/Games/types/Mafia/roles/cards/Rolestopper.js
@@ -1,0 +1,22 @@
+const Card = require("../../Card");
+const { PRIORITY_UNTARGETABLE } = require("../../const/Priority");
+
+module.exports = class Rolestopper extends Card {
+  constructor(role) {
+    super(role);
+
+    this.meetings = {
+      Stop: {
+        states: ["Night"],
+        flags: ["voting"],
+        action: {
+          labels: ["stop"],
+          priority: PRIORITY_UNTARGETABLE,
+          run: function () {
+            this.makeUntargetable();
+          },
+        },
+      },
+    };
+  }
+};

--- a/data/roles.js
+++ b/data/roles.js
@@ -759,6 +759,12 @@ const roleData = {
         "Each night learns how many of their alive neighbors are evil.",
       ],
     },
+    Guard: {
+      alignment: "Village",
+      description: [
+        "Each night protects one person from all visits.",
+      ],
+    },
 
     //Mafia
     Mafioso: {
@@ -1199,6 +1205,12 @@ const roleData = {
       description: [
         "Once per night can forge the will of another player.",
         "Learns that person's real will on the next day.",
+      ],
+    },
+    Bouncer: {
+      alignment: "Mafia",
+      description: [
+        "Each night protects one person from all visits.",
       ],
     },
 


### PR DESCRIPTION
Replaces Jailkeep from EM. Dedicated rolestoppers for both major factions, plus a card that uses makeUntargetable in its function.