### PR TITLE
More Clocktower Roles, Cannoneer Fix

### DIFF
--- a/Games/types/Mafia/roles/Village/Courtier.js
+++ b/Games/types/Mafia/roles/Village/Courtier.js
@@ -1,0 +1,10 @@
+const Role = require("../../Role");
+
+module.exports = class Courtier extends Role {
+  constructor(player, data) {
+    super("Courtier", player, data);
+
+    this.alignment = "Village";
+    this.cards = ["VillageCore", "WinWithVillage", "MindRotRoleFor3Nights"];
+  }
+};

--- a/Games/types/Mafia/roles/Village/Debtor.js
+++ b/Games/types/Mafia/roles/Village/Debtor.js
@@ -1,0 +1,10 @@
+const Role = require("../../Role");
+
+module.exports = class Debtor extends Role {
+  constructor(player, data) {
+    super("Debtor", player, data);
+
+    this.alignment = "Village";
+    this.cards = ["VillageCore", "WinWithVillage", "GuessRoleOrDie"];
+  }
+};

--- a/Games/types/Mafia/roles/Village/Minstrel.js
+++ b/Games/types/Mafia/roles/Village/Minstrel.js
@@ -1,0 +1,14 @@
+const Role = require("../../Role");
+
+module.exports = class Minstrel extends Role {
+  constructor(player, data) {
+    super("Minstrel", player, data);
+
+    this.alignment = "Village";
+    this.cards = [
+      "VillageCore",
+      "WinWithVillage",
+      "MindRotEveryoneOnEvilCondemn",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/cards/Disloyal.js
+++ b/Games/types/Mafia/roles/cards/Disloyal.js
@@ -1,4 +1,5 @@
 const Card = require("../../Card");
+const Player = require("../../../../core/Player");
 const { PRIORITY_NIGHT_ROLE_BLOCKER } = require("../../const/Priority");
 
 module.exports = class Disloyal extends Card {
@@ -7,21 +8,43 @@ module.exports = class Disloyal extends Card {
 
     this.actions = [
       {
-        priority: PRIORITY_NIGHT_ROLE_BLOCKER,
+        priority: PRIORITY_NIGHT_ROLE_BLOCKER-1,
         labels: ["block", "hidden", "absolute"],
         run: function () {
           if (this.game.getStateName() != "Night") return;
 
           if (!this.actor.alive) return;
 
-          
-          let visits = this.getVisits(this.actor);
-          let sameAlignmentVisits = visits.filter(
-            (v) => v.role.alignment == this.actor.role.alignment
-          );
-          if (sameAlignmentVisits.length > 0) {
-            this.blockActions(this.actor,null,"mafia");
+          for (let action of this.game.actions[0]) {
+            if (action.hasLabel("absolute")) {
+              continue;
+            }
+            if (action.hasLabel("mafia")) {
+              continue;
+            }
+            if (action.hasLabel("hidden")) {
+              continue;
+            }
+
+            let toCheck = action.target;
+            if (!Array.isArray(action.target)) {
+              toCheck = [action.target];
+            }
+            
+            if (action.actors.indexOf(this.actor) != -1 && !action.hasLabel("hidden") && action.target && toCheck[0] instanceof Player) {
+              
+              for(let y = 0; y < toCheck.length; y++){
+                if(toCheck[y].role.alignment == this.actor.role.alignment){
+                  if (action.priority > this.priority && !action.hasLabel("absolute")) {
+                    action.cancelActor(this.actor);
+                    break;
+                  }
+                }
+              }
+              
+            }
           }
+         
         },
       },
     ];

--- a/Games/types/Mafia/roles/cards/GainGunIfMafiaAbstained.js
+++ b/Games/types/Mafia/roles/cards/GainGunIfMafiaAbstained.js
@@ -14,7 +14,7 @@ module.exports = class GainGunIfMafiaAbstained extends Card {
 
           if (!this.actor.alive) return;
 
-          if (this.actor.data.gainedGun) return;
+          if (this.actor.role.data.gainedGun) return;
 
           let mafiaKilled = false;
           for (let action of this.game.actions[0]) {

--- a/Games/types/Mafia/roles/cards/GuessRoleOrDie.js
+++ b/Games/types/Mafia/roles/cards/GuessRoleOrDie.js
@@ -1,0 +1,76 @@
+const Card = require("../../Card");
+const { PRIORITY_KILL_DEFAULT } = require("../../const/Priority");
+const { addArticle } = require("../../../../core/Utils");
+
+module.exports = class GuessRoleOrDie extends Card {
+  constructor(role) {
+    super(role);
+
+    this.meetings = {
+      "Choose Player": {
+        states: ["Night"],
+        flags: ["voting", "mustAct"],
+        targets: { include: ["alive", "self", "dead"] },
+        action: {
+          priority: PRIORITY_KILL_DEFAULT - 1,
+          run: function () {
+            this.actor.role.data.targetPlayer = this.target;
+          },
+        },
+      },
+      "Guess Role": {
+        states: ["Night"],
+        flags: ["voting"],
+        inputType: "custom",
+        action: {
+          labels: ["kill"],
+          priority: PRIORITY_KILL_DEFAULT,
+          run: function () {
+            let targetPlayer = this.actor.role.data.targetPlayer;
+            if (targetPlayer) {
+              let tempName = targetPlayer.role.name;
+              let tempModifier = targetPlayer.role.modifier;
+              let playerRole = `${tempName}:${tempModifier}`;
+              if (tempModifier) {
+                playerRole = `${tempName}:${tempModifier}`;
+              } else {
+                playerRole = `${tempName}`;
+              }
+
+              if (this.target == playerRole || this.target == playerRole) {
+                return;
+              } else {
+                if (this.dominates(this.actor))
+                  this.actor.kill("basic", this.actor);
+              }
+
+              delete this.actor.role.data.targetPlayer;
+            }
+          },
+        },
+      },
+    };
+
+    this.listeners = {
+      roleAssigned: function (player) {
+        if (player !== this.player) {
+          return;
+        }
+
+        this.player.role.data.ConvertOptions = this.game.PossibleRoles.filter(
+          (r) => r
+        );
+      },
+      // refresh cooldown
+      state: function (stateInfo) {
+        if (!stateInfo.name.match(/Night/)) {
+          return;
+        }
+        let guessOptions = this.player.role.data.ConvertOptions;
+        //ConvertOptions.push("None");
+
+        this.meetings["Guess Role"].targets = guessOptions;
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/LearnAndLifeLinkToPlayer.js
+++ b/Games/types/Mafia/roles/cards/LearnAndLifeLinkToPlayer.js
@@ -1,0 +1,80 @@
+const Card = require("../../Card");
+const Random = require("../../../../../lib/Random");
+const { PRIORITY_INVESTIGATIVE_DEFAULT } = require("../../const/Priority");
+
+module.exports = class LearnAndLifeLinkToPlayer extends Card {
+  constructor(role) {
+    super(role);
+
+    this.actions = [
+      {
+        priority: PRIORITY_INVESTIGATIVE_DEFAULT,
+        labels: ["investigate", "role"],
+        run: function () {
+          if (this.game.getStateName() != "Night") return;
+          if (this.actor.role.hasInfo) return;
+          if (!this.actor.alive) return;
+
+          if (this.actor.role.targetPlayer) {
+            let learnPlayer = this.actor.role.targetPlayer;
+            let learnRole = learnPlayer.getRoleAppearance();
+
+            if (this.actor.hasEffect("FalseMode")) {
+              var alive = this.game.players.filter(
+                (p) => p.alive && p != this.actor && p != learnPlayer
+              );
+              alive = Random.randomizeArray(alive);
+              learnPlayer = alive[0];
+              if (
+                alive.filter(
+                  (p) =>
+                    p.getRoleAppearance() != learnPlayer.getRoleAppearance() &&
+                    p.role.alignment == this.actor.role.alignment
+                ).length > 0
+              ) {
+                alive = alive.filter(
+                  (p) =>
+                    p.getRoleAppearance() != learnPlayer.getRoleAppearance() &&
+                    p.role.alignment == this.actor.role.alignment
+                );
+              }
+              alive = Random.randomizeArray(alive);
+              learnRole = alive[0].getRoleAppearance();
+            }
+
+            this.actor.queueAlert(
+              `You are Married to ${learnPlayer.name} who is a ${learnRole}. If they die during the night to another alignment, You will die as well.`
+            );
+          }
+
+          this.actor.role.hasInfo = true;
+        },
+      },
+    ];
+
+    this.listeners = {
+      roleAssigned: function (player) {
+        if (player !== this.player) {
+          return;
+        }
+
+        const nonMafia = this.game.players.filter(
+          (p) =>
+            p.role.alignment === this.player.role.alignment &&
+            p.alive &&
+            p !== this.player
+        );
+        let shuffledPlayers = Random.randomizeArray(nonMafia);
+        if (nonMafia.length <= 0) return;
+        this.player.role.targetPlayer = Random.randArrayVal(nonMafia);
+      },
+      death: function (player, killer, deathType) {
+        if (this.game.getStateName() != "Night") return;
+        if (killer.role.alignment == this.player.role.alignment) return;
+        if (player === this.player.role.targetPlayer && this.player.alive) {
+          this.player.kill("basic", this.player);
+        }
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/Loyal.js
+++ b/Games/types/Mafia/roles/cards/Loyal.js
@@ -1,4 +1,5 @@
 const Card = require("../../Card");
+const Player = require("../../../../core/Player");
 const { PRIORITY_NIGHT_ROLE_BLOCKER } = require("../../const/Priority");
 
 module.exports = class Loyal extends Card {
@@ -7,21 +8,44 @@ module.exports = class Loyal extends Card {
 
     this.actions = [
       {
-        priority: PRIORITY_NIGHT_ROLE_BLOCKER,
+        priority: PRIORITY_NIGHT_ROLE_BLOCKER-1,
         labels: ["block", "hidden", "absolute"],
         run: function () {
           if (this.game.getStateName() != "Night") return;
 
           if (!this.actor.alive) return;
 
-          let visits = this.getVisits(this.actor);
-          let differentAlignmentVisits = visits.filter(
-            (v) => v.role.alignment != this.actor.role.alignment
-          );
-          if (differentAlignmentVisits.length > 0) {
-            this.blockActions(this.actor,null,"mafia");
+          for (let action of this.game.actions[0]) {
+            if (action.hasLabel("absolute")) {
+              continue;
+            }
+            if (action.hasLabel("mafia")) {
+              continue;
+            }
+            if (action.hasLabel("hidden")) {
+              continue;
+            }
+
+            let toCheck = action.target;
+            if (!Array.isArray(action.target)) {
+              toCheck = [action.target];
+            }
+            
+            if (action.actors.indexOf(this.actor) != -1 && !action.hasLabel("hidden") && action.target && toCheck[0] instanceof Player) {
+              
+              for(let y = 0; y < toCheck.length; y++){
+                if(toCheck[y].role.alignment != this.actor.role.alignment){
+                  if (action.priority > this.priority && !action.hasLabel("absolute")) {
+                    action.cancelActor(this.actor);
+                    break;
+                  }
+                }
+              }
+              
+            }
           }
         },
+        
       },
     ];
   }

--- a/Games/types/Mafia/roles/cards/MagusGame.js
+++ b/Games/types/Mafia/roles/cards/MagusGame.js
@@ -106,7 +106,7 @@ module.exports = class MagusGame extends Card {
           shuffledPlayers = Random.randomizeArray(alivePlayers);
           if (this.actor.role.data.FakeBlocking) {
             if (this.dominates(shuffledPlayers[0])) {
-              this.blockWithMindRot(shuffledPlayers[0]);
+              this.blockActions(shuffledPlayers[0]);
             }
           }
 

--- a/Games/types/Mafia/roles/cards/MindRotEveryoneOnEvilCondemn.js
+++ b/Games/types/Mafia/roles/cards/MindRotEveryoneOnEvilCondemn.js
@@ -1,0 +1,60 @@
+const Card = require("../../Card");
+const { PRIORITY_NIGHT_ROLE_BLOCKER } = require("../../const/Priority");
+
+module.exports = class MindRotEveryoneOnEvilCondemn extends Card {
+  constructor(role) {
+    super(role);
+
+    //role.evilDied = false;
+
+    this.actions = [
+      {
+        priority: PRIORITY_NIGHT_ROLE_BLOCKER - 1,
+        labels: ["block"],
+        run: function () {
+          if (this.game.getStateName() != "Night") return;
+          if (!this.actor.role.evilDied) return;
+
+          if (!this.actor.alive) return;
+
+          let players = this.game.players.filter((p) => p != this.actor);
+
+          let victims = players;
+
+          for (let x = 0; x < victims.length; x++) {
+            if (this.dominates(victims[x])) {
+              this.blockWithMindRot(victims[x]);
+            }
+          }
+        },
+      },
+    ];
+
+    this.listeners = {
+      state: function (stateInfo) {
+        if (!this.player.alive) {
+          return;
+        }
+
+        if (stateInfo.name.match(/Day/)) {
+          this.player.role.evilDied = false;
+          return;
+        }
+      },
+      death: function (player, killer, deathType) {
+        if (
+          this.game.getRoleAlignment(
+            player.getRoleAppearance().split(" (")[0]
+          ) == "Cult" ||
+          this.game.getRoleAlignment(
+            player.getRoleAppearance().split(" (")[0]
+          ) == "Mafia"
+        ) {
+          if (deathType != "condemn") return;
+
+          this.player.role.evilDied = true;
+        }
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/MindRotRoleFor3Nights.js
+++ b/Games/types/Mafia/roles/cards/MindRotRoleFor3Nights.js
@@ -1,0 +1,96 @@
+const Card = require("../../Card");
+const { PRIORITY_NIGHT_ROLE_BLOCKER } = require("../../const/Priority");
+const { addArticle } = require("../../../../core/Utils");
+module.exports = class MindRotRoleFor3Nights extends Card {
+  constructor(role) {
+    super(role);
+
+    //const targetOptions = this.game.PossibleRoles.filter((r) => r);
+    this.meetings = {
+      "Block Role": {
+        states: ["Night"],
+        flags: ["voting"],
+        inputType: "custom",
+        //targets: { targetOptions },
+        shouldMeet: function () {
+          return !this.hasBlocked;
+        },
+        action: {
+          labels: ["block", "role"],
+          priority: PRIORITY_NIGHT_ROLE_BLOCKER - 1,
+          run: function () {
+            if (this.target == "None") return;
+            this.actor.role.hasBlocked = true;
+            //this.playersToBlock = [];
+
+            let players = this.game.players.filter((p) => p.role);
+            let currentRoles = [];
+
+            for (let x = 0; x < players.length; x++) {
+              //currentRoles.push(players[x].role);
+              let tempName = players[x].role.name;
+              let tempModifier = players[x].role.modifier;
+              let playerRole = `${tempName}:${tempModifier}`;
+              if (tempModifier) {
+                playerRole = `${tempName}:${tempModifier}`;
+              } else {
+                playerRole = `${tempName}`;
+              }
+              currentRoles.push(playerRole);
+            }
+            for (let y = 0; y < currentRoles.length; y++) {
+              if (this.target == currentRoles[y]) {
+                this.actor.role.playersToBlock.push(players[y]);
+                this.actor.role.blockCounter = 3;
+              }
+            }
+          },
+        },
+      },
+    };
+
+    this.actions = [
+      {
+        priority: PRIORITY_NIGHT_ROLE_BLOCKER,
+        labels: ["block"],
+        run: function () {
+          //if(!this.actor.role.playersToBlock) return;
+          let victims = this.actor.role.playersToBlock;
+          if (victims.length <= 0) return;
+          if (this.actor.role.blockCounter <= 0) return;
+          if (!this.actor.alive) return;
+          if (this.game.getStateName() == "Day")
+            this.actor.role.blockCounter = this.actor.role.blockCounter - 1;
+
+          for (let x = 0; x < victims.length; x++) {
+            if (this.dominates(victims[x])) {
+              this.blockWithMindRot(victims[x]);
+            }
+          }
+        },
+      },
+    ];
+
+    this.listeners = {
+      roleAssigned: function (player) {
+        if (player !== this.player) {
+          return;
+        }
+        this.player.role.playersToBlock = [];
+        this.player.role.data.blockOptions = this.game.PossibleRoles.filter(
+          (r) => r
+        );
+      },
+      // refresh cooldown
+      state: function (stateInfo) {
+        if (!stateInfo.name.match(/Night/)) {
+          return;
+        }
+        let blockOptions = this.player.role.data.blockOptions;
+        blockOptions.push("None");
+
+        this.meetings["Block Role"].targets = blockOptions;
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/NightCaroler.js
+++ b/Games/types/Mafia/roles/cards/NightCaroler.js
@@ -33,6 +33,10 @@ module.exports = class NightCaroler extends Card {
               );
             }
 
+            if(evilPlayers.length <= 0){
+              return;
+            }
+
             /* We need to handle a list of visits in order to know if the target should receieve a carol
                if the list is empty, that means the target doesn't visit and should get the carol. */
             let visits = this.getVisits(this.target);
@@ -49,6 +53,9 @@ module.exports = class NightCaroler extends Card {
               chosenThree = Random.randomizeArray(chosenThree);
 
               if (this.actor.hasEffect("FalseMode")) {
+                if(evilPlayers.length <= 2){
+                return;
+                }
                 evilPlayers = Random.randomizeArray(evilPlayers);
                 chosenThree = [];
                 chosenThree.push(evilPlayers[0]);

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -414,6 +414,11 @@ const modifierData = {
       description:
         "While a role with this modifier is in play, Village-aligned players might survive being condemned",
     },
+    Married: {
+      internal: ["LearnAndLifeLinkToPlayer"],
+      description:
+        "On Night 1 will learn a player and their role. If that player is killed during the Night at Any Point in the game, You die.",
+    },
   },
   "Split Decision": {},
   Resistance: {},

--- a/data/roles.js
+++ b/data/roles.js
@@ -2839,7 +2839,7 @@ const roleData = {
         "The Magus will passivly use abilites of Evil roles that can spawn in a setup randomly during the Night. (Even if Dead)",
         "If an Magus is Possible to Spawn in a Setup, players can vote to declare Magus Game during the Day.",
         "If a Magus Game is Proclaimed and Mafia or Cult is Present, All Village-Aligned Players Die.",
-        "Village can't Win if Magus is in the game and a Magus game is not declared."
+        "Village can't Win if Magus is in the game and a Magus game is not declared.",
         "Village and The Magus Lose if only 2 players are Alive.",
         "Wins with Village If a Magus Game is Proclaimed (Can Win When Dead).",
       ],

--- a/data/roles.js
+++ b/data/roles.js
@@ -659,6 +659,17 @@ const roleData = {
         "Cannot choose same the target consecutively.",
       ],
     },
+    Courtier: {
+      alignment: "Village",
+      newlyAdded: true,
+      category: "Night-acting",
+      tags: ["Night-acting", "Mind Rot", "Roles"],
+      description: [
+        "Once per game chooses a Role.",
+        "Any players with that role are inflicted with Mind Rot for 3 Nights.",
+        "If the selected role is not in the game nothing happens.",
+      ],
+    },
     Drunk: {
       alignment: "Village",
       category: "Night-acting",
@@ -935,6 +946,15 @@ const roleData = {
         "Cannot place themselves under house arrest.",
       ],
     },
+    Minstrel: {
+      alignment: "Village",
+      newlyAdded: true,
+      category: "Voting",
+      tags: ["Voting", "Condemn", "Mind Rot", "Alignment"],
+      description: [
+        "If an Evil player is Condemned, All players are Inflicted with Mind Rot that Night.",
+      ],
+    },
     Princess: {
       alignment: "Village",
       newlyAdded: true,
@@ -1116,6 +1136,16 @@ const roleData = {
       description: ["Learns the roles of those who visited them."],
     },
     //killing roles
+      Debtor: {
+      alignment: "Village",
+      newlyAdded: true,
+      category: "Killing",
+      tags: ["Killing", "Information", "Roles"],
+      description: [
+        "Each night must choose a player and role from the Setup.",
+        "If the selected role is not the player's role, The Debtor dies.",
+      ],
+    },
     Firebrand: {
       alignment: "Village",
       category: "Killing",

--- a/data/roles.js
+++ b/data/roles.js
@@ -2834,14 +2834,14 @@ const roleData = {
       newlyAdded: true,
       tags: ["Magus", "Setup Changes", "Village"],
       description: [
-        "In Closed Setups All Mafia and Cult will be Replaced with Village roles from the Setup.",
-        "In Non-Closed Setups All Mafia and Cult are replaced with Villager ",
-        "The Magus will Mimic the Abilites of Mafia and Cult roles.",
+        "If a Magus is in the game at the Start, No Mafia and Cult will be in the Game.",
+        "The Magus will kill a Random player Each Night (Even if Dead)",
+        "The Magus will passivly use abilites of Evil roles that can spawn in a setup randomly during the Night. (Even if Dead)",
         "If an Magus is Possible to Spawn in a Setup, players can vote to declare Magus Game during the Day.",
-        "A Magus Game is only Proclaimed if No one is Condemned.",
         "If a Magus Game is Proclaimed and Mafia or Cult is Present, All Village-Aligned Players Die.",
-        "Wins with Village If a Magus Game is Proclaimed.",
-        "Village Loses if only 2 players are Alive.",
+        "Village can't Win if Magus is in the game and a Magus game is not declared."
+        "Village and The Magus Lose if only 2 players are Alive.",
+        "Wins with Village If a Magus Game is Proclaimed (Can Win When Dead).",
       ],
     },
     "Serial Killer": {


### PR DESCRIPTION
Added Minstrel, If evil is condemned all players are inflicted with Mind rot.

added Courtier, Once per game can choose a role, If the Role is in play all players with are inflicted with mind rot for 3 nights.

added Grandmother as Married Modifier, On learns a player and their role, If that player is killed at night by another alignment, You also die.

added Gambler as Debtor, Each night must choose a player and a role from the setup. If the selected player isn't the selected role, the Debtor dies.

Buff: Caroler in False Mode no longer breaks the game if a town player vegs. (I think)

Better Magus Description.

Cannoneer now only gets a Gun Once.