### PR TITLE
Role Sharing Roles and Bug Fixes

### DIFF
--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -531,36 +531,36 @@ module.exports = class Player {
     const modifiers = roleName.split(":")[1];
     roleName = roleName.split(":")[0];
 
-    for(let effect of this.effects){
-      if(effect.name == "Blind" && effect.lifespan == Infinity){
+    for (let effect of this.effects) {
+      if (effect.name == "Blind" && effect.lifespan == Infinity) {
         effect.remove();
-      }
-      else if(effect.name == "Condemn Immune" && effect.lifespan == Infinity){
+      } else if (
+        effect.name == "Condemn Immune" &&
+        effect.lifespan == Infinity
+      ) {
         effect.remove();
-      }
-      else if(effect.name == "Convert Immune" && effect.lifespan == Infinity){
+      } else if (
+        effect.name == "Convert Immune" &&
+        effect.lifespan == Infinity
+      ) {
         effect.remove();
-      }
-      else if(effect.name == "Immortal" && effect.lifespan == Infinity){
+      } else if (effect.name == "Immortal" && effect.lifespan == Infinity) {
         effect.remove();
-      }
-      else if(effect.name == "Kill Immune" && effect.lifespan == Infinity){
+      } else if (effect.name == "Kill Immune" && effect.lifespan == Infinity) {
         effect.remove();
-      }
-      else if(effect.name == "Leak Whispers" && effect.lifespan == Infinity){
+      } else if (
+        effect.name == "Leak Whispers" &&
+        effect.lifespan == Infinity
+      ) {
         effect.remove();
-      }
-      else if(effect.name == "Save Immune" && effect.lifespan == Infinity){
+      } else if (effect.name == "Save Immune" && effect.lifespan == Infinity) {
         effect.remove();
-      }
-      else if(effect.name == "Scrambled" && effect.lifespan == Infinity){
+      } else if (effect.name == "Scrambled" && effect.lifespan == Infinity) {
         effect.remove();
-      }
-      else if(effect.name == "Tree" && effect.lifespan == Infinity){
+      } else if (effect.name == "Tree" && effect.lifespan == Infinity) {
         effect.remove();
       }
     }
-
 
     if (!faction) {
       this.faction = this.game.getRoleAlignment(roleName);

--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -531,6 +531,37 @@ module.exports = class Player {
     const modifiers = roleName.split(":")[1];
     roleName = roleName.split(":")[0];
 
+    for(let effect of this.effects){
+      if(effect.name == "Blind" && effect.lifespan == Infinity){
+        effect.remove();
+      }
+      else if(effect.name == "Condemn Immune" && effect.lifespan == Infinity){
+        effect.remove();
+      }
+      else if(effect.name == "Convert Immune" && effect.lifespan == Infinity){
+        effect.remove();
+      }
+      else if(effect.name == "Immortal" && effect.lifespan == Infinity){
+        effect.remove();
+      }
+      else if(effect.name == "Kill Immune" && effect.lifespan == Infinity){
+        effect.remove();
+      }
+      else if(effect.name == "Leak Whispers" && effect.lifespan == Infinity){
+        effect.remove();
+      }
+      else if(effect.name == "Save Immune" && effect.lifespan == Infinity){
+        effect.remove();
+      }
+      else if(effect.name == "Scrambled" && effect.lifespan == Infinity){
+        effect.remove();
+      }
+      else if(effect.name == "Tree" && effect.lifespan == Infinity){
+        effect.remove();
+      }
+    }
+
+
     if (!faction) {
       this.faction = this.game.getRoleAlignment(roleName);
 

--- a/Games/types/Mafia/Action.js
+++ b/Games/types/Mafia/Action.js
@@ -33,6 +33,8 @@ module.exports = class MafiaAction extends Action {
     target.removeEffect("Gassed", true);
     target.removeEffect("Lovesick", true);
     target.removeEffect("Zombification", true);
+    target.removeEffect("CannotRoleShare", true);
+    target.removeEffect("MustRoleShare", true);
   }
 
   preventConvert(power, target) {

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -160,11 +160,24 @@ module.exports = class MafiaGame extends Game {
       this.alivePlayers()[0].holdItem("EventManager", 1);
       this.events.emit("ManageRandomEvents");
     }
-    if(this.getStateName() == "Day" && (this.setup.RoleShare || this.setup.AlignmentShare || this.setup.PrivateShare || this.setup.PublicShare)){
-      for(let player of this.alivePlayers()){
-        if(player.items.filter((i) => i.name == "RoleSharing").length <= 0){
-        player.holdItem("RoleSharing", 1, this.setup.RoleShare, this.setup.AlignmentShare, this.setup.PrivateShare,this.setup.PublicShare);
-      }
+    if (
+      this.getStateName() == "Day" &&
+      (this.setup.RoleShare ||
+        this.setup.AlignmentShare ||
+        this.setup.PrivateShare ||
+        this.setup.PublicShare)
+    ) {
+      for (let player of this.alivePlayers()) {
+        if (player.items.filter((i) => i.name == "RoleSharing").length <= 0) {
+          player.holdItem(
+            "RoleSharing",
+            1,
+            this.setup.RoleShare,
+            this.setup.AlignmentShare,
+            this.setup.PrivateShare,
+            this.setup.PublicShare
+          );
+        }
       }
     }
   }

--- a/Games/types/Mafia/effects/CannotRoleShare.js
+++ b/Games/types/Mafia/effects/CannotRoleShare.js
@@ -1,0 +1,8 @@
+const Effect = require("../Effect");
+
+module.exports = class CannotRoleShare extends Effect {
+  constructor(lifespan) {
+    super("CannotRoleShare");
+    this.lifespan = lifespan || Infinity;
+  }
+};

--- a/Games/types/Mafia/effects/FalseMode.js
+++ b/Games/types/Mafia/effects/FalseMode.js
@@ -1,6 +1,6 @@
 const Effect = require("../Effect");
 
-module.exports = class Probe extends Effect {
+module.exports = class FalseMode extends Effect {
   constructor(lifespan) {
     super("FalseMode");
     this.lifespan = lifespan || Infinity;

--- a/Games/types/Mafia/effects/MustRoleShare.js
+++ b/Games/types/Mafia/effects/MustRoleShare.js
@@ -1,0 +1,8 @@
+const Effect = require("../Effect");
+
+module.exports = class MustRoleShare extends Effect {
+  constructor(lifespan) {
+    super("MustRoleShare");
+    this.lifespan = lifespan || Infinity;
+  }
+};

--- a/Games/types/Mafia/events/CultureExchange.js
+++ b/Games/types/Mafia/events/CultureExchange.js
@@ -1,0 +1,41 @@
+const Event = require("../Event");
+const Action = require("../Action");
+const Random = require("../../../../lib/Random");
+const {
+  PRIORITY_ITEM_GIVER_DEFAULT,
+  PRIORITY_BECOME_DEAD_ROLE,
+} = require("../const/Priority");
+
+module.exports = class CultureExchange extends Event {
+  constructor(modifiers, game) {
+    super("Culture Exchange", modifiers, game);
+  }
+
+  getNormalRequirements() {
+    return true;
+  }
+
+  doEvent() {
+    super.doEvent();
+    let victim = Random.randArrayVal(this.game.alivePlayers());
+    let victim2 = Random.randArrayVal(this.game.alivePlayers().filter((p) => p != victim));
+    this.action = new Action({
+      actor: victim2,
+      target: victim,
+      game: this.game,
+      priority: PRIORITY_ITEM_GIVER_DEFAULT,
+      labels: ["hidden", "absolute"],
+      run: function () {
+        if (this.game.SilentEvents != false) {
+          this.game.queueAlert(
+            `Event: Culture Exchange! 2 players wil gain the ability to role share today!`
+          );
+        }
+        
+        this.target.holdItem("RoleSharing", 1, true, false, false,false);
+        this.actor.holdItem("RoleSharing", 1, true, false, false,false);
+      },
+    });
+    this.game.queueAction(this.action);
+  }
+};

--- a/Games/types/Mafia/events/CultureExchange.js
+++ b/Games/types/Mafia/events/CultureExchange.js
@@ -18,7 +18,9 @@ module.exports = class CultureExchange extends Event {
   doEvent() {
     super.doEvent();
     let victim = Random.randArrayVal(this.game.alivePlayers());
-    let victim2 = Random.randArrayVal(this.game.alivePlayers().filter((p) => p != victim));
+    let victim2 = Random.randArrayVal(
+      this.game.alivePlayers().filter((p) => p != victim)
+    );
     this.action = new Action({
       actor: victim2,
       target: victim,
@@ -31,9 +33,9 @@ module.exports = class CultureExchange extends Event {
             `Event: Culture Exchange! 2 players wil gain the ability to role share today!`
           );
         }
-        
-        this.target.holdItem("RoleSharing", 1, true, false, false,false);
-        this.actor.holdItem("RoleSharing", 1, true, false, false,false);
+
+        this.target.holdItem("RoleSharing", 1, true, false, false, false);
+        this.actor.holdItem("RoleSharing", 1, true, false, false, false);
       },
     });
     this.game.queueAction(this.action);

--- a/Games/types/Mafia/items/RoleShareAccept.js
+++ b/Games/types/Mafia/items/RoleShareAccept.js
@@ -20,10 +20,24 @@ module.exports = class RoleShareAccept extends Item {
         this.proposer.name;
     }
 
+    
+
+    this.shareTypes = [];
+    if(accepter.hasEffect("CannotRoleShare")){
+      this.shareTypes = ["No"];
+    }
+    else if(accepter.hasEffect("MustRoleShare")){
+      this.shareTypes = ["Yes"];
+    }
+    else{
+      this.shareTypes = ["Yes","No"];
+    }
+
     this.meetings[meetingName] = {
       states: ["Day"],
       flags: ["voting", "instant"],
-      inputType: "boolean",
+      inputType: "custom",
+      targets: this.shareTypes,
       action: {
         labels: ["marriage"],
         item: this,

--- a/Games/types/Mafia/items/RoleShareAccept.js
+++ b/Games/types/Mafia/items/RoleShareAccept.js
@@ -20,17 +20,13 @@ module.exports = class RoleShareAccept extends Item {
         this.proposer.name;
     }
 
-    
-
     this.shareTypes = [];
-    if(accepter.hasEffect("CannotRoleShare")){
+    if (accepter.hasEffect("CannotRoleShare")) {
       this.shareTypes = ["No"];
-    }
-    else if(accepter.hasEffect("MustRoleShare")){
+    } else if (accepter.hasEffect("MustRoleShare")) {
       this.shareTypes = ["Yes"];
-    }
-    else{
-      this.shareTypes = ["Yes","No"];
+    } else {
+      this.shareTypes = ["Yes", "No"];
     }
 
     this.meetings[meetingName] = {

--- a/Games/types/Mafia/items/RoleShareAccept.js
+++ b/Games/types/Mafia/items/RoleShareAccept.js
@@ -9,11 +9,15 @@ module.exports = class RoleShareAccept extends Item {
     this.cannotBeStolen = true;
     this.cannotBeSnooped = true;
     let meetingName;
-    if(this.type == "Role Share"){
-    meetingName = "Role Share between " + accepter.name + " and " + this.proposer.name;
-    }
-    else{
-    meetingName = "Alignment Share between " + accepter.name + " and " + this.proposer.name;
+    if (this.type == "Role Share") {
+      meetingName =
+        "Role Share between " + accepter.name + " and " + this.proposer.name;
+    } else {
+      meetingName =
+        "Alignment Share between " +
+        accepter.name +
+        " and " +
+        this.proposer.name;
     }
 
     this.meetings[meetingName] = {
@@ -25,33 +29,41 @@ module.exports = class RoleShareAccept extends Item {
         item: this,
         run: function () {
           if (this.target == "Yes") {
-            if(this.item.type == "Role Share"){
-            this.actor.role.revealToPlayer(this.item.proposer);
-            this.item.proposer.role.revealToPlayer(this.actor);
-              this.game.events.emit("ShareRole", this.actor, this.item.proposer, false);
-            }
-            else if(this.item.type == "Alignment Share"){
+            if (this.item.type == "Role Share") {
+              this.actor.role.revealToPlayer(this.item.proposer);
+              this.item.proposer.role.revealToPlayer(this.actor);
+              this.game.events.emit(
+                "ShareRole",
+                this.actor,
+                this.item.proposer,
+                false
+              );
+            } else if (this.item.type == "Alignment Share") {
+              var roleActor = this.actor.getAppearance("reveal", true);
+              var alignmentActor = this.game.getRoleAlignment(roleActor);
+              var roleProposer = this.item.proposer.getAppearance(
+                "reveal",
+                true
+              );
+              var alignmentProposer = this.game.getRoleAlignment(roleProposer);
 
-            var roleActor = this.actor.getAppearance("reveal", true);
-            var alignmentActor = this.game.getRoleAlignment(roleActor);
-            var roleProposer = this.item.proposer.getAppearance("reveal", true);
-            var alignmentProposer = this.game.getRoleAlignment(roleProposer);
-
-              
-            this.actor.queueAlert(
-            `${this.item.proposer.name}'s Alignment is ${alignmentProposer}.`
-          );
-          this.item.proposer.queueAlert(
-            `${this.actor.name}'s Alignment is ${alignmentActor}.`
-          );
-            this.game.events.emit("ShareRole", this.actor, this.item.proposer, true);
+              this.actor.queueAlert(
+                `${this.item.proposer.name}'s Alignment is ${alignmentProposer}.`
+              );
+              this.item.proposer.queueAlert(
+                `${this.actor.name}'s Alignment is ${alignmentActor}.`
+              );
+              this.game.events.emit(
+                "ShareRole",
+                this.actor,
+                this.item.proposer,
+                true
+              );
             }
-            
-          }
-          else{
+          } else {
             this.item.proposer.queueAlert(
-            `${this.actor.name} has declined to Share.`
-          );
+              `${this.actor.name} has declined to Share.`
+            );
           }
           this.item.drop();
         },

--- a/Games/types/Mafia/items/RoleSharing.js
+++ b/Games/types/Mafia/items/RoleSharing.js
@@ -17,22 +17,20 @@ module.exports = class RoleSharing extends Item {
     this.cannotBeSnooped = true;
     this.lifespan = lifespan || Infinity;
 
-    this.shareTypes = [
-      "None",
-    ];
+    this.shareTypes = ["None"];
 
-if(this.canRoleShare == true){
-  this.shareTypes.push("Role Share");
-}
-if( this.canAlignmentShare == true){
-  this.shareTypes.push("Alignment Share");
-}
-if(this.canPrivateReveal == true){
-  this.shareTypes.push("Private Reveal");
-}
-if(this.canPublicReveal == true){
-  this.shareTypes.push("Public Reveal");
-}
+    if (this.canRoleShare == true) {
+      this.shareTypes.push("Role Share");
+    }
+    if (this.canAlignmentShare == true) {
+      this.shareTypes.push("Alignment Share");
+    }
+    if (this.canPrivateReveal == true) {
+      this.shareTypes.push("Private Reveal");
+    }
+    if (this.canPublicReveal == true) {
+      this.shareTypes.push("Public Reveal");
+    }
 
     this.meetings = {
       "Choose Share Method": {
@@ -47,7 +45,6 @@ if(this.canPublicReveal == true){
       },
     };
 
-
     this.listeners = {
       state: function (stateInfo) {
         this.hasSharedWith = [];
@@ -57,29 +54,36 @@ if(this.canPublicReveal == true){
       },
       vote: function (vote) {
         if (
-          (vote.meeting.name === "Choose Share Method") &&
+          vote.meeting.name === "Choose Share Method" &&
           vote.voter === this.holder
         ) {
           this.currentShareMethod = vote.target;
-        }
-        else if((vote.meeting.name === "Share With Target") &&
-          vote.voter === this.holder && vote.target){
+        } else if (
+          vote.meeting.name === "Share With Target" &&
+          vote.voter === this.holder &&
+          vote.target
+        ) {
+          let targetPlayer = this.game
+            .alivePlayers()
+            .filter((p) => p.id == vote.target);
+          if (targetPlayer.length > 0) {
+            targetPlayer = targetPlayer[0];
+          } else {
+            return;
+          }
+          if (
+            this.currentShareMethod == null ||
+            this.currentShareMethod == "None"
+          )
+            return;
 
-
-            let targetPlayer = this.game.alivePlayers().filter((p) => p.id == vote.target);
-            if(targetPlayer.length > 0){
-              targetPlayer = targetPlayer[0];
-            }
-            else{
-              return;
-            }
-            if(this.currentShareMethod == null || this.currentShareMethod == "None") return;
-
-
-          if(this.hasSharedWith.includes(targetPlayer)) return;
+          if (this.hasSharedWith.includes(targetPlayer)) return;
           this.hasSharedWith.push(targetPlayer);
 
-          if(this.currentShareMethod == "Role Share" || this.currentShareMethod == "Alignment Share"){
+          if (
+            this.currentShareMethod == "Role Share" ||
+            this.currentShareMethod == "Alignment Share"
+          ) {
             var action = new Action({
               actor: this.holder,
               target: targetPlayer,
@@ -97,12 +101,16 @@ if(this.canPublicReveal == true){
             });
             this.game.instantAction(action);
 
-          let ShareWith = targetPlayer.holdItem("RoleShareAccept", this.holder,this.currentShareMethod,targetPlayer);
-          this.game.instantMeeting(ShareWith.meetings, [targetPlayer]);
-          }
-          else if(this.currentShareMethod == "Private Reveal"){
-             //this.holder.role.revealToPlayer(targetPlayer);
-             var action = new Action({
+            let ShareWith = targetPlayer.holdItem(
+              "RoleShareAccept",
+              this.holder,
+              this.currentShareMethod,
+              targetPlayer
+            );
+            this.game.instantMeeting(ShareWith.meetings, [targetPlayer]);
+          } else if (this.currentShareMethod == "Private Reveal") {
+            //this.holder.role.revealToPlayer(targetPlayer);
+            var action = new Action({
               actor: this.holder,
               target: targetPlayer,
               game: this.game,
@@ -119,10 +127,9 @@ if(this.canPublicReveal == true){
               },
             });
             this.game.instantAction(action);
-          }
-          else if(this.currentShareMethod == "Public Reveal"){
-             //this.holder.role.revealToAll();
-             var action = new Action({
+          } else if (this.currentShareMethod == "Public Reveal") {
+            //this.holder.role.revealToAll();
+            var action = new Action({
               actor: this.holder,
               target: targetPlayer,
               game: this.game,
@@ -137,18 +144,12 @@ if(this.canPublicReveal == true){
             });
             this.game.instantAction(action);
           }
-          
-          }
+        }
       },
     };
-
-
-    
   }
 
   hold(player) {
-    
-
     super.hold(player);
     //this.data.currentShareMethod = null;
   }

--- a/Games/types/Mafia/items/RoleSharing.js
+++ b/Games/types/Mafia/items/RoleSharing.js
@@ -78,7 +78,7 @@ module.exports = class RoleSharing extends Item {
             return;
 
           if (this.hasSharedWith.includes(targetPlayer)) return;
-          if (this.player.hasEffect("CannotRoleShare")) return;
+          if (this.holder.hasEffect("CannotRoleShare")) return;
           this.hasSharedWith.push(targetPlayer);
           if (
             this.currentShareMethod == "Role Share" ||

--- a/Games/types/Mafia/items/RoleSharing.js
+++ b/Games/types/Mafia/items/RoleSharing.js
@@ -78,8 +78,8 @@ module.exports = class RoleSharing extends Item {
             return;
 
           if (this.hasSharedWith.includes(targetPlayer)) return;
+          if(this.player.hasEffect("CannotRoleShare")) return;
           this.hasSharedWith.push(targetPlayer);
-
           if (
             this.currentShareMethod == "Role Share" ||
             this.currentShareMethod == "Alignment Share"

--- a/Games/types/Mafia/items/RoleSharing.js
+++ b/Games/types/Mafia/items/RoleSharing.js
@@ -78,7 +78,7 @@ module.exports = class RoleSharing extends Item {
             return;
 
           if (this.hasSharedWith.includes(targetPlayer)) return;
-          if(this.player.hasEffect("CannotRoleShare")) return;
+          if (this.player.hasEffect("CannotRoleShare")) return;
           this.hasSharedWith.push(targetPlayer);
           if (
             this.currentShareMethod == "Role Share" ||

--- a/Games/types/Mafia/roles/Cult/Cthulhu.js
+++ b/Games/types/Mafia/roles/Cult/Cthulhu.js
@@ -9,7 +9,7 @@ module.exports = class Cthulhu extends Role {
       "VillageCore",
       "WinWithFaction",
       "MeetingFaction",
-
+      "MakeInsaneOnRoleShare",
       "MakeVisitorsInsane",
     ];
   }

--- a/Games/types/Mafia/roles/Cult/Doomsayer.js
+++ b/Games/types/Mafia/roles/Cult/Doomsayer.js
@@ -9,7 +9,7 @@ module.exports = class Doomsayer extends Role {
       "VillageCore",
       "WinWithFaction",
       "MeetingFaction",
-
+      "ConvertOnRoleShare",
       "ConvertVisitors",
       "KillCultistsOnDeath",
     ];

--- a/Games/types/Mafia/roles/Mafia/Blackmailer.js
+++ b/Games/types/Mafia/roles/Mafia/Blackmailer.js
@@ -1,0 +1,15 @@
+const Role = require("../../Role");
+
+module.exports = class Blackmailer extends Role {
+  constructor(player, data) {
+    super("Blackmailer", player, data);
+
+    this.alignment = "Mafia";
+    this.cards = [
+      "VillageCore",
+      "WinWithFaction",
+      "MeetingFaction",
+      "MakeShyOnRoleShare",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/Mafia/Bully.js
+++ b/Games/types/Mafia/roles/Mafia/Bully.js
@@ -1,0 +1,15 @@
+const Role = require("../../Role");
+
+module.exports = class Bully extends Role {
+  constructor(player, data) {
+    super("Bully", player, data);
+
+    this.alignment = "Mafia";
+    this.cards = [
+      "VillageCore",
+      "WinWithFaction",
+      "MeetingFaction",
+      "MakeSkittishOnRoleShare",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/Mafia/Dealer.js
+++ b/Games/types/Mafia/roles/Mafia/Dealer.js
@@ -1,0 +1,17 @@
+const Role = require("../../Role");
+
+module.exports = class Dealer extends Role {
+  constructor(player, data) {
+    super("Dealer", player, data);
+
+    this.alignment = "Mafia";
+    this.cards = [
+      "VillageCore",
+      "WinWithFaction",
+      "MeetingFaction",
+      "CleanseVisitors",
+      "CleanseOnRoleShare",
+    ];
+    this.immunity.wolfBite = 1;
+  }
+};

--- a/Games/types/Mafia/roles/Village/Apothecary.js
+++ b/Games/types/Mafia/roles/Village/Apothecary.js
@@ -10,6 +10,7 @@ module.exports = class Apothecary extends Role {
       "WinWithFaction",
       "MeetingFaction",
       "CleanseVisitors",
+      "CleanseOnRoleShare",
     ];
     this.immunity.wolfBite = 1;
   }

--- a/Games/types/Mafia/roles/Village/Brute.js
+++ b/Games/types/Mafia/roles/Village/Brute.js
@@ -1,0 +1,15 @@
+const Role = require("../../Role");
+
+module.exports = class Brute extends Role {
+  constructor(player, data) {
+    super("Brute", player, data);
+
+    this.alignment = "Village";
+    this.cards = [
+      "VillageCore",
+      "WinWithFaction",
+      "MeetingFaction",
+      "MakeSkittishOnRoleShare",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/Village/Recluse.js
+++ b/Games/types/Mafia/roles/Village/Recluse.js
@@ -1,0 +1,16 @@
+const Role = require("../../Role");
+
+module.exports = class Recluse extends Role {
+  constructor(player, data) {
+    super("Recluse", player, data);
+
+    this.alignment = "Village";
+    this.cards = [
+      "VillageCore",
+      "WinWithFaction",
+      "MeetingFaction",
+      "MakeShyOnRoleShare",
+    ];
+    
+  }
+};

--- a/Games/types/Mafia/roles/Village/Recluse.js
+++ b/Games/types/Mafia/roles/Village/Recluse.js
@@ -11,6 +11,5 @@ module.exports = class Recluse extends Role {
       "MeetingFaction",
       "MakeShyOnRoleShare",
     ];
-    
   }
 };

--- a/Games/types/Mafia/roles/cards/CleanseOnRoleShare.js
+++ b/Games/types/Mafia/roles/cards/CleanseOnRoleShare.js
@@ -1,0 +1,41 @@
+const Card = require("../../Card");
+const Action = require("../../Action");
+const { PRIORITY_OVERTHROW_VOTE } = require("../../const/Priority");
+
+module.exports = class CleanseOnRoleShare extends Card {
+  constructor(role) {
+    super(role);
+
+    this.listeners = {
+      ShareRole: function (PlayerA, PlayerB, isAlignmentShare) {
+        if (
+          (PlayerA == this.player || PlayerB == this.player) &&
+          !isAlignmentShare
+        ) {
+          let thisPlayer;
+          let otherPlayer;
+          if (PlayerA == this.player) {
+            thisPlayer = PlayerA;
+            otherPlayer = PlayerB;
+          } else {
+            thisPlayer = PlayerB;
+            otherPlayer = PlayerA;
+          }
+          var action = new Action({
+            actor: this.player,
+            target: otherPlayer,
+            game: this.game,
+            item: this,
+            labels: ["hidden"],
+            run: function () {
+              if (this.dominates(this.target)) {
+                this.cleanse(1, this.target);
+              }
+            },
+          });
+          this.game.instantAction(action);
+        }
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/CleanseVisitors.js
+++ b/Games/types/Mafia/roles/cards/CleanseVisitors.js
@@ -24,13 +24,7 @@ module.exports = class CleanseVisitors extends Card {
 
           for (let action of this.game.actions[0]) {
             if (action.target == this.actor && !action.hasLabel("hidden")) {
-              action.actor.removeEffect("Poison", true);
-              action.actor.removeEffect("Bleeding", true);
-              action.actor.removeEffect("Insanity", true);
-              action.actor.removeEffect("Polarised", true);
-              action.actor.removeEffect("Gasoline", true);
-              action.actor.removeEffect("Gassed", true);
-              action.actor.removeEffect("Lovesick", true);
+              this.cleanse(1, action.actor);
             }
           }
         },

--- a/Games/types/Mafia/roles/cards/ConvertOnRoleShare.js
+++ b/Games/types/Mafia/roles/cards/ConvertOnRoleShare.js
@@ -29,7 +29,6 @@ module.exports = class ConvertOnRoleShare extends Card {
             labels: ["convert", "hidden"],
             run: function () {
                 if (this.dominates()) this.target.setRole("Cultist");
-              }
             },
           });
           this.game.instantAction(action);

--- a/Games/types/Mafia/roles/cards/ConvertOnRoleShare.js
+++ b/Games/types/Mafia/roles/cards/ConvertOnRoleShare.js
@@ -1,0 +1,40 @@
+const Card = require("../../Card");
+const Action = require("../../Action");
+const { PRIORITY_OVERTHROW_VOTE } = require("../../const/Priority");
+
+module.exports = class ConvertOnRoleShare extends Card {
+  constructor(role) {
+    super(role);
+
+    this.listeners = {
+      ShareRole: function (PlayerA, PlayerB, isAlignmentShare) {
+        if (
+          (PlayerA == this.player || PlayerB == this.player) &&
+          !isAlignmentShare
+        ) {
+          let thisPlayer;
+          let otherPlayer;
+          if (PlayerA == this.player) {
+            thisPlayer = PlayerA;
+            otherPlayer = PlayerB;
+          } else {
+            thisPlayer = PlayerB;
+            otherPlayer = PlayerA;
+          }
+          var action = new Action({
+            actor: this.player,
+            target: otherPlayer,
+            game: this.game,
+            item: this,
+            labels: ["convert", "hidden"],
+            run: function () {
+                if (this.dominates()) this.target.setRole("Cultist");
+              }
+            },
+          });
+          this.game.instantAction(action);
+        }
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/ConvertOnRoleShare.js
+++ b/Games/types/Mafia/roles/cards/ConvertOnRoleShare.js
@@ -28,7 +28,7 @@ module.exports = class ConvertOnRoleShare extends Card {
             item: this,
             labels: ["convert", "hidden"],
             run: function () {
-                if (this.dominates()) this.target.setRole("Cultist");
+              if (this.dominates()) this.target.setRole("Cultist");
             },
           });
           this.game.instantAction(action);

--- a/Games/types/Mafia/roles/cards/ForceSplitDecision.js
+++ b/Games/types/Mafia/roles/cards/ForceSplitDecision.js
@@ -100,12 +100,14 @@ module.exports = class ForceSplitDecision extends Card {
             p.alive && (p.role.name == "President" || p.role.name == "Senator")
         );
         if (Presidents <= 0) {
-          let players = this.game.alivePlayers().filter(
-            (p) =>
-              (p.role.alignment == "Village" ||
-                p.role.alignment == "Independent") &&
-              p.role.data.UnReplaceable != true
-          );
+          let players = this.game
+            .alivePlayers()
+            .filter(
+              (p) =>
+                (p.role.alignment == "Village" ||
+                  p.role.alignment == "Independent") &&
+                p.role.data.UnReplaceable != true
+            );
           let shuffledPlayers = Random.randomizeArray(players);
           shuffledPlayers[0].setRole("President");
         }

--- a/Games/types/Mafia/roles/cards/ForceSplitDecision.js
+++ b/Games/types/Mafia/roles/cards/ForceSplitDecision.js
@@ -100,7 +100,7 @@ module.exports = class ForceSplitDecision extends Card {
             p.alive && (p.role.name == "President" || p.role.name == "Senator")
         );
         if (Presidents <= 0) {
-          let players = this.game.players.filter(
+          let players = this.game.alivePlayers().filter(
             (p) =>
               (p.role.alignment == "Village" ||
                 p.role.alignment == "Independent") &&

--- a/Games/types/Mafia/roles/cards/MakeInsaneOnRoleShare.js
+++ b/Games/types/Mafia/roles/cards/MakeInsaneOnRoleShare.js
@@ -1,0 +1,46 @@
+const Card = require("../../Card");
+const Action = require("../../Action");
+const { PRIORITY_OVERTHROW_VOTE } = require("../../const/Priority");
+
+module.exports = class MakeInsaneOnRoleShare extends Card {
+  constructor(role) {
+    super(role);
+
+    this.listeners = {
+      ShareRole: function (PlayerA, PlayerB, isAlignmentShare) {
+        if (
+          (PlayerA == this.player || PlayerB == this.player) &&
+          !isAlignmentShare
+        ) {
+          let thisPlayer;
+          let otherPlayer;
+          if (PlayerA == this.player) {
+            thisPlayer = PlayerA;
+            otherPlayer = PlayerB;
+          } else {
+            thisPlayer = PlayerB;
+            otherPlayer = PlayerA;
+          }
+          var action = new Action({
+            actor: this.player,
+            target: otherPlayer,
+            game: this.game,
+            item: this,
+            labels: ["hidden"],
+            run: function () {
+              if (this.dominates(this.target)) {
+                /*
+                this.target.queueAlert(
+                  `Your feeling S after Role Sharing with ${this.actor.name}`
+                );
+                */
+                this.target.giveEffect("Insanity");
+              }
+            },
+          });
+          this.game.instantAction(action);
+        }
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/MakeShyOnRoleShare.js
+++ b/Games/types/Mafia/roles/cards/MakeShyOnRoleShare.js
@@ -1,0 +1,44 @@
+const Card = require("../../Card");
+const Action = require("../../Action");
+const { PRIORITY_OVERTHROW_VOTE } = require("../../const/Priority");
+
+module.exports = class MakeShyOnRoleShare extends Card {
+  constructor(role) {
+    super(role);
+
+    this.listeners = {
+      ShareRole: function (PlayerA, PlayerB, isAlignmentShare) {
+        if (
+          (PlayerA == this.player || PlayerB == this.player) &&
+          !isAlignmentShare
+        ) {
+          let thisPlayer;
+          let otherPlayer;
+          if (PlayerA == this.player) {
+            thisPlayer = PlayerA;
+            otherPlayer = PlayerB;
+          } else {
+            thisPlayer = PlayerB;
+            otherPlayer = PlayerA;
+          }
+          var action = new Action({
+            actor: this.player,
+            target: otherPlayer,
+            game: this.game,
+            item: this,
+            labels: ["hidden"],
+            run: function () {
+              if (this.dominates(this.target)) {
+                this.target.queueAlert(
+                  `Your feeling Shy after Role Sharing with ${this.actor.name}`
+                );
+                this.target.giveEffect("CannotRoleShare");
+              }
+            },
+          });
+          this.game.instantAction(action);
+        }
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/MakeSkittishOnRoleShare.js
+++ b/Games/types/Mafia/roles/cards/MakeSkittishOnRoleShare.js
@@ -7,35 +7,38 @@ module.exports = class MakeSkittishOnRoleShare extends Card {
     super(role);
 
     this.listeners = {
-      ShareRole: function (PlayerA, PlayerB, isAlignmentShare){
-        if((PlayerA == this.player || PlayerB == this.player) && !isAlignmentShare){
+      ShareRole: function (PlayerA, PlayerB, isAlignmentShare) {
+        if (
+          (PlayerA == this.player || PlayerB == this.player) &&
+          !isAlignmentShare
+        ) {
           let thisPlayer;
           let otherPlayer;
-          if(PlayerA == this.player){
+          if (PlayerA == this.player) {
             thisPlayer = PlayerA;
             otherPlayer = PlayerB;
-          }
-          else{
+          } else {
             thisPlayer = PlayerB;
             otherPlayer = PlayerA;
           }
-              var action = new Action({
-              actor: this.player,
-              target: otherPlayer,
-              game: this.game,
-              item: this,
-              labels: ["hidden"],
-              run: function () {
-                if (this.dominates(this.target)) {
-                  this.target.queueAlert(`Your feeling Skittish after Role Sharing with ${this.actor.name}`);
-                    this.target.giveEffect("MustRoleShare");
-                  }
-              },
-            });
-            this.game.instantAction(action);
+          var action = new Action({
+            actor: this.player,
+            target: otherPlayer,
+            game: this.game,
+            item: this,
+            labels: ["hidden"],
+            run: function () {
+              if (this.dominates(this.target)) {
+                this.target.queueAlert(
+                  `Your feeling Skittish after Role Sharing with ${this.actor.name}`
+                );
+                this.target.giveEffect("MustRoleShare");
+              }
+            },
+          });
+          this.game.instantAction(action);
         }
       },
-      
     };
   }
 };

--- a/Games/types/Mafia/roles/cards/MakeSkittishOnRoleShare.js
+++ b/Games/types/Mafia/roles/cards/MakeSkittishOnRoleShare.js
@@ -1,0 +1,41 @@
+const Card = require("../../Card");
+const Action = require("../../Action");
+const { PRIORITY_OVERTHROW_VOTE } = require("../../const/Priority");
+
+module.exports = class MakeSkittishOnRoleShare extends Card {
+  constructor(role) {
+    super(role);
+
+    this.listeners = {
+      ShareRole: function (PlayerA, PlayerB, isAlignmentShare){
+        if((PlayerA == this.player || PlayerB == this.player) && !isAlignmentShare){
+          let thisPlayer;
+          let otherPlayer;
+          if(PlayerA == this.player){
+            thisPlayer = PlayerA;
+            otherPlayer = PlayerB;
+          }
+          else{
+            thisPlayer = PlayerB;
+            otherPlayer = PlayerA;
+          }
+              var action = new Action({
+              actor: this.player,
+              target: otherPlayer,
+              game: this.game,
+              item: this,
+              labels: ["hidden"],
+              run: function () {
+                if (this.dominates(this.target)) {
+                  this.target.queueAlert(`Your feeling Skittish after Role Sharing with ${this.actor.name}`);
+                    this.target.giveEffect("MustRoleShare");
+                  }
+              },
+            });
+            this.game.instantAction(action);
+        }
+      },
+      
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/ModifierLoud.js
+++ b/Games/types/Mafia/roles/cards/ModifierLoud.js
@@ -21,7 +21,7 @@ module.exports = class ModifierLoud extends Card {
           "uncontrollable",
         ],
         run: function () {
-          if (this.game.getStateName() != "Night") return;
+          if (this.game.getStateName() != "Night" && this.game.getStateName() != "Dawn") return;
 
           let visitors = this.getVisitors();
           let MafiaKill = this.getVisitors(this.actor, "mafia");

--- a/Games/types/Mafia/roles/cards/ModifierLoud.js
+++ b/Games/types/Mafia/roles/cards/ModifierLoud.js
@@ -21,7 +21,11 @@ module.exports = class ModifierLoud extends Card {
           "uncontrollable",
         ],
         run: function () {
-          if (this.game.getStateName() != "Night" && this.game.getStateName() != "Dawn") return;
+          if (
+            this.game.getStateName() != "Night" &&
+            this.game.getStateName() != "Dawn"
+          )
+            return;
 
           let visitors = this.getVisitors();
           let MafiaKill = this.getVisitors(this.actor, "mafia");

--- a/Games/types/Mafia/roles/cards/Vain.js
+++ b/Games/types/Mafia/roles/cards/Vain.js
@@ -12,7 +12,6 @@ module.exports = class Vain extends Card {
         priority: PRIORITY_KILL_DEFAULT,
         labels: ["kill", "hidden"],
         run: function () {
-        
           if (
             this.game.getStateName() != "Night" &&
             this.game.getStateName() != "Dawn"
@@ -44,10 +43,10 @@ module.exports = class Vain extends Card {
               toCheck[0] instanceof Player
             ) {
               for (let y = 0; y < toCheck.length; y++) {
-              if (toCheck[y].role.alignment == this.actor.role.alignment) {
-            if(this.dominates(this.actor)){
-            this.actor.kill("basic", this.actor);
-            }
+                if (toCheck[y].role.alignment == this.actor.role.alignment) {
+                  if (this.dominates(this.actor)) {
+                    this.actor.kill("basic", this.actor);
+                  }
                 }
               }
             }
@@ -55,6 +54,5 @@ module.exports = class Vain extends Card {
         },
       },
     ];
-
   }
 };

--- a/Games/types/Mafia/roles/cards/Weak.js
+++ b/Games/types/Mafia/roles/cards/Weak.js
@@ -12,8 +12,7 @@ module.exports = class Weak extends Card {
         priority: PRIORITY_KILL_DEFAULT,
         labels: ["kill", "hidden"],
         run: function () {
-
-                   if (
+          if (
             this.game.getStateName() != "Night" &&
             this.game.getStateName() != "Dawn"
           )
@@ -44,15 +43,14 @@ module.exports = class Weak extends Card {
               toCheck[0] instanceof Player
             ) {
               for (let y = 0; y < toCheck.length; y++) {
-              if (toCheck[y].role.alignment != this.actor.role.alignment) {
-                if(this.dominates(this.actor)){
-                  this.actor.kill("basic", this.actor);
-                }
+                if (toCheck[y].role.alignment != this.actor.role.alignment) {
+                  if (this.dominates(this.actor)) {
+                    this.actor.kill("basic", this.actor);
+                  }
                 }
               }
             }
           }
-          
         },
       },
     ];

--- a/data/roles.js
+++ b/data/roles.js
@@ -1159,7 +1159,7 @@ const roleData = {
     Apothecary: {
       alignment: "Village",
       category: "Reflexive",
-      tags: ["Reflexive", "Protective", "Malicious Effects","Role Share"],
+      tags: ["Reflexive", "Protective", "Malicious Effects", "Role Share"],
       description: [
         "When visited, heals and cleanses all effects currently possessed by the visiting player.",
         "Players who Role Share with an Apothecary are Cleansed.",
@@ -2010,7 +2010,7 @@ const roleData = {
     Dealer: {
       alignment: "Mafia",
       category: "Reflexive",
-      tags: ["Reflexive", "Protective", "Malicious Effects","Role Share"],
+      tags: ["Reflexive", "Protective", "Malicious Effects", "Role Share"],
       description: [
         "When visited, heals and cleanses all effects currently possessed by the visiting player.",
         "Players who Role Share with a Dealer are Cleansed.",

--- a/data/roles.js
+++ b/data/roles.js
@@ -1159,9 +1159,10 @@ const roleData = {
     Apothecary: {
       alignment: "Village",
       category: "Reflexive",
-      tags: ["Reflexive", "Protective", "Malicious Effects"],
+      tags: ["Reflexive", "Protective", "Malicious Effects","Role Share"],
       description: [
         "When visited, heals and cleanses all effects currently possessed by the visiting player.",
+        "Players who Role Share with you are Cleansed.",
       ],
     },
     Dreamer: {
@@ -1422,6 +1423,24 @@ const roleData = {
         "During the day, can make an anonymous proposal to another player.",
         "The player has to publicly accept or deny the proposal.",
         "Once a proposal is accepted, the Suitress cannot make another proposal.",
+      ],
+    },
+    Brute: {
+      alignment: "Village",
+      category: "Role Sharing",
+      tags: ["Role Share"],
+      description: [
+        "Player who Role Share with a Brute become skittish.",
+        "Skittish players must accept all Role/Alignment Shares",
+      ],
+    },
+    Recluse: {
+      alignment: "Village",
+      category: "Role Sharing",
+      tags: ["Role Share"],
+      description: [
+        "Player who Role Share with a Recluse become shy.",
+        "Shy players cannot accept Role/Alignment Shares and cannot Private/Public Reveal.",
       ],
     },
     //Mafia
@@ -1988,6 +2007,15 @@ const roleData = {
         "Malicious effects include poison, bleeding, insanity, and polarization.",
       ],
     },
+    Dealer: {
+      alignment: "Village",
+      category: "Reflexive",
+      tags: ["Reflexive", "Protective", "Malicious Effects","Role Share"],
+      description: [
+        "When visited, heals and cleanses all effects currently possessed by the visiting player.",
+        "Players who Role Share with you are Cleansed.",
+      ],
+    },
     Diplomat: {
       alignment: "Mafia",
       tags: ["Condemn", "Protective", "Condemn Immune"],
@@ -2132,6 +2160,24 @@ const roleData = {
         "Mafia will not win by majority if an Assassin is present.",
       ],
     },
+    Bully: {
+      alignment: "Mafia",
+      category: "Role Sharing",
+      tags: ["Role Share"],
+      description: [
+        "Player who Role Share with a Bully become skittish.",
+        "Skittish players must accept all Role/Alignment Shares",
+      ],
+    },
+    Blackmailer: {
+      alignment: "Mafia",
+      category: "Role Sharing",
+      tags: ["Role Share"],
+      description: [
+        "Player who Role Share with a Blackmailer become shy.",
+        "Shy players cannot accept Role/Alignment Shares and cannot Private/Public Reveal.",
+      ],
+    },
 
     //Cult
     //Basic
@@ -2157,9 +2203,10 @@ const roleData = {
     Doomsayer: {
       alignment: "Cult",
       category: "Conversion",
-      tags: ["Conversion", "Kills Cultist", "Reflexive"],
+      tags: ["Conversion", "Kills Cultist", "Reflexive", "Role Share"],
       description: [
         "Converts all players who visit during the night.",
+        "Converts all players who Role Share with the Doomsayer.",
         "All Cultists die if the Doomsayer dies.",
       ],
     },
@@ -2316,6 +2363,7 @@ const roleData = {
       tags: ["Speaking", "Insanity", "Reflexive"],
       description: [
         "All players who visit Cthulhu go insane.",
+        "All players who Role Share with Cthulhu go insane.",
         "Insane players speak gibberish for the rest of the game.",
       ],
     },
@@ -3461,6 +3509,13 @@ const roleData = {
       tags: ["Event"],
       description: [
         "If this Event occurs, 1-3 Players learn if their role changed.",
+      ],
+    },
+    "Culture Exchange": {
+      alignment: "Event",
+      tags: ["Event"],
+      description: [
+        "If this Event occurs, 2 Players gain the ability to role share today.",
       ],
     },
   },

--- a/data/roles.js
+++ b/data/roles.js
@@ -1162,7 +1162,7 @@ const roleData = {
       tags: ["Reflexive", "Protective", "Malicious Effects","Role Share"],
       description: [
         "When visited, heals and cleanses all effects currently possessed by the visiting player.",
-        "Players who Role Share with you are Cleansed.",
+        "Players who Role Share with an Apothecary are Cleansed.",
       ],
     },
     Dreamer: {
@@ -2008,12 +2008,12 @@ const roleData = {
       ],
     },
     Dealer: {
-      alignment: "Village",
+      alignment: "Mafia",
       category: "Reflexive",
       tags: ["Reflexive", "Protective", "Malicious Effects","Role Share"],
       description: [
         "When visited, heals and cleanses all effects currently possessed by the visiting player.",
-        "Players who Role Share with you are Cleansed.",
+        "Players who Role Share with a Dealer are Cleansed.",
       ],
     },
     Diplomat: {


### PR DESCRIPTION
Assassin nerf- If an Assassin is created mid game they can no Longer spawn President as a Dead Player.

Filibuster and other roles lose their condemn/Kill immunities when changing roles.

New Role Brute (Town)/Bully (Mafia), Players who Role Share with you must accept all future role/alignment shares.
New Role Recluse (Town)/Blackmailer (Mafia), Players who Role Share with you cannot accept all future role/alignment shares. (They also can't send role/alignment shares.)

New* Role Dealer- Mafia version of Apothecary.

Apothecary Buff- Players who role share with an Apothecary are cleansed. (Also applies to Dealer).
Cthulhu Buff- applies Insanity to players who Role Share with them.
Doomsayer Buff- Converts players who Role Share

New Event- Culture Exchange, Enables Role Sharing for 2 players for 1 day. 
