### PR TITLE
Fixed bug where guiser vegged if target kill vegged

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -563,7 +563,7 @@ module.exports = class Game {
       new Action({
         actor: player,
         target: player,
-        priority: 0,
+        priority: -999,
         game: this,
         labels: ["hidden", "absolute", "uncontrollable"],
         run: function () {

--- a/Games/types/Mafia/roles/cards/IdentityStealer.js
+++ b/Games/types/Mafia/roles/cards/IdentityStealer.js
@@ -24,7 +24,7 @@ module.exports = class IdentityStealer extends Card {
             var originalActor = this.actor;
 
             for (let action of this.game.actions[0]) {
-              if (action.hasLabels(["kill", "mafia"]) && action.dominates(action.target, false)) {
+              if (action.hasLabels(["kill", "mafia"]) && action.dominates(action.target, false) && action.target.alive) {
                 stealIdentity.bind(originalActor.role)(action.target);
                 action.target = originalActor;
                 break;


### PR DESCRIPTION
This picture shows the bug where the cop got kicked for not voting but the guiser got vegged instead because they stole the identity of the cop:
![firefox_96IGw036Y9](https://github.com/user-attachments/assets/94a7f770-130f-4f24-94d1-16d1f302423c)

The cop is dead even though the veg didn't target them because they got killed normally by mafia.

This happens because identity steal occurs before the queued veg action. When I tried to reproduce the bug after I made my changes, the expected behavior of only the cop vegging occurred.

I don't know if this is the best possible fix for this bug but it feels like a safe resolution to me.