### PR TITLE
fix(ui): closed role count in popover [need help]

### DIFF
--- a/react_main/src/components/Roles.jsx
+++ b/react_main/src/components/Roles.jsx
@@ -79,7 +79,6 @@ export function RoleCount(props) {
 
     return (
       <div className="role-count-wrap">
-        {props.count > 1 && <DigitsCount digits={digits} />}
         <div
           className={`role role-${roleClass} ${props.small ? "small" : ""} ${
             props.bg ? "bg" : ""
@@ -89,6 +88,7 @@ export function RoleCount(props) {
           onMouseEnter={onRoleMouseEnter}
           ref={roleRef}
         >
+          {props.count > 1 && <DigitsCount digits={digits} />}
           {modifier && (
             <div
               className={`modifier modifier-${props.gameType}-${hyphenDelimit(
@@ -101,7 +101,7 @@ export function RoleCount(props) {
     );
   } else if (props.count > 0 || props.hideCount) {
     return (
-      <div className="role-count-wrap">
+      <div className="role-count-wrap closed-role-count">
         {!props.hideCount && <DigitsCount digits={digits} />}
         <i
           className={`fas fa-question i-${props.alignment}`}

--- a/react_main/src/css/roles.css
+++ b/react_main/src/css/roles.css
@@ -137,9 +137,14 @@
 
 .digits-wrapper {
   position: absolute;
-  align-self: flex-end;
+  top: 18px;
   width: auto;
   z-index: 1;
+}
+
+.closed-role-count .digits-wrapper {
+  position: relative;
+  left: 8px;
 }
 
 .digit {


### PR DESCRIPTION
before:
![image](https://github.com/UltiMafia/Ultimafia/assets/24848927/f8f75cb9-c1af-47e4-a6d6-35f25fe17f37)
counts were appearing all the way at the bottom

after:
![image](https://github.com/UltiMafia/Ultimafia/assets/24848927/e7cf0c5c-b85a-4a36-b6b9-95dea7c663a4)
