### PR TITLE
feat: catlady/diabolist are culties

### DIFF
--- a/Games/types/Mafia/roles/Cult/CatLady.js
+++ b/Games/types/Mafia/roles/Cult/CatLady.js
@@ -3,7 +3,7 @@ const Role = require("../../Role");
 module.exports = class CatLady extends Role {
   constructor(player, data) {
     super("Cat Lady", player, data);
-    this.alignment = "Mafia";
-    this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia", "CatGiver"];
+    this.alignment = "Cult";
+    this.cards = ["VillageCore", "WinWithCult", "MeetingCult", "CatGiver"];
   }
 };

--- a/Games/types/Mafia/roles/Cult/Diabolist.js
+++ b/Games/types/Mafia/roles/Cult/Diabolist.js
@@ -3,7 +3,7 @@ const Role = require("../../Role");
 module.exports = class Diabolist extends Role {
   constructor(player, data) {
     super("Diabolist", player, data);
-    this.alignment = "Mafia";
-    this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia", "CurseVote"];
+    this.alignment = "Cult";
+    this.cards = ["VillageCore", "WinWithCult", "MeetingCult", "CurseVote"];
   }
 };

--- a/data/roles.js
+++ b/data/roles.js
@@ -986,13 +986,6 @@ const roleData = {
         "Once per game, can rush at another player during the day, killing them both.",
       ],
     },
-    Diabolist: {
-      alignment: "Mafia",
-      description: [
-        "Chooses a player to be a victim and a target each night.",
-        "If the victim votes for the target in the village meeting the following day, the victim will die.",
-      ],
-    },
     Tailor: {
       alignment: "Mafia",
       description: [
@@ -1091,15 +1084,6 @@ const roleData = {
       description: [
         "Starts with a gun.",
         "Chooses one player each night to frame as the shooter of any guns shot by the Illusionist.",
-      ],
-    },
-    "Cat Lady": {
-      alignment: "Mafia",
-      description: [
-        "Chooses a player to send them a cat, each day.",
-        "The player can choose to let the cat in during the night, or chase it out.",
-        "If the cat is let in, the player is blocked from performing night actions.",
-        "If the cat is chased out, the Cat Lady will learn the player's role.",
       ],
     },
     Slasher: {
@@ -1438,6 +1422,24 @@ const roleData = {
         "During the day, once per game, can choose to start a snowstorm.",
         "Everyone is forced to pass the next night snowed in together.",
         "During the next night, only Cult actions will go through.",
+      ],
+    },
+    "Cat Lady": {
+      alignment: "Cult",
+      recentlyUpdated: true,
+      description: [
+        "Chooses a player to send them a cat, each day.",
+        "The player can choose to let the cat in during the night, or chase it out.",
+        "If the cat is let in, the player is blocked from performing night actions.",
+        "If the cat is chased out, the Cat Lady will learn the player's role.",
+      ],
+    },
+    Diabolist: {
+      alignment: "Cult",
+      recentlyUpdated: true,
+      description: [
+        "Chooses a player to be a victim and a target each night.",
+        "If the victim votes for the target in the village meeting the following day, the victim will die.",
       ],
     },
 


### PR DESCRIPTION
based on conversations with other devs and the community

two roles are being realigned to cult due to theme/flavor reasons as well as mechanic reasons: cat lady and diabolist

cult lacked a voting role or a roleblocking/rolelearning role, so these two take those slots

future plans for a role that allows mafia and cult to joint is in the works based on these same conversations, but the code for winCheck is annoying so that's WIP