### PR TITLE
feat: deep one role

### DIFF
--- a/Games/types/Mafia/Winners.js
+++ b/Games/types/Mafia/Winners.js
@@ -31,7 +31,9 @@ module.exports = class MafiaWinners extends Winners {
         return "Ordained by Mount Olympus, Cupid ensured that the star-crossed lovers survived the chaos.";
       case "Dodo":
         return "If this were target practice then that would have been a crack shot! Unfortunately, someone killed the last living Dodo.";
-      case "Executioner":
+      case "Deep One":
+        return "The Cult had been infiltrated by the spawn of the Deep Ones. Now their progeny live at the bottom of an abyssal lake, and a great shadow has been cast over the town.";
+        case "Executioner":
         return "The Executioner finally got to pull the lever on their begrudged victim.";
       case "Fool":
         return "Who is more foolish: the Fool, or the fools who condemned him?";
@@ -44,7 +46,7 @@ module.exports = class MafiaWinners extends Winners {
       case "Hellhound":
         return "The town was ravaged by a demon in the shape of a beast. Under the Blood Moon, one can still hear the baying of the Hellhound.";
       case "Joker":
-        return "Who's having the last laugh, now? The Joker or those who fell for the trap?";
+        return "In the end, it was the Joker who had the last laugh.";
       case "Leprechaun":
         return "The Leprechaun retrieved all of their four-leaf clovers and got out of town at the next opportunity!";
       case "Lover":

--- a/Games/types/Mafia/effects/Fishy.js
+++ b/Games/types/Mafia/effects/Fishy.js
@@ -1,0 +1,40 @@
+const Effect = require("../Effect");
+const Action = require("../Action");
+
+module.exports = class Fishy extends Effect {
+  constructor() {
+    super("Fishy");
+  }
+
+  apply(player) {
+    if (player.hasEffect("Fishy")) {
+      return;
+    }
+
+    super.apply(player);
+    player.queueAlert("Your skin itches...");
+
+    this.action = new Action({
+      actor: this.player,
+      target: player,
+      game: this.player.game,
+      labels: ["convert", "hidden"],
+      delay: 1,
+      effect: this,
+      run: function () {
+        if (this.dominates()) {
+          this.target.setRole("Deep One");
+        }
+
+        this.effect.remove();
+      },
+    });
+
+    this.game.queueAction(this.action);
+  }
+
+  remove() {
+    super.remove();
+    this.action.cancel(true);
+  }
+};

--- a/Games/types/Mafia/effects/TaintedConversions.js
+++ b/Games/types/Mafia/effects/TaintedConversions.js
@@ -1,0 +1,22 @@
+const Effect = require("../Effect");
+const Action = require("../Action");
+
+module.exports = class TaintedConversions extends Effect {
+  constructor() {
+    super("TaintedConversions");
+    this.lifespan = Infinity;
+
+    this.listeners = {
+        immune: function (action) {
+          if (
+            action.target === this.player &&
+            action.hasLabel("convert") &&
+            !this.player.tempImmunity["convert"]
+          ) {
+  
+            this.player.giveEffect("Fishy", action.actor);
+          }
+        },
+      };
+  }
+};

--- a/Games/types/Mafia/roles/Hostile/DeepOne.js
+++ b/Games/types/Mafia/roles/Hostile/DeepOne.js
@@ -1,0 +1,17 @@
+const Role = require("../../Role");
+
+module.exports = class DeepOne extends Role {
+  constructor(player, data) {
+    super("Deep One", player, data);
+
+    this.alignment = "Hostile";
+    this.cards = [
+      "VillageCore",
+      "MeetingCult",
+      "CannotVoteInCultMeeting",
+      "TaintConversions",
+      "AnonymizeCult",
+      "WinWithDeepOnes",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/cards/CannotVoteInCultMeeting.js
+++ b/Games/types/Mafia/roles/cards/CannotVoteInCultMeeting.js
@@ -1,0 +1,9 @@
+const Card = require("../../Card");
+
+module.exports = class CannotVoteInCultMeeting extends Card {
+  constructor(role) {
+    super(role);
+
+    this.startEffects = [{ type: "CannotVote", args: [undefined, "Cult"] }];
+  }
+};

--- a/Games/types/Mafia/roles/cards/TaintConversions.js
+++ b/Games/types/Mafia/roles/cards/TaintConversions.js
@@ -1,0 +1,23 @@
+const Card = require("../../Card");
+const { PRIORITY_EFFECT_GIVER_DEFAULT } = require("../../const/Priority");
+
+module.exports = class TaintConversions extends Card {
+  constructor(role) {
+    super(role);
+
+    this.meetings = {
+      Taint: {
+        states: ["Night"],
+        flags: ["group", "voting"],
+        targets: { include: ["alive"], exclude: ["self"] },
+        action: {
+          labels: ["effect"],
+          priority: PRIORITY_EFFECT_GIVER_DEFAULT,
+          run: function () {
+            this.target.giveEffect("TaintedConversions", infinity);
+          },
+        },
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/TaintedConversions.js
+++ b/Games/types/Mafia/roles/cards/TaintedConversions.js
@@ -1,0 +1,21 @@
+const Card = require("../../Card");
+const Action = require("../../Action");
+
+module.exports = class TaintedConversions extends Card {
+  constructor(role) {
+    super(role);
+
+    this.listeners = {
+        immune: function (action) {
+          if (
+            action.target === this.player &&
+            action.hasLabel("convert") &&
+            !this.player.tempImmunity["convert"]
+          ) {
+  
+            this.player.giveEffect("Fishy", action.actor);
+          }
+        },
+      };
+  }
+};

--- a/Games/types/Mafia/roles/cards/WinWithDeepOnes.js
+++ b/Games/types/Mafia/roles/cards/WinWithDeepOnes.js
@@ -1,0 +1,37 @@
+const Card = require("../../Card");
+const { PRIORITY_WIN_CHECK_DEFAULT } = require("../../const/Priority");
+
+module.exports = class WinWithDeepOnes extends Card {
+  constructor(role) {
+    super(role);
+
+    this.winCheck = {
+      priority: PRIORITY_WIN_CHECK_DEFAULT + 1,
+      check: function (counts, winners, aliveCount) {
+        if (!this.player.alive) {
+          return;
+        }
+
+        // win with majority
+        const numFishAlive = this.game.players.filter(
+          (p) => p.alive && p.role.name == "Deep One"
+        ).length;
+        if (aliveCount > 0 && numFishAlive >= aliveCount / 2) {
+          winners.addPlayer(this.player, this.name);
+          return;
+        }
+      },
+    };
+    this.listeners = {
+      roleAssigned: function (player) {
+        if (player !== this.player) {
+          return;
+        }
+
+        this.player.queueAlert(
+          "The primate Cultists have summoned you from Y'ha-nthlei to serve their Dark Gods. Instead, your hellish hybrids will cast a long shadow over this town."
+        );
+      },
+    };
+  }
+};

--- a/data/roles.js
+++ b/data/roles.js
@@ -1748,11 +1748,19 @@ const roleData = {
     },
     Nyarlathotep: {
       alignment: "Hostile",
-      newlyAdded: true,
       description: [
         "Cult meeting is anonymous if Nyarlathotep is present in the game.",
         "All players who visit Nyarlathotep go insane.",
         "Wins instead of Cult and counts toward their total.",
+      ],
+    },
+    "Deep One": {
+      alignment: "Hostile",
+      newlyAdded: true,
+      description: [
+        "Attends Cult meetings, makes them anonymous and cannot vote in them.",
+        "Each night, chooses a player. If that player is targeted for a conversion, they will at first convert as per usual but then convert to a Deep One after one day and night cycle.",
+        "Wins if the Deep Ones achieve a majority over other players.",
       ],
     },
     Alien: {


### PR DESCRIPTION
new cult-imitating hostile

effects applied are pretty complex. it is basically the equivalent of turning someone into a bleeder, except instead of bleeding when hit by a converter they begin turning into a deep one

going to add a modifier as well. need to test some interactions before this is ready