### PR TITLE
hotfix: tree cannot be lynched

### DIFF
--- a/Games/types/Mafia/roles/cards/CondemnImmune.js
+++ b/Games/types/Mafia/roles/cards/CondemnImmune.js
@@ -4,6 +4,6 @@ module.exports = class CondemnImmune extends Card {
   constructor(role) {
     super(role);
 
-    this.startEffects = ["CondemnImmune"];
+    this.immunity["condemn"] = 3;
   }
 };


### PR DESCRIPTION
last night people were able to lynch trees and filibusters

reviewed CondemnImmune.js and reverted to function independently of the effect file of the same name