### PR TITLE
feat: new modifiers

### DIFF
--- a/Games/types/Mafia/roles/cards/ActAliveOrDead.js
+++ b/Games/types/Mafia/roles/cards/ActAliveOrDead.js
@@ -1,0 +1,14 @@
+const Card = require("../../Card");
+
+module.exports = class ActAliveOrDead extends Card {
+  constructor(role) {
+    super(role);
+
+    this.meetingMods = {
+        "*": {
+          whileDead: true,
+          whileAlive: true,
+        },
+      };
+  }
+};

--- a/Games/types/Mafia/roles/cards/ActWhileDead.js
+++ b/Games/types/Mafia/roles/cards/ActWhileDead.js
@@ -1,0 +1,14 @@
+const Card = require("../../Card");
+
+module.exports = class ActWhileDead extends Card {
+  constructor(role) {
+    super(role);
+
+    this.meetingMods = {
+        "*": {
+          whileDead: true,
+          whileAlive: false,
+        },
+      };
+  }
+};

--- a/Games/types/Mafia/roles/cards/AddVoteWeight.js
+++ b/Games/types/Mafia/roles/cards/AddVoteWeight.js
@@ -1,0 +1,15 @@
+const Card = require("../../Card");
+
+module.exports = class AddVoteWeight extends Card {
+  constructor(role) {
+    super(role);
+
+    this.listeners = {
+      meeting: function (meeting) {
+        if (meeting.members[this.player.id]) {
+          meeting.members[this.player.id].voteWeight++;
+        }
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/StealFromVisitors.js
+++ b/Games/types/Mafia/roles/cards/StealFromVisitors.js
@@ -1,0 +1,21 @@
+const Card = require("../../Card");
+const { PRIORITY_ITEM_TAKER_DEFAULT } = require("../../const/Priority");
+
+module.exports = class StealFromVisitors extends Card {
+  constructor(role) {
+    super(role);
+
+    this.actions = [
+      {
+        priority: PRIORITY_ITEM_TAKER_DEFAULT,
+        labels: ["stealItem"],
+        run: function () {
+          if (this.game.getStateName() != "Night") return;
+
+          let visits = this.getVisits(this.actor);
+          visits.map((v) => this.stealAllItems(v));
+        },
+      },
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/cards/SubtractVoteWeight.js
+++ b/Games/types/Mafia/roles/cards/SubtractVoteWeight.js
@@ -1,0 +1,15 @@
+const Card = require("../../Card");
+
+module.exports = class SubtractVoteWeight extends Card {
+  constructor(role) {
+    super(role);
+
+    this.listeners = {
+      meeting: function (meeting) {
+        if (meeting.members[this.player.id]) {
+          meeting.members[this.player.id].voteWeight--;
+        }
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/VisitOnlyDead.js
+++ b/Games/types/Mafia/roles/cards/VisitOnlyDead.js
@@ -1,0 +1,15 @@
+const Card = require("../../Card");
+
+module.exports = class VisitOnlyDead extends Card {
+  constructor(role) {
+    super(role);
+
+    this.meetingMods = {
+        "*": {
+          states: ["Night"],
+          flags: ["voting"],
+          targets: { include: ["dead"], exclude: ["alive", "self"] },
+        },
+      };
+  }
+};

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -210,6 +210,14 @@ const modifierData = {
       internal: ["StealFromVisitors"],
       description: "Steals from a player's target in their night action.",
     },
+    Influential: {
+      internal: ["StealFromVisitors"],
+      description: "Each additional modifier adds voteweight by one.",
+    },
+    Felon: {
+      internal: ["SubtractVoteWeight"],
+      description: "Each additional modifier subtracts voteweight by one.",
+    },
   },
   "Split Decision": {},
   Resistance: {},

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -186,6 +186,30 @@ const modifierData = {
       internal: ["Clueless"],
       description: "Sees all speech as coming from random people.",
     },
+    Gunslinging: {
+      internal: ["DefendAndSnatchGun"],
+      description: "80% chance of snatching a gun when shot at.",
+    },
+    Restless: {
+      internal: ["ActWhileDead"],
+      description: "Can only perform action while dead.",
+    },
+    Transcendent: {
+      internal: ["ActAliveOrDead"],
+      description: "Can perform action while either alive or dead.",
+    },
+    Commuting: {
+      internal: ["BlockVisitors"],
+      description: "Can only perform action while dead.",
+    },
+    Morbid: {
+      internal: ["VisitOnlyDead"],
+      description: "Can only visit dead players.",
+    },
+    Kleptomaniac: {
+      internal: ["StealFromVisitors"],
+      description: "Steals from a player's target in their night action.",
+    },
   },
   "Split Decision": {},
   Resistance: {},


### PR DESCRIPTION
from role patrol sheet:  gunslinging, restless, transcendent, commuting, morbid, kleptomaniac, influential, felon

gunslinging and commuting just use cards from the roles they're based on, no code changed

restless/transcendent change whether a player has a night meeting while alive or dead (restless is only while dead, transcendent both alive and dead)

morbid changes a player to only visit dead targets

kleptomaniac is like friendly but for theft instead of roleblocking

influential/felon add/subtract from overall voteweight