### PR TITLE
feat: all mafia meet by default + oblivious mod

### DIFF
--- a/Games/types/Mafia/roles/Mafia/Arsonist.js
+++ b/Games/types/Mafia/roles/Mafia/Arsonist.js
@@ -7,7 +7,7 @@ module.exports = class Arsonist extends Role {
     this.cards = [
       "VillageCore",
       "WinWithMafia",
-      "Oblivious",
+      "MeetingMafia",
       "DouseInGasoline",
     ];
   }

--- a/Games/types/Mafia/roles/Mafia/Blinder.js
+++ b/Games/types/Mafia/roles/Mafia/Blinder.js
@@ -5,6 +5,6 @@ module.exports = class Blinder extends Role {
     super("Blinder", player, data);
 
     this.alignment = "Mafia";
-    this.cards = ["VillageCore", "WinWithMafia", "Blinder"];
+    this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia", "Blinder"];
   }
 };

--- a/Games/types/Mafia/roles/Mafia/Crank.js
+++ b/Games/types/Mafia/roles/Mafia/Crank.js
@@ -4,6 +4,6 @@ module.exports = class Crank extends Role {
   constructor(player, data) {
     super("Crank", player, data);
     this.alignment = "Mafia";
-    this.cards = ["VillageCore", "WinWithMafia", "SeanceTarget"];
+    this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia", "SeanceTarget"];
   }
 };

--- a/Games/types/Mafia/roles/Mafia/Cyclist.js
+++ b/Games/types/Mafia/roles/Mafia/Cyclist.js
@@ -5,6 +5,6 @@ module.exports = class Cyclist extends Role {
     super("Cyclist", player, data);
 
     this.alignment = "Mafia";
-    this.cards = ["VillageCore", "WinWithMafia", "VisitEveryone"];
+    this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia", "VisitEveryone"];
   }
 };

--- a/Games/types/Mafia/roles/Mafia/Enforcer.js
+++ b/Games/types/Mafia/roles/Mafia/Enforcer.js
@@ -4,6 +4,6 @@ module.exports = class Enforcer extends Role {
   constructor(player, data) {
     super("Enforcer", player, data);
     this.alignment = "Mafia";
-    this.cards = ["VillageCore", "WinWithMafia", "CureAllMadness"];
+    this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia", "CureAllMadness"];
   }
 };

--- a/Games/types/Mafia/roles/Mafia/Fiddler.js
+++ b/Games/types/Mafia/roles/Mafia/Fiddler.js
@@ -5,6 +5,6 @@ module.exports = class Fiddler extends Role {
     super("Fiddler", player, data);
 
     this.alignment = "Mafia";
-    this.cards = ["VillageCore", "WinWithMafia", "Fiddler"];
+    this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia", "Fiddler"];
   }
 };

--- a/Games/types/Mafia/roles/Mafia/Hitman.js
+++ b/Games/types/Mafia/roles/Mafia/Hitman.js
@@ -4,6 +4,6 @@ module.exports = class Hitman extends Role {
   constructor(player, data) {
     super("Hitman", player, data);
     this.alignment = "Mafia";
-    this.cards = ["VillageCore", "WinWithMafia", "NightKiller", "Oblivious"];
+    this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia", "NightKiller"];
   }
 };

--- a/Games/types/Mafia/roles/Mafia/Interrogator.js
+++ b/Games/types/Mafia/roles/Mafia/Interrogator.js
@@ -7,7 +7,7 @@ module.exports = class Interrogator extends Role {
     super("Interrogator", player, data);
 
     this.alignment = "Mafia";
-    this.cards = ["VillageCore", "WinWithMafia", "JailTarget"];
+    this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia", "JailTarget"];
 
     this.meetingMods = {
       "Jail Target": {

--- a/Games/types/Mafia/roles/Mafia/Silencer.js
+++ b/Games/types/Mafia/roles/Mafia/Silencer.js
@@ -5,6 +5,6 @@ module.exports = class Silencer extends Role {
     super("Silencer", player, data);
 
     this.alignment = "Mafia";
-    this.cards = ["VillageCore", "WinWithMafia", "Silencer"];
+    this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia", "Silencer"];
   }
 };

--- a/Games/types/Mafia/roles/Mafia/Slasher.js
+++ b/Games/types/Mafia/roles/Mafia/Slasher.js
@@ -8,6 +8,7 @@ module.exports = class Slasher extends Role {
     this.cards = [
       "VillageCore",
       "WinWithMafia",
+      "MeetingMafia",
       "EnqueueVisitors",
       "DaySlasher",
     ];

--- a/Games/types/Mafia/roles/Mafia/Sniper.js
+++ b/Games/types/Mafia/roles/Mafia/Sniper.js
@@ -5,7 +5,7 @@ module.exports = class Sniper extends Role {
     super("Sniper", player, data);
 
     this.alignment = "Mafia";
-    this.cards = ["VillageCore", "WinWithMafia"];
+    this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia"];
     this.startItems = [
       {
         type: "Gun",

--- a/Games/types/Mafia/roles/Mafia/Thief.js
+++ b/Games/types/Mafia/roles/Mafia/Thief.js
@@ -4,6 +4,6 @@ module.exports = class Thief extends Role {
   constructor(player, data) {
     super("Thief", player, data);
     this.alignment = "Mafia";
-    this.cards = ["VillageCore", "WinWithMafia", "StealItem"];
+    this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia", "StealItem"];
   }
 };

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -52,6 +52,10 @@ const modifierData = {
       internal: ["Lone"],
       description: "Does not attend the Mafia/Monsters/Cop/Templar meeting.",
     },
+    Oblivious: {
+      internal: ["Oblivious"],
+      description: "Does not know the identities of their partners.",
+    },
     Solitary: {
       internal: ["Lone"],
       hidden: true,


### PR DESCRIPTION
See above. All Mafia roles save for Clown meet by default and have had Oblivious taken off of their cards. Oblivious has also been made into a modifier to bring back that function.