### PR TITLE
feat: add must condemn

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -1406,6 +1406,10 @@ module.exports = class Game {
     return this.mustAct || this.setup.mustAct;
   }
 
+  isMustCondemn() {
+    return this.mustCondemn || this.setup.mustCondemn;
+  }
+
   isNoAct() {
     return false;
   }

--- a/Games/core/Meeting.js
+++ b/Games/core/Meeting.js
@@ -30,6 +30,7 @@ module.exports = class Meeting {
     this.liveJoin = false;
     this.votesInvisible = game.setup.votesInvisible;
     this.mustAct = game.isMustAct();
+    this.mustCondemn = game.isMustCondemn();
     this.noAct = game.isNoAct();
     this.noVeg = false;
     this.multiActor = false;
@@ -313,14 +314,24 @@ module.exports = class Meeting {
         );
       }
 
-      if (
-        (!this.mustAct && !this.repeatable) ||
-        (this.mustAct && this.targets.length === 0)
-      ) {
-        this.targets.push("*");
+      if (this.actionName !== "Village Vote") {
+        if (
+          (!this.mustAct && !this.repeatable) ||
+          (this.mustAct && this.targets.length === 0)
+        ) {
+          this.targets.push("*");
+        }
+      } else {
+        if (
+          (!this.mustCondemn && !this.repeatable) ||
+          (this.mustCondemn && this.targets.length === 0)
+        ) {
+          this.targets.push("*");
+        }
       }
+
     } else if (this.inputType == "boolean") {
-      if (!this.mustAct || this.includeNo) this.targets = ["Yes", "No"];
+      if ((!this.mustAct && !this.mustCondemn)|| this.includeNo) this.targets = ["Yes", "No"];
       else this.targets = ["Yes"];
     }
 
