### PR TITLE
Fixes for guiser interaction with armor, alerts

### DIFF
--- a/Games/core/Action.js
+++ b/Games/core/Action.js
@@ -25,7 +25,14 @@ module.exports = class Action {
     this.run();
   }
 
-  dominates(player) {
+  /**
+   * Checks if this action's target is immune to it or not
+   * @param {Player} player the target. If undefined, defaults to this action's target
+   * @param {boolean} emitEvent whether an immune event should occur or not. Set to false
+   *  if the caller would not actually subsequently result in the action being checked for
+   * @returns {boolean} true if the target lacks immunity to this action
+   */
+  dominates(player, emitEvent = true) {
     player = player || this.target;
     // will be true if immune to any label
     let immune = false;
@@ -51,7 +58,7 @@ module.exports = class Action {
       }
     }
 
-    if (immune) this.game.events.emit("immune", this, player);
+    if (emitEvent && immune) this.game.events.emit("immune", this, player);
 
     return !immune;
   }

--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -1362,6 +1362,20 @@ module.exports = class Player {
 
     for (let effect of player.effects) effect.player = player;
 
+    for (let alert of player.game.alertQueue.items) {
+      if(!alert.recipients) {
+        continue;
+      }
+      for (let i = 0; i < alert.recipients.length; i++) {
+        let recipient = alert.recipients[i];
+        if (recipient.id === player.id) {
+          alert.recipients[i] = this;
+        } else if (recipient.id === this.id) {
+          alert.recipients[i] = player;
+        }
+      }
+    }
+
     // Reveal disguiser to disguised player
     player.role.revealToPlayer(this, true);
   }

--- a/Games/types/Mafia/roles/cards/IdentityStealer.js
+++ b/Games/types/Mafia/roles/cards/IdentityStealer.js
@@ -24,7 +24,7 @@ module.exports = class IdentityStealer extends Card {
             var originalActor = this.actor;
 
             for (let action of this.game.actions[0]) {
-              if (action.hasLabels(["kill", "mafia"]) && action.dominates()) {
+              if (action.hasLabels(["kill", "mafia"]) && action.dominates(action.target, false)) {
                 stealIdentity.bind(originalActor.role)(action.target);
                 action.target = originalActor;
                 break;
@@ -110,7 +110,7 @@ function stealIdentity(target) {
   if (!this.data.originalUser) this.data.originalUser = this.player.user;
   if (!this.data.originalPlayer) this.data.originalPlayer = this.player;
   let temp = this.player.faction;
-  this.player.queueAlert(":anon: Someone has stolen your identity!");
+  target.queueAlert(":anon: Someone has stolen your identity!");
   this.player.faction = target.faction;
   target.faction = temp;
   this.data.swaps.unshift([this.player, target]);

--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -254,6 +254,10 @@ class TestSocket {
     for (let action of actions) action(data);
   }
 
+  clearListeners() {
+    this.listeners = {};
+  }
+
   terminate() {
     this.listeners = {};
     this.clientMessages.push({ eventName: "terminate" });


### PR DESCRIPTION
For: https://github.com/UltiMafia/Ultimafia/issues/22

- Fixed guiser going thru armor immunity. It was the same bug in nature as the turncoat bug from https://github.com/UltiMafia/Ultimafia/pull/1782 so I tried a different approach to fixing it this time. The dominates check for identity stealer should no longer cause immune events.
- Fixed alerts being given to the wrong player when guising occurred; swapIdentity now additionally swaps the recipients of alerts that are presently queued.
- Added some guiser tests. The sockets.js change supports this because it's a necessary function for swapIdentity.

Tested the alerts issue locally by having the gunsmith give a gun to a cop then verifying that when they were guised, the dead player received the alert for the gun and not the guiser.