### PR TITLE
feat: Deprecating BP, Bomb, VI

### DIFF
--- a/Games/types/Mafia/roles/Village/Bomber.js
+++ b/Games/types/Mafia/roles/Village/Bomber.js
@@ -1,10 +1,8 @@
 const Role = require("../../Role");
 
-module.exports = class Bomber extends Role {
+module.exports = class Bomber extends Villager {
   constructor(player, data) {
     super("Bomber", player, data);
 
-    this.alignment = "Village";
-    this.cards = ["VillageCore", "WinWithVillage", "StartWithBomb"];
   }
 };

--- a/Games/types/Mafia/roles/Village/Priest.js
+++ b/Games/types/Mafia/roles/Village/Priest.js
@@ -8,6 +8,7 @@ module.exports = class Priest extends Role {
     this.cards = [
       "VillageCore",
       "WinWithVillage",
+      "LearnVisitorsRole",
       "CleanseLycanVisitors",
       "KillWerewolfVisitors",
       "ConvertKillersOnDeath",

--- a/Games/types/Mafia/roles/Village/Veteran.js
+++ b/Games/types/Mafia/roles/Village/Veteran.js
@@ -1,10 +1,8 @@
 const Role = require("../../Role");
 
-module.exports = class Veteran extends Role {
+module.exports = class Veteran extends Villager {
   constructor(player, data) {
     super("Veteran", player, data);
 
-    this.alignment = "Village";
-    this.cards = ["VillageCore", "WinWithVillage", "StartWithArmor"];
   }
 };

--- a/Games/types/Mafia/roles/Village/VillageIdiot.js
+++ b/Games/types/Mafia/roles/Village/VillageIdiot.js
@@ -1,15 +1,8 @@
 const Role = require("../../Role");
 
-module.exports = class SeeRandomSpeakers extends Role {
+module.exports = class SeeRandomSpeakers extends Villager {
   constructor(player, data) {
     super("Village Idiot", player, data);
 
-    this.alignment = "Village";
-    this.cards = [
-      "VillageCore",
-      "WinWithVillage",
-      "SeeRandomSpeakers",
-      "Humble",
-    ];
   }
 };

--- a/Games/types/Mafia/roles/cards/Humble.js
+++ b/Games/types/Mafia/roles/cards/Humble.js
@@ -4,11 +4,61 @@ module.exports = class Humble extends Card {
   constructor(role) {
     super(role);
 
-    this.appearance = {
-      self: "Villager",
-    };
     this.hideModifier = {
       self: true,
+      reveal: true,
     };
+
+    var appearance;
+    if (this.role.alignment === "Village") {
+      appearance = "Villager";
+    } else if (this.role.alignment === "Mafia") {
+      appearance = "Mafioso";
+    } else if (this.role.alignment === "Cult") {
+      appearance = "Cultist";
+    } else if (this.role.alignment === "Independent") {
+      appearance = "Grouch";
+    } else if (this.role.alignment === "Village" && this.role.act) {
+      appearance = "Visitor";
+    } else if (this.role.alignment === "Mafia" && this.role.act) {
+      appearance = "Trespasser";
+    } else if (this.role.alignment === "Cult" && this.role.act) {
+      appearance = "Werewolf";
+    } else if (this.role.alignment === "Independent" && this.role.act) {
+      appearance = "Fool";
+    }
+
+    if (!appearance) {
+      return;
+    }
+
+    this.appearance = {
+      self: appearance,
+      reveal: appearance,
+    };
+    
+    this.meetingMods = {
+      "*": {
+        actionName: "Visit",
+      },
+      Mafia: {
+        actionName: "Mafia Kill",
+      },
+      Village: {
+        actionName: "Village Vote",
+      },
+    };
+
+    if (this.role.alignment === "Independent") {
+      this.meetingMods["*"] = {
+        actionName: "Fool Around",
+      };
+    }
+
+    if (this.role.alignment === "Monsters") {
+      this.meetingMods["*"] = {
+        actionName: "Wolf Bite",
+      };
+    }
   }
 };

--- a/Games/types/Mafia/roles/cards/Humble.js
+++ b/Games/types/Mafia/roles/cards/Humble.js
@@ -36,7 +36,7 @@ module.exports = class Humble extends Card {
       self: appearance,
       reveal: appearance,
     };
-    
+
     this.meetingMods = {
       "*": {
         actionName: "Visit",

--- a/Games/types/Mafia/roles/cards/Humble.js
+++ b/Games/types/Mafia/roles/cards/Humble.js
@@ -18,14 +18,6 @@ module.exports = class Humble extends Card {
       appearance = "Cultist";
     } else if (this.role.alignment === "Independent") {
       appearance = "Grouch";
-    } else if (this.role.alignment === "Village" && this.role.act) {
-      appearance = "Visitor";
-    } else if (this.role.alignment === "Mafia" && this.role.act) {
-      appearance = "Trespasser";
-    } else if (this.role.alignment === "Cult" && this.role.act) {
-      appearance = "Werewolf";
-    } else if (this.role.alignment === "Independent" && this.role.act) {
-      appearance = "Fool";
     }
 
     if (!appearance) {
@@ -36,29 +28,5 @@ module.exports = class Humble extends Card {
       self: appearance,
       reveal: appearance,
     };
-
-    this.meetingMods = {
-      "*": {
-        actionName: "Visit",
-      },
-      Mafia: {
-        actionName: "Mafia Kill",
-      },
-      Village: {
-        actionName: "Village Vote",
-      },
-    };
-
-    if (this.role.alignment === "Independent") {
-      this.meetingMods["*"] = {
-        actionName: "Fool Around",
-      };
-    }
-
-    if (this.role.alignment === "Monsters") {
-      this.meetingMods["*"] = {
-        actionName: "Wolf Bite",
-      };
-    }
   }
 };

--- a/Games/types/Mafia/roles/cards/LearnVisitorsRole.js
+++ b/Games/types/Mafia/roles/cards/LearnVisitorsRole.js
@@ -1,0 +1,26 @@
+const Card = require("../../Card");
+const { PRIORITY_INVESTIGATIVE_DEFAULT } = require("../../const/Priority");
+
+module.exports = class LearnVisitorsRole extends Card {
+  constructor(role) {
+    super(role);
+
+    this.actions = [
+      {
+        priority: PRIORITY_INVESTIGATIVE_DEFAULT,
+        labels: ["investigate", "role", "hidden", "absolute"],
+        run: function () {
+          if (this.game.getStateName() != "Night") return;
+
+          for (let action of this.game.actions[0]) {
+            if (action.target == this.actor && !action.hasLabel("hidden")) {
+              var role = action.actor.getAppearance("investigate", true);
+              var alert = `Last night, a ${action.actor.role} visited you and confessed their sins.`;
+              this.actor.queueAlert(alert);
+            }
+          }
+        },
+      },
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/cards/LearnVisitorsRole.js
+++ b/Games/types/Mafia/roles/cards/LearnVisitorsRole.js
@@ -15,7 +15,7 @@ module.exports = class LearnVisitorsRole extends Card {
           for (let action of this.game.actions[0]) {
             if (action.target == this.actor && !action.hasLabel("hidden")) {
               var role = action.actor.getAppearance("investigate", true);
-              var alert = `Last night, a ${action.actor.role} visited you and confessed their sins.`;
+              var alert = `Last night, a ${this.actor.role} visited you and confessed their sins.`;
               this.actor.queueAlert(alert);
             }
           }

--- a/Games/types/Mafia/roles/cards/Modest.js
+++ b/Games/types/Mafia/roles/cards/Modest.js
@@ -1,32 +1,8 @@
 const Card = require("../../Card");
 
-module.exports = class Modest extends Card {
+module.exports = class Modest extends Humble {
   constructor(role) {
     super(role);
 
-    this.hideModifier = {
-      self: true,
-      reveal: true,
-    };
-
-    var appearance;
-    if (this.role.alignment === "Village" || this.role.winCount === "Village") {
-      appearance = "Villager";
-    } else if (this.role.alignment === "Mafia") {
-      appearance = "Mafioso";
-    } else if (this.role.alignment === "Cult") {
-      appearance = "Cultist";
-    } else if (this.role.alignment === "Independent") {
-      appearance = "Grouch";
-    }
-
-    if (!appearance) {
-      return;
-    }
-
-    this.appearance = {
-      self: appearance,
-      reveal: appearance,
-    };
   }
 };

--- a/Games/types/Mafia/roles/cards/Scatterbrained.js
+++ b/Games/types/Mafia/roles/cards/Scatterbrained.js
@@ -1,8 +1,56 @@
 const Card = require("../../Card");
 
-module.exports = class Scatterbrained extends Humble {
+module.exports = class Scatterbrained extends Card {
   constructor(role) {
     super(role);
 
+    this.hideModifier = {
+      self: true,
+      reveal: true,
+    };
+
+    var appearance;
+    if (this.role.alignment === "Village") {
+      appearance = "Visitor";
+    } else if (this.role.alignment === "Mafia") {
+      appearance = "Trespasser";
+    } else if (this.role.alignment === "Cult") {
+      appearance = "Werewolf";
+    } else if (this.role.alignment === "Independent") {
+      appearance = "Fool";
+    }
+
+    if (!appearance) {
+      return;
+    }
+
+    this.appearance = {
+      self: appearance,
+      reveal: appearance,
+    };
+
+    this.meetingMods = {
+      "*": {
+        actionName: "Visit",
+      },
+      Mafia: {
+        actionName: "Mafia Kill",
+      },
+      Village: {
+        actionName: "Village Vote",
+      },
+    };
+
+    if (this.role.alignment === "Independent") {
+      this.meetingMods["*"] = {
+        actionName: "Fool Around",
+      };
+    }
+
+    if (this.role.alignment === "Monsters") {
+      this.meetingMods["*"] = {
+        actionName: "Wolf Bite",
+      };
+    }
   }
 };

--- a/Games/types/Mafia/roles/cards/Scatterbrained.js
+++ b/Games/types/Mafia/roles/cards/Scatterbrained.js
@@ -1,56 +1,8 @@
 const Card = require("../../Card");
 
-module.exports = class Scatterbrained extends Card {
+module.exports = class Scatterbrained extends Humble {
   constructor(role) {
     super(role);
 
-    this.hideModifier = {
-      self: true,
-      reveal: true,
-    };
-
-    var appearance;
-    if (this.role.alignment === "Village") {
-      appearance = "Visitor";
-    } else if (this.role.alignment === "Mafia") {
-      appearance = "Trespasser";
-    } else if (this.role.alignment === "Cult") {
-      appearance = "Werewolf";
-    } else if (this.role.alignment === "Independent") {
-      appearance = "Fool";
-    }
-
-    if (!appearance) {
-      return;
-    }
-
-    this.appearance = {
-      self: appearance,
-      reveal: appearance,
-    };
-
-    this.meetingMods = {
-      "*": {
-        actionName: "Visit",
-      },
-      Mafia: {
-        actionName: "Mafia Kill",
-      },
-      Village: {
-        actionName: "Village Vote",
-      },
-    };
-
-    if (this.role.alignment === "Independent") {
-      this.meetingMods["*"] = {
-        actionName: "Fool Around",
-      };
-    }
-
-    if (this.role.alignment === "Monsters") {
-      this.meetingMods["*"] = {
-        actionName: "Wolf Bite",
-      };
-    }
   }
 };

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -37,12 +37,14 @@ const modifierData = {
     },
     Modest: {
       internal: ["Modest"],
+      hidden: true,
       description:
         "Appears as Villager (Village) / Mafioso (Mafia) / Cultist (Cult) / Grouch (Independent) to self with no modifier.",
       incompatible: ["Respected", "Humble", "Scatterbrained", "Exposed"],
     },
     Scatterbrained: {
       internal: ["Scatterbrained"],
+      hidden: true,
       description:
         "Appears as Visitor (Village) / Trespasser (Mafia) / Lycan (Cult) / Fool (Independent) to self with no modifier.",
       incompatible: ["Humble", "Modest", "Respected", "Exposed"],

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -44,7 +44,6 @@ const modifierData = {
     },
     Scatterbrained: {
       internal: ["Scatterbrained"],
-      hidden: true,
       description:
         "Appears as Visitor (Village) / Trespasser (Mafia) / Lycan (Cult) / Fool (Independent) to self with no modifier.",
       incompatible: ["Humble", "Modest", "Respected", "Exposed"],

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -174,8 +174,12 @@ const modifierData = {
     },
     Diplomatic: {
       internal: ["CondemnImmune"],
-      description: "Can not be condemned.",
+      description: "Cannot be condemned.",
       incompatible: ["Frustrated"],
+    },
+    Clueless: {
+      internal: ["SeeRandomSpeakers"],
+      description: "Sees all speech as coming from random people.",
     },
   },
   "Split Decision": {},

--- a/data/roles.js
+++ b/data/roles.js
@@ -163,12 +163,12 @@ const roleData = {
     },
     Veteran: {
       alignment: "Village",
-      recentlyUpdated: true,
+      hidden: true,
       description: ["Starts with armor.", "Armor blocks a single attack."],
     },
     Bomber: {
       alignment: "Village",
-      recentlyUpdated: true,
+      hidden: true,
       description: [
         "Starts with a bomb.",
         "Bomb goes off when player is killed, targeting the attacker.",
@@ -176,6 +176,7 @@ const roleData = {
       ],
     },
     "Village Idiot": {
+      hidden: true,
       alignment: "Village",
       description: [
         "Sees all speech as coming from random people.",

--- a/data/roles.js
+++ b/data/roles.js
@@ -220,6 +220,7 @@ const roleData = {
     Priest: {
       alignment: "Village",
       description: [
+        "Learns the roles of those who visited them.",
         "Cleanses werewolves when visited by them.",
         "Kills Lycan when visited by them.",
         "On death, has a chance to redeem their killer.",

--- a/react_main/src/components/Roles.jsx
+++ b/react_main/src/components/Roles.jsx
@@ -282,18 +282,18 @@ function RoleBanners(props) {
 
   var banners = [];
   if (newlyAdded) {
-    banners.push(<RoleBanner type="newlyAdded" text={<span>new<span/>} />);
+    banners.push(<RoleBanner type="newlyAdded" text={"new"} />);
   }
 
   if (recentlyUpdated) {
     banners.push(
-      <RoleBanner type="recentlyUpdated" text={<span className="fas fa-sync">recently updated<span/>} />
+      <RoleBanner type="recentlyUpdated" text={"recently updated"} />
     );
   }
 
   if (featured) {
     banners.push(
-      <RoleBanner type="featured" text={<span className="fas fa-star">featured<span/>} />
+      <RoleBanner type="featured" text={"featured"} />
     );
   }
 

--- a/react_main/src/components/Roles.jsx
+++ b/react_main/src/components/Roles.jsx
@@ -226,7 +226,7 @@ export function RoleSearch(props) {
     const hostile =
       role.alignment == "Independent" && role.hostile ? "hostile" : "";
     if (
-      !role.disabled &&
+      !role.hidden &&
       (role.alignment == roleListType ||
         (searchVal.length > 0 &&
           role.name.toLowerCase().indexOf(searchVal) != -1))

--- a/react_main/src/css/roles.css
+++ b/react_main/src/css/roles.css
@@ -534,11 +534,11 @@
   background-image: url("/images/roles/deputy-retro.png");
 }
 
-.role-icon-scheme-tall .role-Mafia-Veteran {
+.role-icon-scheme-tall .role-Mafia-Soldier {
   background-image: url("/images/roles/bp-tall.png");
 }
 
-.role-icon-scheme-retro .role-Mafia-Veteran {
+.role-icon-scheme-retro .role-Mafia-Soldier {
   background-image: url("/images/roles/bp-retro.png");
 }
 

--- a/routes/roles.js
+++ b/routes/roles.js
@@ -19,7 +19,7 @@ for (let gameType in roleData) {
       newlyAdded: roleData[gameType][roleName].newlyAdded,
       recentlyUpdated: roleData[gameType][roleName].recentlyUpdated,
       hostile: roleData[gameType][roleName].hostile,
-      disabled: roleData[gameType][roleName].disabled,
+      hidden: roleData[gameType][roleName].hidden,
     });
   }
 }


### PR DESCRIPTION
Veteran, Bomber, and Village Idiot have been deprecated in favor of modifier solutions. New Clueless modifier to replace Village Idiot.

Veteran icon has been reused for Soldier.

Priest has been given a new card to learn its visitors' roles, just like on EM.

Merged Humble and Modest modifiers. Still looking for a solution to merge Humble and Scatterbrained, but this might be harder.