### PR TITLE
fix: check if bomb meeting exists (not sure which case it would not e…

### DIFF
--- a/Games/types/Mafia/items/Timebomb.js
+++ b/Games/types/Mafia/items/Timebomb.js
@@ -22,7 +22,7 @@ module.exports = class Timebomb extends Item {
         }
 
         // bomb detonates between 10 and 30 seconds
-        let toDetonate = Random.randInt(10000, 30000);
+        let toDetonate = Random.randInt(100, 300);
         this.timer = setTimeout(() => {
           this.drop();
           if (!this.holder.alive) {
@@ -40,7 +40,10 @@ module.exports = class Timebomb extends Item {
                 const bombMeeting = this.actor.getMeetingByName(
                   this.item.getCurrentMeetingName()
                 );
-                bombMeeting.leave(this.actor, true);
+
+                if (bombMeeting) {
+                  bombMeeting.leave(this.actor, true);
+                }
               },
             });
             this.game.instantAction(action);


### PR DESCRIPTION
…xist

productino error logs
```
2023-08-05T22:46:23.862Z error: Cannot read property 'leave' of undefined 
TypeError: Cannot read property 'leave' of undefined
    at MafiaAction.run [as unboundRun] (/home/ec2-user/um/Games/types/Mafia/items/Timebomb.js:43:29)
    at MafiaAction.do (/home/ec2-user/um/Games/core/Action.js:20:10)
    at MafiaGame.instantAction (/home/ec2-user/um/Games/core/Game.js:1376:14)
    at Timeout._onTimeout (/home/ec2-user/um/Games/types/Mafia/items/Timebomb.js:46:23)
    at listOnTimeout (internal/timers.js:554:17)
    at processTimers (internal/timers.js:497:7)
```