### PR TITLE
jinx/hexer refactor

### DIFF
--- a/Games/types/Mafia/effects/Cursed.js
+++ b/Games/types/Mafia/effects/Cursed.js
@@ -10,7 +10,7 @@ module.exports = class Cursed extends Effect {
   }
 
   speak(message) {
-    if (message.content.replace(" ", "").toLowerCase().includes(this.word)) {
+    if (message.content.replaceAll(" ", "").replaceAll("-", "").replaceAll("*", "").replaceAll("_", "").toLowerCase().includes(this.word)) {
       var action = new Action({
         actor: this.actor,
         target: this.player,

--- a/Games/types/Mafia/effects/CursedCult.js
+++ b/Games/types/Mafia/effects/CursedCult.js
@@ -10,7 +10,7 @@ module.exports = class CursedCult extends Effect {
   }
 
   speak(message) {
-    if (message.content.replace(" ", "").toLowerCase().includes(this.word)) {
+    if (message.content.replaceAll(" ", "").replaceAll("-", "").replaceAll("*", "").replaceAll("_", "").toLowerCase().includes(this.word)) {
       var action = new Action({
         actor: this.actor,
         target: this.player,


### PR DESCRIPTION
closes #1689.

jinx/hexer should now skip all spaces, hyphens, asterisks and underscores.