### PR TITLE
feat: most roles are not humble

### DIFF
--- a/Games/types/Mafia/roles/Village/King.js
+++ b/Games/types/Mafia/roles/Village/King.js
@@ -10,6 +10,6 @@ module.exports = class King extends Role {
         voteWeight: Infinity,
       },
     };
-    this.cards = ["VillageCore", "WinWithVillage", "Humble"];
+    this.cards = ["VillageCore", "WinWithVillage"];
   }
 };

--- a/Games/types/Mafia/roles/Village/Loudmouth.js
+++ b/Games/types/Mafia/roles/Village/Loudmouth.js
@@ -8,7 +8,6 @@ module.exports = class Loudmouth extends Role {
     this.cards = [
       "VillageCore",
       "WinWithVillage",
-      "Humble",
       "CryOutVisitors",
       "AllWhispersLeak",
     ];

--- a/Games/types/Mafia/roles/Village/Scapegoat.js
+++ b/Games/types/Mafia/roles/Village/Scapegoat.js
@@ -8,7 +8,6 @@ module.exports = class Scapegoat extends Role {
       "VillageCore",
       "WinWithVillage",
       "FrustratedCondemnation",
-      "Humble",
     ];
   }
 };

--- a/Games/types/Mafia/roles/Village/Sleepwalker.js
+++ b/Games/types/Mafia/roles/Village/Sleepwalker.js
@@ -4,6 +4,6 @@ module.exports = class Sleepwalker extends Role {
   constructor(player, data) {
     super("Sleepwalker", player, data);
     this.alignment = "Village";
-    this.cards = ["VillageCore", "WinWithVillage", "SleepWalk", "Humble"];
+    this.cards = ["VillageCore", "WinWithVillage", "SleepWalk"];
   }
 };

--- a/Games/types/Mafia/roles/Village/Trickster.js
+++ b/Games/types/Mafia/roles/Village/Trickster.js
@@ -4,6 +4,6 @@ module.exports = class Trickster extends Role {
   constructor(player, data) {
     super("Trickster", player, data);
     this.alignment = "Village";
-    this.cards = ["VillageCore", "WinWithVillage", "TrickedWares", "Humble"];
+    this.cards = ["VillageCore", "WinWithVillage", "TrickedWares"];
   }
 };

--- a/data/roles.js
+++ b/data/roles.js
@@ -692,7 +692,6 @@ const roleData = {
     },
     Shrink: {
       alignment: "Village",
-      recentlyUpdated: true,
       description: [
         "Each night, counsels one player and heals their insanity.",
         "Prevents their target from being converted.",
@@ -1242,7 +1241,6 @@ const roleData = {
     },
     Enforcer: {
       alignment: "Mafia",
-      recentlyUpdated: true,
       description: [
         "Each night, counsels one player and heals their insanity.",
         "Prevents their target from being converted.",

--- a/data/roles.js
+++ b/data/roles.js
@@ -427,7 +427,6 @@ const roleData = {
       disabled: true,
       description: [
         "If visited, cries out the identity of players who visited them during the night.",
-        "Appears as villager to self.",
         "All whispers leak.",
         "Immune to silencing.",
       ],
@@ -464,12 +463,12 @@ const roleData = {
     },
     Trickster: {
       alignment: "Village",
+      recentlyUpdated: true,
       description: [
         "Gives out an item each night to a random player.",
         "The item can be a Gun, Knife, Armor, Whiskey, or Crystal.",
         "The item has a 50% chance to be Cursed.",
         "Cursed items will misfire or be otherwise ineffective.",
-        "Appears as Villager to self.",
       ],
     },
     Medium: {
@@ -540,9 +539,9 @@ const roleData = {
     },
     King: {
       alignment: "Village",
+      recentlyUpdated: true,
       description: [
         "Vote overrides others in village meeting.",
-        "Appears as Villager to self.",
       ],
     },
     Suitress: {
@@ -555,9 +554,9 @@ const roleData = {
     },
     Sleepwalker: {
       alignment: "Village",
+      recentlyUpdated: true,
       description: [
         "Visits a random player each night.",
-        "Appears as Villager to self.",
       ],
     },
     Messenger: {
@@ -671,8 +670,8 @@ const roleData = {
     },
     Scapegoat: {
       alignment: "Village",
+      recentlyUpdated: true,
       description: [
-        "Appears to self as Villager.",
         "When the Scapegoat receives the majority of the Village vote, they will not be condemned.",
         "Will get frustrated and die if it has a non-zero minority Village vote.",
       ],
@@ -693,6 +692,7 @@ const roleData = {
     },
     Shrink: {
       alignment: "Village",
+      recentlyUpdated: true,
       description: [
         "Each night, counsels one player and heals their insanity.",
         "Prevents their target from being converted.",
@@ -1242,6 +1242,7 @@ const roleData = {
     },
     Enforcer: {
       alignment: "Mafia",
+      recentlyUpdated: true,
       description: [
         "Each night, counsels one player and heals their insanity.",
         "Prevents their target from being converted.",


### PR DESCRIPTION
King, Scapegoat, Sleepwalker, and Trickster are now self-aware by default

Humble modifier can always be used for previous functionality