### PR TITLE
feat: morbid modifier, rewritten

### DIFF
--- a/Games/types/Mafia/roles/cards/VisitOnlyDead.js
+++ b/Games/types/Mafia/roles/cards/VisitOnlyDead.js
@@ -1,0 +1,24 @@
+const Card = require("../../Card");
+
+module.exports = class VisitOnlyDead extends Card {
+  constructor(role) {
+    super(role);
+
+    this.meetingMods = {
+        Village: {
+            targets: { include: ["alive, self"], exclude: ["dead"] },
+        },
+        Cultists: {
+            targets: { include: ["alive"], exclude: ["Cult"] },
+        },
+        Mafia: {
+            targets: { include: ["alive"], exclude: ["Mafia"] },
+        },
+        "*": {
+            states: ["Night"],
+            flags: ["voting"],
+            targets: { include: ["dead"], exclude: ["alive", "self"] },
+        },
+      };
+  }
+};

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -220,6 +220,10 @@ const modifierData = {
         "If this player visits a player with a vanilla role, all their actions will be blocked.",
       incompatible: ["Simple"],
     },
+    Morbid: {
+      internal: ["VisitOnlyDead"],
+      description: "Can only visit dead players.",
+    },
   },
   "Split Decision": {},
   Resistance: {},


### PR DESCRIPTION
rewritten versions from https://github.com/UltiMafia/Ultimafia/pull/924

morbid: can only use secondary actions on dead players. useful for investigators and item stealers

excluded changes to Village/Mafia/Cult meetings. There is probably a cleaner way of doing it compared to how I did it

this mod will be necessary to complete https://github.com/UltiMafia/Ultimafia/issues/1143