### PR TITLE
fix(mafia): butterfly reset roles should preserve role data

### DIFF
--- a/Games/types/Mafia/roles/cards/ResetRolesOnDeath.js
+++ b/Games/types/Mafia/roles/cards/ResetRolesOnDeath.js
@@ -11,7 +11,7 @@ module.exports = class ResetRolesOnDeath extends Card {
 
         for (let _player of this.game.players) {
           if (_player.alive) {
-            _player.setRole(this.data.originalRoles[_player.name]);
+            _player.setRole(this.data.originalRoles[_player.name], _player.role.data);
           }
         }
       },


### PR DESCRIPTION
Fixes #827 

happens on second butterfly death, because second butterfly has data.originalRoles deleted