### PR TITLE
fix: oneshot does not cancel meetings if you pick "no one"

### DIFF
--- a/Games/types/Mafia/roles/cards/OneShot.js
+++ b/Games/types/Mafia/roles/cards/OneShot.js
@@ -7,6 +7,10 @@ module.exports = class OneShot extends Card {
     role.metCount = {};
     this.meetingMods = {
       "*": {
+        shouldMeet: function () {
+          if (target === "*") target = "no one"
+            return true;
+        },
         shouldMeet: function (meetingName) {
           if (meetingName == "Village" || meetingName == "Graveyard")
             return true;


### PR DESCRIPTION
long standing issue predating BM and UM