### PR TITLE
fix: do not crash the app when Message content is undefined

### DIFF
--- a/react_main/src/components/Basic.jsx
+++ b/react_main/src/components/Basic.jsx
@@ -133,7 +133,7 @@ export function UserText(props) {
     setContent(text);
   }, [props.text, props.terminologyEmoticons]);
 
-  return content;
+  return content ?? "";
 }
 
 export function linkify(text) {


### PR DESCRIPTION
fixes Secret Hitler Execution

but there's still 1 empty alert message in Secret Hitler; at least it won't crash everything now