### PR TITLE
Fixed turncoat guiser kill interaction

### DIFF
--- a/Games/types/Mafia/roles/cards/TurnIntoTraitorOnMafiaKill.js
+++ b/Games/types/Mafia/roles/cards/TurnIntoTraitorOnMafiaKill.js
@@ -16,6 +16,8 @@ module.exports = class TurnIntoTraitorOnMafiaKill extends Card {
           return;
         }
 
+        this.player.tempImmunity["mafia"] = Infinity;
+
         let convertAction = new Action({
           labels: ["convert"],
           actor: this.player,


### PR DESCRIPTION
As is, guiser voting yes to steal identity while targeting a turncoat with mafia meeting will convert them into a traitor then kill them.

Turncoat would listen to the emitted immune event when guiser steal identity action checks for immunity, causing the conversion to happen sooner in priority than maf kill. Adding temp immunity allows turncoat to keep its mafia immunity for the entire night that it gets converted.