### PR TITLE
fix: seer check get checking length on undefined

### DIFF
--- a/Games/types/Mafia/roles/cards/WinWithMafia.js
+++ b/Games/types/Mafia/roles/cards/WinWithMafia.js
@@ -66,7 +66,7 @@ module.exports = class WinWithMafia extends Card {
           return;
         }
 
-        if (seersInGame.length == this.game.guessedSeers["Mafia"].length) {
+        if (seersInGame.length == this.game.guessedSeers["Mafia"]?.length) {
           mafiaWin(this);
           return;
         }


### PR DESCRIPTION
```
2023-08-11T21:48:51.758Z error: Cannot read property 'length' of undefined 
TypeError: Cannot read property 'length' of undefined
    at Hooker.check (/home/ec2-user/um/Games/types/Mafia/roles/cards/WinWithMafia.js:69:67)
    at MafiaGame.checkWinConditions (/home/ec2-user/um/Games/types/Mafia/Game.js:280:27)
    at MafiaGame.checkGameEnd (/home/ec2-user/um/Games/core/Game.js:1418:36)
```