### PR TITLE
fix: medic does not save first target

### DIFF
--- a/Games/types/Mafia/roles/cards/DonateLife.js
+++ b/Games/types/Mafia/roles/cards/DonateLife.js
@@ -1,7 +1,6 @@
 const Card = require("../../Card");
 const {
-  PRIORITY_NIGHT_SAVER,
-  PRIORITY_EFFECT_GIVER_DEFAULT,
+ PRIORITY_EFFECT_GIVER_DEFAULT,
 } = require("../../const/Priority");
 
 module.exports = class DonateLife extends Card {
@@ -14,10 +13,10 @@ module.exports = class DonateLife extends Card {
         flags: ["voting"],
         targets: { include: ["alive"], exclude: ["dead", "self"] },
         action: {
-          priority: PRIORITY_NIGHT_SAVER - 1,
           run: function () {
-            this.heal();
-            this.actor.role.savedTarget = this.target;
+            if (target.kill("*", this.actor) && this.dominates()) {
+            this.actor.role.data.harvested++;
+            }
           },
         },
       },
@@ -28,14 +27,11 @@ module.exports = class DonateLife extends Card {
         action: {
           priority: PRIORITY_NIGHT_SAVER,
           run: function () {
-            const savedTarget = this.actor.role.savedTarget;
-            if (!savedTarget) return;
-            if (!this.hasVisitors(savedTarget, "kill")) return;
-
             this.target.giveEffect("ExtraLife");
             this.target.queueAlert(
               "You have received an organ donation, giving you an extra life!"
             );
+            this.actor.role.data.harvested--;
           },
         },
       },

--- a/data/roles.js
+++ b/data/roles.js
@@ -173,7 +173,7 @@ const roleData = {
       recentlyUpdated: true,
       description: [
         "Visits two players each night.",
-        "If the first person is targeted for a night kill, the second person gains an extra life.",
+        "If the first person is targeted for a night kill, that person dies and the second person gains an extra life.",
       ],
     },
     Granny: {


### PR DESCRIPTION
https://ultimafia.com/game/uNmofN6bJ/review

medic was capable of saving its first target. intended effect is for medic to give an extra life to its second target only if the first target is killed

attempted quick fix for this

many other bugs in that game. very disappointing