### PR TITLE
improvements for searching roles in create setup and learn page - can…

### DIFF
--- a/react_main/src/components/Roles.jsx
+++ b/react_main/src/components/Roles.jsx
@@ -314,6 +314,26 @@ export function RoleSearch(props) {
     setRoleListType(alignment);
   }
 
+  const roleAbbreviations = {
+    gs: ["Gunsmith"],
+    gf: ["Godfather"],
+    bs: ["Blacksmith"],
+    orc: ["Oracle"],
+    ww: ["Werewolf", "Hellhound"],
+    hh: ["Hellhound"],
+    bg: ["Bodyguard"],
+    cl: ["Cult Leader"],
+    gt: ["Graverobber"],
+    hb: ["Heartbreaker"],
+    lk: ["Lightkeeper"],
+    lm: ["Loudmouth"],
+    mm: ["Mastermind"],
+    ph: ["Party Host"],
+    sk: ["Serial Killer"],
+    sw: ["Sleepwalker"],
+    tc: ["Town Crier"],
+  };
+
   function onSearchInput(query) {
     setSearchVal(query.toLowerCase());
 
@@ -347,11 +367,20 @@ export function RoleSearch(props) {
   if (!siteInfo.roles) return <NewLoading small />;
 
   const roleCells = siteInfo.roles[props.gameType].map((role, i) => {
+    const searchTerms = searchVal.split(',').filter(term => term.trim() !== '').map(term => term.trim().toLowerCase());
+
+    const matchesSearch = searchTerms.length === 0 || searchTerms.some(term => 
+      role.name.toLowerCase().includes(term) ||
+      Object.entries(roleAbbreviations).some(([shortcut, roleNames]) => 
+        shortcut === term && roleNames.includes(role.name)
+      )
+    );
+  
     if (
       !role.disabled &&
       (role.alignment === roleListType ||
         (searchVal.length > 0 &&
-          role.name.toLowerCase().indexOf(searchVal) !== -1))
+          (role.name.toLowerCase().indexOf(searchVal) !== -1 || matchesSearch)))
     ) {
       return (
         <Card

--- a/react_main/src/constants/slangList.js
+++ b/react_main/src/constants/slangList.js
@@ -164,11 +164,6 @@ export const slangList = {
       "Notes. Used by players to record the game in progress, whether provided by system messages or by the player's own deductions.",
     emoji: "📝",
   },
-  PR: {
-    definition:
-      "1. Power Role. A role with a unique ability, such as a Cop's Investigate. 2. A role that is meaningful to claim.",
-    emoji: "💪",
-  },
   // unaware: {
   //   definition:
   //     "A type of role that appears to itself as something it's not. Synonymous with SSA, from Sees Self As.",


### PR DESCRIPTION
… search multiple roles at once by separating with comma and can search some roles by abbreviations (gs, ww, hh)