### PR TITLE
Conjuror and Butler roles (Baron and Butler from BOTC) + Banished modifer (Outsiders from BOTC)

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -753,9 +753,11 @@ module.exports = class Game {
 
     var roleset = {};
     var rolesByAlignment = {};
+    this.banishedRoles = [];
 
     for (let role in this.setup.roles[0]) {
       let roleName = role.split(":")[0];
+      let isBanished = role.toLowerCase().includes("banished");
 
       const roleFromRoleData = roleData[this.type][roleName];
       if (!roleFromRoleData) {
@@ -766,11 +768,15 @@ module.exports = class Game {
       }
 
       let alignment = roleFromRoleData.alignment;
-
+      if(!isBanished){
       if (!rolesByAlignment[alignment]) rolesByAlignment[alignment] = [];
 
       for (let i = 0; i < this.setup.roles[0][role]; i++)
         rolesByAlignment[alignment].push(role);
+      }
+      else{
+        this.banishedRoles.push(role);
+      }
     }
 
     for (let alignment in rolesByAlignment) {
@@ -798,6 +804,7 @@ module.exports = class Game {
 
   generateClosedRolesetUsingRoleGroups() {
     let finalRoleset = {};
+    this.banishedRoles = [];
 
     for (let i in this.setup.roles) {
       let size = this.setup.roleGroupSizes[i];
@@ -806,8 +813,14 @@ module.exports = class Game {
       // has common logic with generatedClosedRoleset, can be refactored in future
       let rolesetArray = [];
       for (let role in roleset) {
+        let isBanished = role.toLowerCase().includes("banished");
+        if(!isBanished){
         for (let i = 0; i < roleset[role]; i++) {
           rolesetArray.push(role);
+        }
+        }
+        else{
+          this.banishedRoles.push(role);
         }
       }
 
@@ -943,12 +956,43 @@ module.exports = class Game {
     for (let roleName in roleset) {
       for (let j = 0; j < roleset[roleName]; j++) {
         let player = randomPlayers[i];
-        player.setRole(roleName);
+        //player.setRole(roleName);
+        player.setRole(roleName, undefined, false, true, true);
         this.originalRoles[player.id] = roleName;
         i++;
       }
     }
 
+       if(this.setup.closed && this.setup.banished > 0){
+        var banishedRoles = this.banishedRoles;
+        var banishedCount = this.setup.banished;
+        var validReplace = this.players.filter((p) => (p.role.alignment == "Village" || p.role.alignment == "Independent"));
+        if(banishedCount > validReplace.length){ bashishedCount = validReplace.length};
+        if(this.setup.unique && banishedRoles.length < banishedCount){ banishedCount = banishedRoles.length};
+        if(banishedCount > 0){
+            for (let i = 0; i < banishedCount; i++){
+            let newRole = Random.randArrayVal(banishedRoles);
+            let targetPlayer = Random.randArrayVal(validReplace);
+            targetPlayer.setRole(newRole, undefined, false, true);
+            if(this.setup.unique){
+            banishedRoles.slice(banishedRoles.indexOf(newRole), 1);
+            }
+            validReplace.slice(validReplace.indexOf(targetPlayer), 1);
+            this.originalRoles[targetPlayer.id] = newRole;
+          }
+        }  
+    }
+    if(this.setup.closed && this.banishedRoles.length > 0){
+    this.players.map((p) => this.events.emit("addBanished", p));
+
+    this.rollQueue = [];
+
+    while (this.rollQueue.length < 0){
+      this.events.emit("addBanished", rollQueue[0]);
+      this.rollQueue.shift();
+    }
+    }
+    this.players.map((p) => p.role.revealToSelf(false));
     this.players.map((p) => this.events.emit("roleAssigned", p));
   }
 

--- a/Games/types/Mafia/roles/Cult/Conjuror.js
+++ b/Games/types/Mafia/roles/Cult/Conjuror.js
@@ -1,0 +1,15 @@
+const Role = require("../../Role");
+
+module.exports = class Conjuror extends Role {
+  constructor(player, data) {
+    super("Conjuror", player, data);
+
+    this.alignment = "Cult";
+    this.cards = [
+      "VillageCore",
+      "WinWithCult",
+      "MeetingCult",
+      "Add2Banished",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/Village/Butler.js
+++ b/Games/types/Mafia/roles/Village/Butler.js
@@ -1,0 +1,10 @@
+const Role = require("../../Role");
+
+module.exports = class Butler extends Role {
+  constructor(player, data) {
+    super("Butler", player, data);
+
+    this.alignment = "Village";
+    this.cards = ["VillageCore", "WinWithVillage", "VoteWithMaster"];
+  }
+};

--- a/Games/types/Mafia/roles/cards/Add2Banished.js
+++ b/Games/types/Mafia/roles/cards/Add2Banished.js
@@ -1,0 +1,41 @@
+const Card = require("../../Card");
+const Random = require("../../../../../lib/Random");
+
+module.exports = class Add2Banished extends Card {
+  constructor(role) {
+    super(role);
+
+    this.listeners = {
+      addBanished: function (player) {
+        if (player != this.player) return;
+        if(this.reroll) return;
+
+        //let players = this.game.players.filter((p) => p.role.alignment == "Villager" && !p.role.reroll);
+        let players = this.game.players.filter((p) => (p.role.alignment == "Village" || p.role.alignment == "Independent") && !p.role.data.banished);
+        let shuffledPlayers = Random.randomizeArray(players);
+        let roles = this.game.banishedRoles;
+        for (let i = 0; i < 2; i++){
+          if(this.game.setup.unique){
+            let currentBanishedPlayers = this.game.players.filter((p) => p.role.data.banished);
+            let currentBanishedRoles = [];
+            for(let x = 0;x<currentBanishedPlayers.length;x++){
+            currentBanishedRoles.push(currentBanishedPlayers[x].role);
+            }
+            for(let x = 0;x<roles.length;x++){
+            if(currentBanishedRoles.includes(roles [x])){
+              roles.slice(roles.indexOf(roles[x]), 1);
+            }
+            }
+          }
+          let newRole = Random.randArrayVal(roles);
+          shuffledPlayers[i].setRole(newRole, undefined, false, true);
+          //this.game.originalRoles[suffledPlayers[i].id] = newRole;
+          roles.slice(roles.indexOf(newRole), 1);
+        }
+        //this.game.excessRoles["Outcast"] = roles;
+      },
+    };
+
+    //this.reroll = true;
+  }
+};

--- a/Games/types/Mafia/roles/cards/VoteWithMaster.js
+++ b/Games/types/Mafia/roles/cards/VoteWithMaster.js
@@ -1,0 +1,54 @@
+const Card = require("../../Card");
+const { PRIORITY_SUPPORT_VISIT_DEFAULT } = require("../../const/Priority");
+
+
+module.exports = class VoteWithMaster extends Card {
+  constructor(role) {
+    super(role);
+
+    this.meetings = {
+      Butler: {
+        actionName: "Become Servent",
+        states: ["Night"],
+        flags: ["voting"],
+        action: {
+          labels: ["visit"],
+          priority: PRIORITY_SUPPORT_VISIT_DEFAULT,
+          run: function () {
+            this.role.data.master = this.target;
+          },
+        },
+      },
+    };
+
+    this.listeners = {
+      meeting: function (meeting) {
+        if (meeting.members[this.player.id] && meeting.name === "Village") {
+          meeting.members[this.player.id].voteWeight = 0;
+        }
+      },
+      vote: function (vote) {
+        if (vote.meeting.name === "Village") {
+          if(vote.voter == this.player){
+            this.role.data.BulterVote = vote;
+          }
+          else if(vote.voter == this.role.data.master){
+          this.role.data.MasterVote = vote;
+          }
+          else{
+          return;
+          }
+
+          if(this.role.data.MasterVote.target === this.role.data.ButlerVote.target){
+            vote.meeting.members[this.player.id].voteWeight = 1;
+          }
+          else{
+            vote.meeting.members[this.player.id].voteWeight = 0;
+          }
+          
+
+         
+        }
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/VoteWithMaster.js
+++ b/Games/types/Mafia/roles/cards/VoteWithMaster.js
@@ -5,7 +5,7 @@ const { PRIORITY_SUPPORT_VISIT_DEFAULT } = require("../../const/Priority");
 module.exports = class VoteWithMaster extends Card {
   constructor(role) {
     super(role);
-
+    this.role.data.master = 0;
     this.meetings = {
       Butler: {
         actionName: "Become Servent",
@@ -15,7 +15,9 @@ module.exports = class VoteWithMaster extends Card {
           labels: ["visit"],
           priority: PRIORITY_SUPPORT_VISIT_DEFAULT,
           run: function () {
-            this.role.data.master = this.target;
+            this.actor.role.data.master = this.target;
+            //this.actor.role.data.MasterVote = 0;
+            //this.actor.role.data.ButlerVote = 0;
           },
         },
       },
@@ -23,32 +25,15 @@ module.exports = class VoteWithMaster extends Card {
 
     this.listeners = {
       meeting: function (meeting) {
-        if (meeting.members[this.player.id] && meeting.name === "Village") {
+        if (meeting.name != "Village" || this.player.role.data.master == 0) return;
+        if (meeting.members[this.player.role.data.master.id]) {
+          meeting.members[this.player.role.data.master.id].voteWeight = 2;
+        }
+        if (meeting.members[this.player.id]) {
           meeting.members[this.player.id].voteWeight = 0;
         }
       },
-      vote: function (vote) {
-        if (vote.meeting.name === "Village") {
-          if(vote.voter == this.player){
-            this.role.data.BulterVote = vote;
-          }
-          else if(vote.voter == this.role.data.master){
-          this.role.data.MasterVote = vote;
-          }
-          else{
-          return;
-          }
-
-          if(this.role.data.MasterVote.target === this.role.data.ButlerVote.target){
-            vote.meeting.members[this.player.id].voteWeight = 1;
-          }
-          else{
-            vote.meeting.members[this.player.id].voteWeight = 0;
-          }
-          
-
-         
-        }
-    };
   }
 };
+}
+

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -356,6 +356,11 @@ const modifierData = {
       description:
         "If possible kills will redirected to another player of the same alignment.",
     },
+    Banished: {
+      internal: ["BanishedRole"],
+      description:
+        "Banished roles will not spawn normally in closed setups or role group setups. Banished roles will only spawn if the banished count is increased or if another roles adds Banished roles to the game.",
+    },
   },
   "Split Decision": {},
   Resistance: {},

--- a/data/renamedRoles.js
+++ b/data/renamedRoles.js
@@ -37,7 +37,6 @@ module.exports = {
     Prizefighter: "Pedagogue",
     // deprecated roles
     Framer: "Lawyer",
-    Butler: "Mafioso",
     Knight: "Villager",
     Veteran: "Villager",
     Bomb: "Villager",

--- a/data/roles.js
+++ b/data/roles.js
@@ -664,6 +664,15 @@ const roleData = {
       category: "Voting",
       description: ["Vote weight is worth 2 votes in day meeting."],
     },
+    Butler: {
+      alignment: "Village",
+      newlyAdded: true,
+      category: "Voting",
+      description: [
+        "Each night choose a player to be their Master.",
+        "Vote weight is worth 0 votes in the day meeting unless they are voting the same player as their Master.",
+      ],
+    },
     Governor: {
       alignment: "Village",
       category: "Voting",

--- a/data/roles.js
+++ b/data/roles.js
@@ -1845,6 +1845,14 @@ const roleData = {
         "If a Cult role that kills the team on death dies, the Devotee will prevent those deaths and converts to that role.",
       ],
     },
+    Conjuror: {
+      alignment: "Cult",
+      newlyAdded: true,
+      description: [
+        "Adds 2 Banished roles in Closed Setups.",
+        "If a Conjuror is created mid-game, 2 Village/Independant players will be converted to Banished Roles."
+      ],
+    },
 
     //Independent
     Fool: {

--- a/data/roles.js
+++ b/data/roles.js
@@ -669,8 +669,8 @@ const roleData = {
       newlyAdded: true,
       category: "Voting",
       description: [
-        "Each night choose a player to be their Master.",
-        "Vote weight is worth 0 votes in the day meeting unless they are voting the same player as their Master.",
+        "Vote weight is worth 0 votes",
+        "Each night chooses a player to have a Vote weight of 2 the following day",
       ],
     },
     Governor: {

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -130,6 +130,7 @@ var schemas = {
     alignmentReveal: Boolean,
     votesInvisible: Boolean,
     gameStartPrompt: { type: String, default: undefined },
+    banished: Number,
     swapAmt: Number,
     roundAmt: Number,
     firstTeamSize: Number,

--- a/react_main/src/pages/Play/CreateSetup/CreateMafiaSetup.jsx
+++ b/react_main/src/pages/Play/CreateSetup/CreateMafiaSetup.jsx
@@ -138,6 +138,15 @@ export default function CreateMafiaSetup() {
       ref: "gameStartPrompt",
       type: "text",
     },
+    {
+      label: "Banished Count",
+      ref: "banished",
+      type: "number",
+      value: "0",
+      min: "0",
+      max: "50",
+      showIf: ["closed"],
+    },
   ]);
 
   const formFieldValueMods = {
@@ -178,6 +187,7 @@ export default function CreateMafiaSetup() {
           Independent: Number(formFields[18].value),
         },
         gameStartPrompt: formFields[19].value,
+        banished: Number(formFields[20].value),
         editing: editing,
         id: params.get("edit"),
       })

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -396,6 +396,7 @@ router.post("/create", async function (req, res) {
     setup.mustAct = Boolean(setup.mustAct);
     setup.mustCondemn = Boolean(setup.mustCondemn);
     setup.gameStartPrompt = String(setup.gameStartPrompt || "");
+    setup.banished = Number(setup.banished);
 
     if (
       !routeUtils.validProp(setup.gameType) ||


### PR DESCRIPTION
Banished roles won't spawn normally in closed setups. Banished roles can be added to the game by increasing a the Banished Count during setup creation.

Conjuror adds 2 Banished Roles regardless of the Banished Count to game in closed setups.  

Butler has a vote weight of 0. Each night chooses a player to have a vote weight of 2.