@@ -470,7 +481,7 @@ module.exports = class Meeting {
 
     if (this.inputType != "text") {
       if (this.targets.indexOf(selection) != -1) target = selection;
-      else if (selection == "*" && !this.mustAct && !this.repeatable) {
+      else if (selection == "*" && !this.mustAct && !this.mustCondemn && !this.repeatable) {
         if (this.inputType == "boolean") target = "No";
         else if (this.inputType == "customBoolean")
           target = this.displayOptions.customBooleanNegativeReply;
@@ -646,7 +657,7 @@ module.exports = class Meeting {
 
       if (highest.targets.length == 1) {
         //Winning vote
-        if (this.inputType == "boolean" && this.mustAct && this.includeNo) {
+        if (this.inputType == "boolean" && (this.mustAct || this.mustCondemn) && this.includeNo) {
           if (highest.votes > this.totalVoters / 2)
             finalTarget = highest.targets[0];
           else finalTarget = "No";

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -153,9 +153,19 @@ module.exports = class MafiaGame extends Game {
     var mustAct = super.isMustAct();
     mustAct |=
       this.statesSinceLastDeath >= this.noDeathLimit &&
-      this.getStateName() != "Sunset";
+      this.getStateName() != "Sunset" &&
+      meeting.name != "Village";
     return mustAct;
   }
+
+  isMustCondemn() {
+    var mustCondemn = super.isMustCondemn();
+    mustCondemn |=
+      this.statesSinceLastDeath >= this.noDeathLimit &&
+      this.getStateName() != "Sunset" &&
+      meeting.name == "Village";
+    return mustCondemn;
+  } 
 
   inactivityCheck() {
     var stateName = this.getStateName();

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -105,6 +105,7 @@ var schemas = {
     dawn: Boolean,
     lastWill: Boolean,
     mustAct: Boolean,
+    mustCondemn: Boolean,
     noReveal: Boolean,
     votesInvisible: Boolean,
     swapAmt: Number,

--- a/docs/info-mafia-constants.md
+++ b/docs/info-mafia-constants.md
@@ -31,7 +31,8 @@ Sunset is used for the Hunter interaction.
 | liveJoin      | Informs other meeting members about the join. Currently only used by the village core.                                                     |
 | exclusive     | Players can only join one exclusive meeting every night. Non-exclusive meetings can only be joined if they have a higher meeting priority. |
 | voting        | Meeting members will vote for the meeting target, which is then piped to the corresponding action as action.target.                        |
-| mustAct       | Unable to select "no one" as the meeting target.                                                                                           |
+| mustAct       | Unable to select "no one" as a target, not including village meeting.                                                                                          |
+| mustCondemn   | Unable to select "no one" as the village meeting target.                                                                                           |
 | instant       | The game will process the actions immediately. E.g. Gun, KillerBee                                                                         |
 | noVeg         | Does not cause veg when the timer is up.                                                                                                   |
 | group         | Multiple people share the same meeting.                                                                                                    |

--- a/react_main/src/components/Popover.jsx
+++ b/react_main/src/components/Popover.jsx
@@ -323,6 +323,15 @@ export function parseSetupPopover(setup, roleData) {
     />
   );
 
+  // Must condemn
+  result.push(
+    <InfoRow
+      title="Must Condemn"
+      content={setup.mustCondemn ? "Yes" : "No"}
+      key="mustCondemn"
+    />
+  );
+
   //Game settings
   switch (setup.gameType) {
     case "Mafia":

--- a/react_main/src/pages/Learn/LearnMafia.jsx
+++ b/react_main/src/pages/Learn/LearnMafia.jsx
@@ -141,7 +141,11 @@ export default function LearnMafia(props) {
     },
     {
       name: "Must Act",
-      text: "Players cannot select 'no one' for their actions.",
+      text: "Players cannot select 'no one' for their actions, not including the village meeting.",
+    },
+    {
+      name: "Must Condemn",
+      text: "Players cannot condemn 'no one' during the village meeting.",
     },
     {
       name: "No Reveal",

--- a/react_main/src/pages/Play/CreateSetup/CreateMafiaSetup.jsx
+++ b/react_main/src/pages/Play/CreateSetup/CreateMafiaSetup.jsx
@@ -55,6 +55,11 @@ export default function CreateMafiaSetup() {
       type: "boolean",
     },
     {
+      label: "Must Condemn",
+      ref: "mustCondemn",
+      type: "boolean",
+    },
+    {
       label: "No Reveal",
       ref: "noReveal",
       type: "boolean",
@@ -148,17 +153,18 @@ export default function CreateMafiaSetup() {
         leakPercentage: Number(formFields[4].value),
         lastWill: formFields[5].value,
         mustAct: formFields[6].value,
-        noReveal: formFields[7].value,
-        votesInvisible: formFields[8].value,
-        unique: formFields[10].value,
-        uniqueWithoutModifier: formFields[11].value,
+        mustCondemn: formFields[7].value,
+        noReveal: formFields[8].value,
+        votesInvisible: formFields[9].value,
+        unique: formFields[11].value,
+        uniqueWithoutModifier: formFields[12].value,
         useRoleGroups: roleData.useRoleGroups,
         roleGroupSizes: roleData.roleGroupSizes,
         count: {
-          Village: Number(formFields[13].value),
-          Mafia: Number(formFields[14].value),
-          Cult: Number(formFields[15].value),
-          Independent: Number(formFields[16].value),
+          Village: Number(formFields[14].value),
+          Mafia: Number(formFields[15].value),
+          Cult: Number(formFields[16].value),
+          Independent: Number(formFields[17].value),
         },
         editing: editing,
         id: params.get("edit"),
@@ -179,8 +185,8 @@ export default function CreateMafiaSetup() {
       formFields={formFields}
       updateFormFields={updateFormFields}
       resetFormFields={resetFormFields}
-      closedField={formFields[9]}
-      useRoleGroupsField={formFields[12]}
+      closedField={formFields[10]}
+      useRoleGroupsField={formFields[13]}
       formFieldValueMods={formFieldValueMods}
       onCreateSetup={onCreateSetup}
     />

--- a/react_main/src/pages/Play/CreateSetup/CreateOneNightSetup.jsx
+++ b/react_main/src/pages/Play/CreateSetup/CreateOneNightSetup.jsx
@@ -38,6 +38,11 @@ export default function CreateOneNightSetup() {
       type: "boolean",
     },
     {
+      label: "Must Condemn",
+      ref: "mustCondemn",
+      type: "boolean",
+    },
+    {
       label: "Votes Invisible",
       ref: "votesInvisible",
       type: "boolean",
@@ -109,13 +114,14 @@ export default function CreateOneNightSetup() {
         whispers: formFields[1].value,
         leakPercentage: Number(formFields[2].value),
         mustAct: formFields[3].value,
-        votesInvisible: formFields[4].value,
-        excessRoles: formFields[5].value,
-        unique: formFields[7].value,
+        mustCondemn: formFields[4].value,
+        votesInvisible: formFields[5].value,
+        excessRoles: formFields[6].value,
+        unique: formFields[8].value,
         count: {
-          Village: Number(formFields[8].value),
-          Werewolves: Number(formFields[9].value),
-          Independent: Number(formFields[10].value),
+          Village: Number(formFields[9].value),
+          Werewolves: Number(formFields[10].value),
+          Independent: Number(formFields[11].value),
         },
         editing: editing,
         id: params.get("edit"),
@@ -136,7 +142,7 @@ export default function CreateOneNightSetup() {
       formFields={formFields}
       updateFormFields={updateFormFields}
       resetFormFields={resetFormFields}
-      closedField={formFields[6]}
+      closedField={formFields[7]}
       formFieldValueMods={formFieldValueMods}
       onCreateSetup={onCreateSetup}
     />

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -352,6 +352,7 @@ router.post("/create", async function (req, res) {
     setup.leakPercentage = Number(setup.leakPercentage);
     setup.dawn = Boolean(setup.dawn);
     setup.mustAct = Boolean(setup.mustAct);
+    setup.mustCondemn = Boolean(setup.mustCondemn);
 
     if (
       !routeUtils.validProp(setup.gameType) ||


### PR DESCRIPTION
tested with must act and must condemn separately, and together. works as expected except with Must Condemn = true, roles like party host and psyche are forced to pick yes while guns and chef can nl. this should be sorted before merging