### PR TITLE
One Night Game Modifier and Enchantress Fix

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -1740,6 +1740,10 @@ module.exports = class Game {
     return this.votingDead || this.setup.votingDead;
   }
 
+  isOneNightMode() {
+    return this.OneNightMode || this.setup.OneNightMode;
+  }
+
   isNoVeg() {
     return this.noVeg;
   }

--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -1307,6 +1307,15 @@ module.exports = class Game {
         ),
       ];
     }
+    if (this.setup.OneNightMode && this.currentState == 0) {
+      [
+        this.sendAlert(
+          `:crystal2: ${this.setup.name}: This Setup is using One Night Mode! The game will end after Day 1. If all Members of the mafia/cult alive Mafia/cult wins. If any mafia member is killed town wins. If No Mafia/Cult are in game if any village aligned players die, Village loses. If Mafia and Cult are in a game, Then 1 mafia and 1 Cult must be killed for village to win, 1 Cult and 0 mafia must be killed for Mafia to win, 1 Mafia and 0 cult must be killed for cult to win.`,
+          undefined,
+          { color: " #713cfe" }
+        ),
+      ];
+    }
 
     // Check for inactivity
     this.inactivityCheck();

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -51,6 +51,7 @@ module.exports = class MafiaGame extends Game {
     this.resetLastDeath = false;
     this.extensions = 0;
     this.extensionVotes = 0;
+    this.hasBeenDay = false;
   }
 
   rebroadcastSetup() {

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -300,6 +300,11 @@ module.exports = class MafiaGame extends Game {
       finished = true;
     }
 
+    if(this.isOneNightMode() == true && this.hasBeenDay == true && !finished && winners.groupAmt() <= 0){
+      winners.addGroup("No one");
+      finished = true;
+    }
+
     if (finished)
       for (let winCheck of winQueue)
         if (winCheck.againOnFinished)

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -300,7 +300,12 @@ module.exports = class MafiaGame extends Game {
       finished = true;
     }
 
-    if(this.isOneNightMode() == true && this.hasBeenDay == true && !finished && winners.groupAmt() <= 0){
+    if (
+      this.isOneNightMode() == true &&
+      this.hasBeenDay == true &&
+      !finished &&
+      winners.groupAmt() <= 0
+    ) {
       winners.addGroup("No one");
       finished = true;
     }

--- a/Games/types/Mafia/roles/cards/WinWithFaction.js
+++ b/Games/types/Mafia/roles/cards/WinWithFaction.js
@@ -19,12 +19,12 @@ module.exports = class WinWithFaction extends Card {
   constructor(role) {
     super(role);
 
-      this.actions = [
+    this.actions = [
       {
         priority: PRIORITY_DAY_DEFAULT + 20,
         run: function () {
           if (!this.actor.alive) return;
-          if(!this.game.isOneNightMode()) return;
+          if (!this.game.isOneNightMode()) return;
           if (this.game.getStateName() == "Day") {
             this.game.hasBeenDay = true;
             return;
@@ -42,8 +42,14 @@ module.exports = class WinWithFaction extends Card {
 
         //Const
         const ONE_NIGHT = this.game.isOneNightMode();
-        const CULT_IN_GAME = (this.game.players.filter((p) => CULT_FACTIONS.includes(this.player.faction)).length > 0);
-        const MAFIA_IN_GAME = (this.game.players.filter((p) => MAFIA_FACTIONS.includes(this.player.faction)).length > 0);
+        const CULT_IN_GAME =
+          this.game.players.filter((p) =>
+            CULT_FACTIONS.includes(this.player.faction)
+          ).length > 0;
+        const MAFIA_IN_GAME =
+          this.game.players.filter((p) =>
+            MAFIA_FACTIONS.includes(this.player.faction)
+          ).length > 0;
 
         //Const
         const seersInGame = this.game.players.filter(
@@ -261,41 +267,55 @@ module.exports = class WinWithFaction extends Card {
         //Win Cons
 
         //One Night Win-Cons
-        if(this.game.hasBeenDay == true){
-        //Cult
-        if (CULT_FACTIONS.includes(this.player.faction) && ONE_NIGHT) {
-          var deadCult = this.game.deadPlayers().filter((p) =>p.faction == this.player.faction);
-          var deadMafia = this.game.deadPlayers().filter((p) => MAFIA_FACTIONS.includes(p.faction));
-          if(MAFIA_IN_GAME && deadMafia.length > 0) return;
-          if (deadCult.length <= 0) {
+        if (this.game.hasBeenDay == true) {
+          //Cult
+          if (CULT_FACTIONS.includes(this.player.faction) && ONE_NIGHT) {
+            var deadCult = this.game
+              .deadPlayers()
+              .filter((p) => p.faction == this.player.faction);
+            var deadMafia = this.game
+              .deadPlayers()
+              .filter((p) => MAFIA_FACTIONS.includes(p.faction));
+            if (MAFIA_IN_GAME && deadMafia.length > 0) return;
+            if (deadCult.length <= 0) {
               factionWin(this);
               return;
+            }
           }
-        }
 
-        //Mafia
-        if (MAFIA_FACTIONS.includes(this.player.faction) && ONE_NIGHT) {
-          var deadMafia = this.game.deadPlayers().filter((p) => p.faction == this.player.faction);
-          var deadCult = this.game.deadPlayers().filter((p) => CULT_FACTIONS.includes(p.faction));
-          if(CULT_IN_GAME && deadCult.length > 0) return;
-          if (deadMafia.length <= 0) {
+          //Mafia
+          if (MAFIA_FACTIONS.includes(this.player.faction) && ONE_NIGHT) {
+            var deadMafia = this.game
+              .deadPlayers()
+              .filter((p) => p.faction == this.player.faction);
+            var deadCult = this.game
+              .deadPlayers()
+              .filter((p) => CULT_FACTIONS.includes(p.faction));
+            if (CULT_IN_GAME && deadCult.length > 0) return;
+            if (deadMafia.length <= 0) {
               factionWin(this);
               return;
+            }
           }
-        }
 
-        //Village
-        if (this.player.faction == "Village" && ONE_NIGHT) {
-          var deadMafia = this.game.deadPlayers().filter((p) => MAFIA_FACTIONS.includes(p.faction));
-          var deadCult = this.game.deadPlayers().filter((p) => CULT_FACTIONS.includes(p.faction));
-          var deadVillage = this.game.deadPlayers().filter((p) => p.faction == "Village");
-          if(CULT_IN_GAME && deadCult.length > 0) return;
-          if(MAFIA_IN_GAME && deadMafia.length > 0) return;
-          if(!MAFIA_IN_GAME && !CULT_IN_GAME && deadVillage.length > 0) return;
-              factionWin(this);
+          //Village
+          if (this.player.faction == "Village" && ONE_NIGHT) {
+            var deadMafia = this.game
+              .deadPlayers()
+              .filter((p) => MAFIA_FACTIONS.includes(p.faction));
+            var deadCult = this.game
+              .deadPlayers()
+              .filter((p) => CULT_FACTIONS.includes(p.faction));
+            var deadVillage = this.game
+              .deadPlayers()
+              .filter((p) => p.faction == "Village");
+            if (CULT_IN_GAME && deadCult.length > 0) return;
+            if (MAFIA_IN_GAME && deadMafia.length > 0) return;
+            if (!MAFIA_IN_GAME && !CULT_IN_GAME && deadVillage.length > 0)
               return;
-          
-        }
+            factionWin(this);
+            return;
+          }
         }
 
         //Win with Dead Poltergeist
@@ -327,7 +347,10 @@ module.exports = class WinWithFaction extends Card {
           }
         }
         // win by majority
-        if (FACTION_WIN_WITH_MAJORITY.includes(this.player.faction) && !ONE_NIGHT) {
+        if (
+          FACTION_WIN_WITH_MAJORITY.includes(this.player.faction) &&
+          !ONE_NIGHT
+        ) {
           if (hasMajority) {
             factionWin(this);
             return;
@@ -505,7 +528,8 @@ module.exports = class WinWithFaction extends Card {
         if (
           this.game.getRoleAlignment(this.player.role.name) !=
             this.player.faction &&
-          (!this.player.hasItem("IsTheTelevangelist") || this.player.role.name == "Disguiser")
+          (!this.player.hasItem("IsTheTelevangelist") ||
+            this.player.role.name == "Disguiser")
         ) {
           this.player.queueAlert(
             `You are ${this.player.faction} Aligned, You will win with ${this.player.faction}!`

--- a/Games/types/Mafia/roles/cards/WinWithFaction.js
+++ b/Games/types/Mafia/roles/cards/WinWithFaction.js
@@ -43,13 +43,9 @@ module.exports = class WinWithFaction extends Card {
         //Const
         const ONE_NIGHT = this.game.isOneNightMode();
         const CULT_IN_GAME =
-          this.game.players.filter((p) =>
-            CULT_FACTIONS.includes(this.player.faction)
-          ).length > 0;
+          this.game.players.filter((p) => CULT_FACTIONS.includes(p.faction)).length > 0;
         const MAFIA_IN_GAME =
-          this.game.players.filter((p) =>
-            MAFIA_FACTIONS.includes(this.player.faction)
-          ).length > 0;
+          this.game.players.filter((p) => MAFIA_FACTIONS.includes(p.faction)).length > 0;
 
         //Const
         const seersInGame = this.game.players.filter(
@@ -276,7 +272,7 @@ module.exports = class WinWithFaction extends Card {
             var deadMafia = this.game
               .deadPlayers()
               .filter((p) => MAFIA_FACTIONS.includes(p.faction));
-            if (MAFIA_IN_GAME && deadMafia.length > 0) return;
+            if (MAFIA_IN_GAME && deadMafia.length <= 0 || this.game.deadPlayers().length <= 0) return;
             if (deadCult.length <= 0) {
               factionWin(this);
               return;
@@ -291,7 +287,7 @@ module.exports = class WinWithFaction extends Card {
             var deadCult = this.game
               .deadPlayers()
               .filter((p) => CULT_FACTIONS.includes(p.faction));
-            if (CULT_IN_GAME && deadCult.length > 0) return;
+            if (CULT_IN_GAME && deadCult.length <= 0 || this.game.deadPlayers().length <= 0) return;
             if (deadMafia.length <= 0) {
               factionWin(this);
               return;
@@ -300,19 +296,12 @@ module.exports = class WinWithFaction extends Card {
 
           //Village
           if (this.player.faction == "Village" && ONE_NIGHT) {
-            var deadMafia = this.game
-              .deadPlayers()
-              .filter((p) => MAFIA_FACTIONS.includes(p.faction));
-            var deadCult = this.game
-              .deadPlayers()
-              .filter((p) => CULT_FACTIONS.includes(p.faction));
-            var deadVillage = this.game
-              .deadPlayers()
-              .filter((p) => p.faction == "Village");
-            if (CULT_IN_GAME && deadCult.length > 0) return;
-            if (MAFIA_IN_GAME && deadMafia.length > 0) return;
-            if (!MAFIA_IN_GAME && !CULT_IN_GAME && deadVillage.length > 0)
-              return;
+            var deadMafia = this.game.deadPlayers().filter((p) => MAFIA_FACTIONS.includes(p.faction));
+            var deadCult = this.game.deadPlayers().filter((p) => CULT_FACTIONS.includes(p.faction));
+            var deadVillage = this.game.deadPlayers().filter((p) => p.faction == "Village");
+            if (CULT_IN_GAME == true && (deadCult.length <= 0 || this.game.deadPlayers().length <= 0)) return;
+            if (MAFIA_IN_GAME == true && (deadMafia.length <= 0 || this.game.deadPlayers().length <= 0)) return;
+            if (!MAFIA_IN_GAME && !CULT_IN_GAME && deadVillage.length > 0) return;
             factionWin(this);
             return;
           }

--- a/Games/types/Mafia/roles/cards/WinWithFaction.js
+++ b/Games/types/Mafia/roles/cards/WinWithFaction.js
@@ -2,6 +2,7 @@ const Card = require("../../Card");
 const {
   PRIORITY_WIN_CHECK_DEFAULT,
   PRIORITY_SUNSET_DEFAULT,
+  PRIORITY_DAY_DEFAULT,
 } = require("../../const/Priority");
 const {
   EVIL_FACTIONS,
@@ -18,12 +19,31 @@ module.exports = class WinWithFaction extends Card {
   constructor(role) {
     super(role);
 
+      this.actions = [
+      {
+        priority: PRIORITY_DAY_DEFAULT + 20,
+        run: function () {
+          if (!this.actor.alive) return;
+          if(!this.game.isOneNightMode()) return;
+          if (this.game.getStateName() == "Day") {
+            this.game.hasBeenDay = true;
+            return;
+          }
+        },
+      },
+    ];
+
     this.winCheck = {
       priority: PRIORITY_WIN_CHECK_DEFAULT,
       check: function (counts, winners, aliveCount) {
         function factionWin(role) {
           winners.addPlayer(role.player, role.player.faction);
         }
+
+        //Const
+        const ONE_NIGHT = this.game.isOneNightMode();
+        const CULT_IN_GAME = (this.game.players.filter((p) => CULT_FACTIONS.includes(this.player.faction)).length > 0);
+        const MAFIA_IN_GAME = (this.game.players.filter((p) => MAFIA_FACTIONS.includes(this.player.faction)).length > 0);
 
         //Const
         const seersInGame = this.game.players.filter(
@@ -178,7 +198,7 @@ module.exports = class WinWithFaction extends Card {
           }
         }
         //Poltergeist conditional
-        if (this.player.faction == "Village") {
+        if (this.player.faction == "Village" && !ONE_NIGHT) {
           const deadEvilPoltergeist = this.game
             .deadPlayers()
             .filter(
@@ -194,7 +214,7 @@ module.exports = class WinWithFaction extends Card {
         }
 
         //soldier conditional
-        if (this.player.faction != "Village") {
+        if (this.player.faction != "Village" && !ONE_NIGHT) {
           const soldiersInGame = this.game.players.filter(
             (p) => p.role.name == "Soldier" && p.faction == "Village" && p.alive
           );
@@ -214,7 +234,7 @@ module.exports = class WinWithFaction extends Card {
           }
         }
         //Shoggoth conditional
-        if (CULT_FACTIONS.includes(this.player.faction)) {
+        if (CULT_FACTIONS.includes(this.player.faction) && !ONE_NIGHT) {
           const ShoggothInGame = this.game
             .alivePlayers()
             .filter(
@@ -230,7 +250,7 @@ module.exports = class WinWithFaction extends Card {
           }
         }
         //Vampire conditional
-        if (EVIL_FACTIONS.includes(this.player.faction)) {
+        if (EVIL_FACTIONS.includes(this.player.faction) && !ONE_NIGHT) {
           let vampires = this.game.players.filter(
             (p) => p.role.name == "Vampire" && p.faction == this.player.faction
           );
@@ -240,8 +260,46 @@ module.exports = class WinWithFaction extends Card {
         }
         //Win Cons
 
+        //One Night Win-Cons
+        if(this.game.hasBeenDay == true){
+        //Cult
+        if (CULT_FACTIONS.includes(this.player.faction) && ONE_NIGHT) {
+          var deadCult = this.game.deadPlayers().filter((p) =>p.faction == this.player.faction);
+          var deadMafia = this.game.deadPlayers().filter((p) => MAFIA_FACTIONS.includes(p.faction));
+          if(MAFIA_IN_GAME && deadMafia.length > 0) return;
+          if (deadCult.length <= 0) {
+              factionWin(this);
+              return;
+          }
+        }
+
+        //Mafia
+        if (MAFIA_FACTIONS.includes(this.player.faction) && ONE_NIGHT) {
+          var deadMafia = this.game.deadPlayers().filter((p) => p.faction == this.player.faction);
+          var deadCult = this.game.deadPlayers().filter((p) => CULT_FACTIONS.includes(p.faction));
+          if(CULT_IN_GAME && deadCult.length > 0) return;
+          if (deadMafia.length <= 0) {
+              factionWin(this);
+              return;
+          }
+        }
+
+        //Village
+        if (this.player.faction == "Village" && ONE_NIGHT) {
+          var deadMafia = this.game.deadPlayers().filter((p) => MAFIA_FACTIONS.includes(p.faction));
+          var deadCult = this.game.deadPlayers().filter((p) => CULT_FACTIONS.includes(p.faction));
+          var deadVillage = this.game.deadPlayers().filter((p) => p.faction == "Village");
+          if(CULT_IN_GAME && deadCult.length > 0) return;
+          if(MAFIA_IN_GAME && deadMafia.length > 0) return;
+          if(!MAFIA_IN_GAME && !CULT_IN_GAME && deadVillage.length > 0) return;
+              factionWin(this);
+              return;
+          
+        }
+        }
+
         //Win with Dead Poltergeist
-        if (EVIL_FACTIONS.includes(this.player.faction)) {
+        if (EVIL_FACTIONS.includes(this.player.faction) && !ONE_NIGHT) {
           const deadPoltergeist = this.game
             .deadPlayers()
             .filter(
@@ -269,7 +327,7 @@ module.exports = class WinWithFaction extends Card {
           }
         }
         // win by majority
-        if (FACTION_WIN_WITH_MAJORITY.includes(this.player.faction)) {
+        if (FACTION_WIN_WITH_MAJORITY.includes(this.player.faction) && !ONE_NIGHT) {
           if (hasMajority) {
             factionWin(this);
             return;
@@ -292,7 +350,7 @@ module.exports = class WinWithFaction extends Card {
           }
         }
         //Village Normal Win
-        if (this.player.faction == "Village") {
+        if (this.player.faction == "Village" && !ONE_NIGHT) {
           if (
             counts.Village == aliveCount &&
             aliveCount > 0 &&
@@ -324,7 +382,7 @@ module.exports = class WinWithFaction extends Card {
           }
         }
         //Village Shoggoth Win
-        if (this.player.faction == "Village") {
+        if (this.player.faction == "Village" && !ONE_NIGHT) {
           if (
             this.game
               .alivePlayers()
@@ -447,7 +505,7 @@ module.exports = class WinWithFaction extends Card {
         if (
           this.game.getRoleAlignment(this.player.role.name) !=
             this.player.faction &&
-          !this.player.hasItem("IsTheTelevangelist")
+          (!this.player.hasItem("IsTheTelevangelist") || this.player.role.name == "Disguiser")
         ) {
           this.player.queueAlert(
             `You are ${this.player.faction} Aligned, You will win with ${this.player.faction}!`

--- a/data/roles.js
+++ b/data/roles.js
@@ -2283,7 +2283,7 @@ const roleData = {
     Enchantress: {
       alignment: "Cult",
       category: "Manipulative",
-      tags: ["Night-acting", "Conversion", "Random"],
+      tags: ["Night-acting", "Conversion", "Random","Exorcise Village Meeting"],
       recentlyUpdated: true,
       description: [
         "Each night, converts another Cult teammate into a random Cult-aligned role.",

--- a/data/roles.js
+++ b/data/roles.js
@@ -2283,7 +2283,12 @@ const roleData = {
     Enchantress: {
       alignment: "Cult",
       category: "Manipulative",
-      tags: ["Night-acting", "Conversion", "Random","Exorcise Village Meeting"],
+      tags: [
+        "Night-acting",
+        "Conversion",
+        "Random",
+        "Exorcise Village Meeting",
+      ],
       recentlyUpdated: true,
       description: [
         "Each night, converts another Cult teammate into a random Cult-aligned role.",

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -133,6 +133,7 @@ var schemas = {
     banished: Number,
     talkingDead: Boolean,
     votingDead: Boolean,
+    OneNightMode: Boolean,
     swapAmt: Number,
     roundAmt: Number,
     firstTeamSize: Number,

--- a/react_main/src/pages/Play/CreateSetup/CreateMafiaSetup.jsx
+++ b/react_main/src/pages/Play/CreateSetup/CreateMafiaSetup.jsx
@@ -166,7 +166,7 @@ export default function CreateMafiaSetup() {
       ref: "OneNightMode",
       value: false,
       type: "boolean",
-      showIf: ["!Day Start"],
+      showIf: ["!startState"],
     },
   ]);
 

--- a/react_main/src/pages/Play/CreateSetup/CreateMafiaSetup.jsx
+++ b/react_main/src/pages/Play/CreateSetup/CreateMafiaSetup.jsx
@@ -22,6 +22,7 @@ export default function CreateMafiaSetup() {
       label: "Day Start",
       ref: "startState",
       type: "boolean",
+      showIf: ["!OneNightMode"],
     },
     {
       label: "Dawn",
@@ -160,6 +161,13 @@ export default function CreateMafiaSetup() {
       value: false,
       type: "boolean",
     },
+    {
+      label: "One Night Mode",
+      ref: "OneNightMode",
+      value: false,
+      type: "boolean",
+      showIf: ["!Day Start"],
+    },
   ]);
 
   const formFieldValueMods = {
@@ -203,6 +211,7 @@ export default function CreateMafiaSetup() {
         banished: Number(formFields[20].value),
         talkingDead: formFields[21].value,
         votingDead: formFields[22].value,
+        OneNightMode: formFields[23].value,
         editing: editing,
         id: params.get("edit"),
       })

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -399,6 +399,7 @@ router.post("/create", async function (req, res) {
     setup.banished = Number(setup.banished);
     setup.talkingDead = Boolean(setup.talkingDead);
     setup.votingDead = Boolean(setup.votingDead);
+    setup.OneNightMode = Boolean(setup.OneNightMode);
 
     if (
       !routeUtils.validProp(setup.gameType) ||


### PR DESCRIPTION
Add One Night game option, Game ends after Day 1. Village wins if they kill One mafia/cult. Mafia/Cult wins if all Mafia/Cult are Alive.  If no Mafia/Cult Village wins if no Village died. If Mafia and Cult are present, Village must kill 1 of each. Mafia must kill 1 Cult. Cult must kill one 1 mafia. (Some Independents will need to be adjusted but that will done later)

Enchantress now activates Exorcise Village Meeting.