### PR TITLE
Added user miniprofile and pronouns

### DIFF
--- a/data/constants.js
+++ b/data/constants.js
@@ -295,6 +295,7 @@ module.exports = {
     "publicChat",
     "privateChat",
     "editBio",
+    "editPronouns",
     "changeName",
     "changeBday",
     "viewVotes",
@@ -326,6 +327,7 @@ module.exports = {
     publicChat: true,
     privateChat: true,
     editBio: true,
+    editPronouns: true,
     changeName: true,
     changeBday: true,
 

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -13,7 +13,7 @@ var schemas = {
     pronouns: {
       type: String,
       default:
-        "Click to edit your pronouns",
+        "",
     },
     fbUid: String,
     discordId: String,

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -10,6 +10,11 @@ var schemas = {
     ip: [{ type: String, index: true }],
     email: [{ type: String, index: true }],
     birthday: Date,
+    pronouns: {
+      type: String,
+      default:
+        "Click to edit your pronouns",
+    },
     fbUid: String,
     discordId: String,
     discordName: String,

--- a/react_main/src/components/Popover.jsx
+++ b/react_main/src/components/Popover.jsx
@@ -4,7 +4,7 @@ import axios from "axios";
 import { PopoverContext } from "../Contexts";
 import { Time } from "./Basic";
 import { SmallRoleList, GameStateIcon } from "./Setup";
-import { NameWithAvatar } from "../pages/User/User";
+import { Miniprofile, NameWithAvatar } from "../pages/User/User";
 import { useErrorAlert } from "./Alerts";
 import { GameStates } from "../Constants";
 import { useOnOutsideClick } from "./Basic";
@@ -174,6 +174,9 @@ export function usePopover(siteInfo) {
         break;
       case "game":
         content = parseGamePopover(content);
+        break;
+      case "miniprofile":
+        content = parseMiniprofile(content);
         break;
     }
 
@@ -968,4 +971,14 @@ export function parseRolePopover(role, modifiers) {
   }
 
   return result;
+}
+
+// props are inherited from the NameWithAvatar that spawned the popover and attached to the user object
+export function parseMiniprofile(user) {
+  return (
+    <Miniprofile
+      user={user}
+      key={user.id}
+    />
+  );
 }

--- a/react_main/src/components/Popover.jsx
+++ b/react_main/src/components/Popover.jsx
@@ -175,9 +175,6 @@ export function usePopover(siteInfo) {
       case "game":
         content = parseGamePopover(content);
         break;
-      case "miniprofile":
-        content = parseMiniprofile(content);
-        break;
     }
 
     if (sideload) {
@@ -971,14 +968,4 @@ export function parseRolePopover(role, modifiers) {
   }
 
   return result;
-}
-
-// props are inherited from the NameWithAvatar that spawned the popover and attached to the user object
-export function parseMiniprofile(user) {
-  return (
-    <Miniprofile
-      user={user}
-      key={user.id}
-    />
-  );
 }

--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -607,6 +607,20 @@
   padding: 7px 7px;
 }
 
+.game .player-list .player:hover {
+  box-shadow: 0px 0px 5px #62a0db;
+}
+
+.game .player-list .player .name-with-avatar {
+  width: 100%;
+}
+
+.game .player-list .player .name-with-avatar-clicked {
+  width: 100%;
+  background-color: var(--scheme-color-sec);
+  box-shadow: 0px 0px 5px #62a0db;
+}
+
 .game .player-list .player {
   display: flex;
   flex-flow: row nowrap;

--- a/react_main/src/css/user.css
+++ b/react_main/src/css/user.css
@@ -105,7 +105,7 @@ iframe {
 .love {
   display: flex;
   align-items: center;
-  padding-bottom: 5px;
+  margin-bottom: 8px;
 }
 
 .in-love {
@@ -433,6 +433,44 @@ iframe {
   align-self: flex-start;
 
   margin-right: 10px;
+}
+
+.profile .pronouns {
+  display: inline-block;
+  flex-flow: column;
+
+  box-sizing: border-box;
+  padding: 15px;
+  margin-bottom: 8px;
+
+  background-color: var(--scheme-color);
+  color: var(--scheme-color-text);
+}
+
+.profile .pronouns.edit {
+  cursor: text;
+}
+
+.profile .pronouns.edit:hover {
+  box-shadow: 0px 0px 5px #62a0db;
+}
+
+.profile .pronouns .buttons {
+  display: flex;
+  flex-flow: row nowrap;
+
+  margin-top: 10px;
+}
+
+.profile .btn {
+  align-self: flex-start;
+
+  margin-right: 10px;
+}
+
+.miniprofile .pronouns {
+  color: #777777;
+  padding-bottom: 12px;
 }
 
 .profile .react-mde .grip {

--- a/react_main/src/css/user.css
+++ b/react_main/src/css/user.css
@@ -468,9 +468,24 @@ iframe {
   margin-right: 10px;
 }
 
+.MuiPopover-root .miniprofile {
+  margin-left: 0px;
+  background-color: var(--scheme-color-sec);
+  border: 1px solid var(--scheme-color-border);
+}
+
+.miniprofile .popover-title {
+  background-color: var(--scheme-color);
+}
+
 .miniprofile .pronouns {
   color: #777777;
   padding-bottom: 12px;
+  padding: 8px;
+}
+
+.miniprofile .pie-chart {
+  padding: 8px;
 }
 
 .profile .react-mde .grip {

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -1969,6 +1969,7 @@ export function PlayerRows(props) {
           color={player.nameColor}
           active={activity.speaking[player.id]}
           noLink={props.stateViewing >= 0 && game.options.anonymousGame}
+          includeMiniprofile
           newTab
         />
         {selTab && showBubbles && activity.typing[player.id] === selTab && (

--- a/react_main/src/pages/User/PieChart.jsx
+++ b/react_main/src/pages/User/PieChart.jsx
@@ -82,11 +82,11 @@ export const PieChart = ({ wins, losses, abandons }) => {
   }, [wins, losses, abandons]);
 
   return (
-    <>
+    <div className="pie-chart">
       <div style={{ display: displayPieChart ? "block" : "none" }}>
         <svg ref={svgRef} />
       </div>
       {noPieChartMsg}
-    </>
+    </div>
   );
 };

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -90,7 +90,15 @@ export default function Profile() {
           setAvatar(res.data.avatar);
           setBanner(res.data.banner);
           setBio(filterProfanity(res.data.bio, user.settings, "\\*") || "");
-          setPronouns(filterProfanity(res.data.pronouns, user.settings, "\\*") || "");
+
+          var pronouns;
+          if(res.data.pronouns !== "") {
+            pronouns = res.data.pronouns;
+          }
+          else {
+            pronouns = "Click to edit your pronouns"
+          }
+          setPronouns(filterProfanity(pronouns, user.settings, "\\*") || "");
           setIsFriend(res.data.isFriend);
           setIsLove(res.data.isLove);
           setIsMarried(res.data.isMarried);

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -37,6 +37,9 @@ export default function Profile() {
   const [bio, setBio] = useState("");
   const [oldBio, setOldBio] = useState();
   const [editingBio, setEditingBio] = useState(false);
+  const [pronouns, setPronouns] = useState("");
+  const [oldPronouns, setOldPronouns] = useState();
+  const [editingPronouns, setEditingPronouns] = useState(false);
   const [isFriend, setIsFriend] = useState(false);
   const [isLove, setIsLove] = useState(false);
   const [isMarried, setIsMarried] = useState(false);
@@ -74,6 +77,7 @@ export default function Profile() {
 
   useEffect(() => {
     setEditingBio(false);
+    setEditingPronouns(false);
 
     if (userId) {
       setProfileLoaded(false);
@@ -86,6 +90,7 @@ export default function Profile() {
           setAvatar(res.data.avatar);
           setBanner(res.data.banner);
           setBio(filterProfanity(res.data.bio, user.settings, "\\*") || "");
+          setPronouns(filterProfanity(res.data.pronouns, user.settings, "\\*") || "");
           setIsFriend(res.data.isFriend);
           setIsLove(res.data.isLove);
           setIsMarried(res.data.isMarried);
@@ -304,6 +309,11 @@ export default function Profile() {
     setOldBio(bio);
   }
 
+  function onPronounsClick() {
+    setEditingPronouns(isSelf);
+    setOldPronouns(pronouns);
+  }
+
   function onEditBio(e) {
     axios
       .post(`/user/bio`, { bio: bio })
@@ -314,10 +324,26 @@ export default function Profile() {
       .catch(errorAlert);
   }
 
+  function onEditPronouns(e) {
+    axios
+      .post(`/user/pronouns`, { pronouns: pronouns })
+      .then(() => {
+        setEditingPronouns(false);
+        setPronouns(filterProfanity(pronouns, user.settings, "\\*"));
+      })
+      .catch(errorAlert);
+  }
+
   function onCancelEditBio(e) {
     e.stopPropagation();
     setEditingBio(false);
     setBio(oldBio);
+  }
+
+  function onCancelEditPronouns(e) {
+    e.stopPropagation();
+    setEditingPronouns(false);
+    setPronouns(oldPronouns);
   }
 
   function onAcceptFriend(_userId) {
@@ -547,6 +573,32 @@ export default function Profile() {
                 />
               </div>
             )}
+            <div
+              className={`pronouns${isSelf && !editingPronouns ? " edit" : ""}`}
+              onClick={onPronounsClick}
+            >
+              {!editingPronouns && (
+                <div className="md-content">
+                  <ReactMarkdown renderers={basicRenderers()} source={pronouns} />
+                </div>
+              )}
+              {editingPronouns && (
+                <>
+                  <TextEditor value={pronouns} onChange={setPronouns} />
+                  <div className="buttons">
+                    <div className="btn btn-theme" onClick={onEditPronouns}>
+                      Submit
+                    </div>
+                    <div
+                      className="btn btn-theme-sec"
+                      onClick={onCancelEditPronouns}
+                    >
+                      Cancel
+                    </div>
+                  </div>
+                </>
+              )}
+            </div>
             <div className="accounts">
               {accounts.discord && settings.showDiscord && (
                 <div className="account-badge">
@@ -574,7 +626,7 @@ export default function Profile() {
               )}
             </div>
             <div
-              className={`bio ${isSelf && !editingBio ? "edit" : ""}`}
+              className={`bio${isSelf && !editingBio ? " edit" : ""}`}
               onClick={onBioClick}
             >
               {!editingBio && (

--- a/react_main/src/pages/User/User.jsx
+++ b/react_main/src/pages/User/User.jsx
@@ -14,6 +14,7 @@ import { youtubeRegex } from "../../components/Basic";
 import { useTheme } from "@mui/styles";
 import { Link as MuiLink } from "@mui/material";
 import { Box, Card, AppBar, Toolbar } from "@mui/material";
+import { PieChart } from "./PieChart";
 
 export function YouTubeEmbed(props) {
   const embedId = props.embedId;
@@ -313,23 +314,16 @@ export function NameWithAvatar(props) {
   const active = props.active;
   const groups = props.groups;
   const dead = props.dead;
+  const nameWithAvatarRef = useRef();
   const popover = useContext(PopoverContext);
   const avatarId = props.avatarId;
   const deckProfile = props.deckProfile;
+  const includeMiniprofile = props.includeMiniprofile;
 
   var userNameClassName = `user-name ${props.dead ? "dead" : color}`;
 
-  return (
-    <Link
-      className={`name-with-avatar ${noLink ? "no-link" : ""}`}
-      to={`/user/${id}`}
-      target={newTab ? "_blank" : ""}
-      onClick={(e) => {
-        popover.setVisible(false);
-
-        if (noLink) e.preventDefault();
-      }}
-    >
+  var contents = (
+    <>
       <Avatar
         hasImage={avatar}
         id={id}
@@ -347,7 +341,107 @@ export function NameWithAvatar(props) {
         {name}
       </div>
       {groups && <Badges groups={groups} small={small} />}
-    </Link>
+    </>);
+
+  // noLink should take precedence over includeMiniprofile
+  if(noLink)
+  {
+    return (
+      <div
+        className={`name-with-avatar no-link`}
+        target={newTab ? "_blank" : ""}
+        onClick={(e) => {
+          popover.setVisible(false);
+  
+          if (noLink) e.preventDefault();
+        }}
+      >
+        {contents}
+      </div>
+    );
+  }
+  else if(includeMiniprofile)
+  {
+    var title = (
+      <Link
+        className={`name-with-avatar`}
+        to={`/user/${id}`}
+        target={newTab ? "_blank" : ""}
+        onClick={(e) => {
+          popover.setVisible(false);
+
+          if (noLink) e.preventDefault();
+        }}
+      >
+        {contents}
+      </Link>
+    );
+
+    function onClick() {
+      popover.onClick(
+        `/user/${id}/profile`,
+        "miniprofile",
+        nameWithAvatarRef.current,
+        title,
+        (data) => {data.props = props;} // allow the miniprofile component to access our props
+      );
+    }
+
+    return (
+      <div
+        ref={nameWithAvatarRef}
+        className={`name-with-avatar no-link`}
+        onClick={onClick}
+        onMouseOver={onClick}
+      >
+        {contents}
+      </div>
+    );
+  }
+  else
+  {
+    return (
+      <Link
+        className={`name-with-avatar`}
+        to={`/user/${id}`}
+        target={newTab ? "_blank" : ""}
+        onClick={(e) => {
+          popover.setVisible(false);
+
+          if (noLink) e.preventDefault();
+        }}
+      >
+        {contents}
+      </Link>
+    );
+  }
+}
+
+export function Miniprofile(user) {
+  console.log(user);
+
+  user = user.user;
+  const props = user.props;
+
+  const id = user.id;
+  const name = user.name || "[deleted]";
+  const avatar = user.avatar;
+  const color = props.color;
+  const newTab = props.newTab;
+  const active = props.active;
+  const groups = props.groups;
+  const avatarId = props.avatarId;
+
+  var mafiaStats = user.stats["Mafia"].all;
+
+  return (
+    <>
+      <PieChart
+        wins={mafiaStats.wins.count}
+        losses={mafiaStats.wins.total - mafiaStats.wins.count}
+        abandons={mafiaStats.abandons.total}
+      />
+    </>
   );
 }
 

--- a/react_main/src/pages/User/User.jsx
+++ b/react_main/src/pages/User/User.jsx
@@ -443,9 +443,7 @@ export function NameWithAvatar(props) {
   }
 }
 
-export function Miniprofile(user, title) {
-  console.log(user);
-
+export function Miniprofile(user) {
   user = user.user;
   const props = user.props;
 

--- a/react_main/src/pages/User/User.jsx
+++ b/react_main/src/pages/User/User.jsx
@@ -425,6 +425,7 @@ export function Miniprofile(user) {
 
   const id = user.id;
   const name = user.name || "[deleted]";
+  const pronouns = user.pronouns || "[deleted]";
   const avatar = user.avatar;
   const color = props.color;
   const newTab = props.newTab;
@@ -435,13 +436,14 @@ export function Miniprofile(user) {
   var mafiaStats = user.stats["Mafia"].all;
 
   return (
-    <>
+    <div className="miniprofile">
+      <div className="pronouns">({pronouns})</div>
       <PieChart
         wins={mafiaStats.wins.count}
         losses={mafiaStats.wins.total - mafiaStats.wins.count}
         abandons={mafiaStats.abandons.total}
       />
-    </>
+    </div>
   );
 }
 

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -260,6 +260,7 @@ async function authSuccess(req, uid, email, discordProfile) {
             "privateChat",
             "playGame",
             "editBio",
+            "editPronouns",
             "changeName",
           ],
           "ipFlag"

--- a/routes/mod.js
+++ b/routes/mod.js
@@ -1005,6 +1005,7 @@ router.post("/blacklist", async (req, res) => {
         "privateChat",
         "playGame",
         "editBio",
+        "editPronouns",
         "changeName",
       ],
       "ipFlag"

--- a/routes/user.js
+++ b/routes/user.js
@@ -176,7 +176,7 @@ router.get("/:id/profile", async function (req, res) {
     var isSelf = reqUserId == userId;
     var user = await models.User.findOne({ id: userId, deleted: false })
       .select(
-        "id name avatar settings accounts wins losses bio banner setups games numFriends stats -_id"
+        "id name avatar settings accounts wins losses bio pronouns banner setups games numFriends stats -_id"
       )
       .populate({
         path: "setups",
@@ -688,6 +688,32 @@ router.post("/bio", async function (req, res) {
     logger.error(e);
     res.status(500);
     res.send("Error editing bio");
+  }
+});
+
+router.post("/pronouns", async function (req, res) {
+  res.setHeader("Content-Type", "application/json");
+  try {
+    var userId = await routeUtils.verifyLoggedIn(req);
+    var pronouns = String(req.body.pronouns);
+    var perm = "editPronouns";
+
+    if (!(await routeUtils.verifyPermission(res, userId, perm))) return;
+
+    if (pronouns.length < 15) {
+      await models.User.updateOne({ id: userId }, { $set: { pronouns: pronouns } });
+      res.sendStatus(200);
+    } else if (pronouns.length >= 15) {
+      res.status(500);
+      res.send("Pronouns must be less than 15 characters");
+    } else {
+      res.status(500);
+      res.send("Error editing pronouns");
+    }
+  } catch (e) {
+    logger.error(e);
+    res.status(500);
+    res.send("Error editing pronouns");
   }
 });
 
@@ -1432,6 +1458,7 @@ router.post("/delete", async function (req, res) {
           avatar: "",
           banner: "",
           bio: "",
+          pronouns: "",
           settings: "",
           numFriends: "",
           dev: "",


### PR DESCRIPTION
Resolves #1517 and #1518

Miniprofile appears whenever you hover over the panel of a user inside a game. You can click on the user's panel to "lock" the miniprofile in place. Clicking on the user's name inside the miniprofile takes you the user's profile. Pronouns are conditionally displayed if set. Pie chart is displayed using the same mechanism from the profile page. The contents of the miniprofile are populated from a REST request that happens once per user in the game per refresh of your page.

Pronouns are set from your profile, they default to the empty string and your profile has a default message in place of your pronouns if they are still empty. You can edit them exactly like your bio - the limit is 15 characters (it can be increased but it'd need to be tweaked to play nice with the miniprofile). Profanity is filtered in the same way that the bio is.

I also tested anonymous games to make sure I didn't break those - the miniprofile doesn't appear as normal because noLink is set to true.

Screenshots:
### Appearance of miniprofile for brand new user:
![image](https://github.com/user-attachments/assets/0a606bef-0d97-40cd-b6e3-d53283b1703f)

### Appearance of miniprofile in hover state:
![image](https://github.com/user-attachments/assets/f10e6e04-62c4-4a7c-b00c-849b5513961d)

### Appearance of miniprofile in "locked" state:
![image](https://github.com/user-attachments/assets/78284a85-04fd-493d-8779-0099effece18)

### Appearance of profile for brand new user:
![image](https://github.com/user-attachments/assets/6678755f-93e6-4cf9-aaa6-ec1f33144912)

### Appearance of profile for established user:
![image](https://github.com/user-attachments/assets/9af7213d-f22b-4759-b8a0-7543068ec2c2)
