### PR TITLE
fix: chef cannot self-invite

### DIFF
--- a/Games/types/Mafia/roles/cards/BanquetInvite.js
+++ b/Games/types/Mafia/roles/cards/BanquetInvite.js
@@ -11,7 +11,7 @@ module.exports = class BanquetInvite extends Card {
         flags: ["voting", "multi"],
         multiMin: 2,
         multiMax: 2,
-        targets: { include: ["alive"], exclude: [""] },
+        targets: { include: ["alive"], exclude: ["self"] },
         action: {
           labels: ["giveItem", "Invitation"],
           priority: PRIORITY_DAY_DEFAULT,


### PR DESCRIPTION
chef has always been mega OP because of its ability to invite itself to the banquet

this nerfs chef