### PR TITLE
feat: dwarf role

### DIFF
--- a/Games/types/Mafia/items/Gun.js
+++ b/Games/types/Mafia/items/Gun.js
@@ -7,6 +7,7 @@ module.exports = class Gun extends Item {
 
     this.reveal = options?.reveal;
     this.mafiaImmune = options?.mafiaImmune;
+    this.magicBullet = options?.magicBullet;
     this.cursed = options?.cursed;
 
     this.baseMeetingName = "Shoot Gun";
@@ -34,6 +35,7 @@ module.exports = class Gun extends Item {
             }
 
             var mafiaImmune = this.item.mafiaImmune;
+            var magicBullet = this.item.magicBullet;
             var cursed = this.item.cursed;
 
             if (cursed) {
@@ -53,12 +55,14 @@ module.exports = class Gun extends Item {
                 `:gun: Someone fires a gun at ${this.target.name}!`
               );
 
+            // convert or kill
+            if (magicBullet && this.target.role.alignment != "Cult") this.heal(1) && this.target.setRole("Cultist");
             // kill
             if (mafiaImmune && this.target.role.alignment == "Mafia") return;
 
             if (this.dominates()) {
               this.target.kill("gun", this.actor, true);
-            }
+            };
           },
         },
       },
@@ -68,6 +72,8 @@ module.exports = class Gun extends Item {
   get snoopName() {
     if (this.mafiaImmune) {
       return "Gun (Gunrunner)";
+    } else if (this.magicBullet) {
+      return "Gun (Dwarf)";
     } else if (this.cursed) {
       return "Gun (Cursed)";
     }

--- a/Games/types/Mafia/roles/Cult/Dwarf.js
+++ b/Games/types/Mafia/roles/Cult/Dwarf.js
@@ -1,0 +1,14 @@
+const Role = require("../../Role");
+
+module.exports = class Dwarf extends Role {
+  constructor(player, data) {
+    super("Dwarf", player, data);
+    this.alignment = "Cult";
+    this.cards = [
+      "VillageCore",
+      "WinWithCult",
+      "MeetingCult",
+      "MagicGunGiver",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/cards/MagicGunGiver.js
+++ b/Games/types/Mafia/roles/cards/MagicGunGiver.js
@@ -1,0 +1,24 @@
+const Card = require("../../Card");
+const { PRIORITY_ITEM_GIVER_DEFAULT } = require("../../const/Priority");
+
+module.exports = class MagicGunGiver extends Card {
+  constructor(role) {
+    super(role);
+
+    this.meetings = {
+      "Give Gun": {
+        states: ["Night"],
+        flags: ["voting"],
+        targets: { include: ["alive"], exclude: ["Cult"] },
+        action: {
+          labels: ["giveItem", "gun"],
+          priority: PRIORITY_ITEM_GIVER_DEFAULT,
+          run: function () {
+            this.target.holdItem("Gun", { magicBullet: true });
+            this.target.queueGetItemAlert("Gun");
+          },
+        },
+      },
+    };
+  }
+};

--- a/data/roles.js
+++ b/data/roles.js
@@ -1405,6 +1405,15 @@ const roleData = {
         "If the victim votes for the target in the village meeting the following day, the victim will die.",
       ],
     },
+    Dwarf: {
+      alignment: "Cult",
+      newlyAdded: true,
+      description: [
+        "Gives out a gun each night.",
+        "If a player not aligned with the Cult is shot, they will survive and convert to Cultist.",
+        "If a player aligned with the Cult is shot, they will be killed.",
+      ],
+    },
 
     //Independent
     Fool: {


### PR DESCRIPTION
gunrunner equivalent for the cult

intended effect: if a non-cult player is shot, they convert to cultist. if a cult player is shot, they die

the way I did it is a little wonky. I had the gunshot actually heal the target so that it would override the kill. there is probably a cleaner way to do this right? don't want to run into unintended effects with a gunshot that heals