### PR TITLE
Seer and Retired Info Files + False, True, Naive, Paranoid Modifiers + Hitchhiker and Politician buffs

### DIFF
--- a/Games/types/Mafia/information/RevealEvilPlayersInfo.js
+++ b/Games/types/Mafia/information/RevealEvilPlayersInfo.js
@@ -1,0 +1,131 @@
+const Information = require("../Information");
+const Random = require("../../../../lib/Random");
+const {
+  EVIL_FACTIONS,
+  NOT_EVIL_FACTIONS,
+  CULT_FACTIONS,
+  MAFIA_FACTIONS,
+  FACTION_LEARN_TEAM,
+  FACTION_WIN_WITH_MAJORITY,
+  FACTION_WITH_MEETING,
+  FACTION_KILL,
+} = require("../const/FactionList");
+
+module.exports = class RevealEvilPlayersInfo extends Information {
+  constructor(creator, game) {
+    super("Reveal Evil Players Info", creator, game, revealTo);
+    if (revealTo == null) {
+      revealTo == "Self";
+    }
+    let evilPlayers = this.game.players.filter((p) => this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")) == "Mafia" || this.game.getRoleAlignment(this.game.getRoleAppearance(p).split(" (")) == "Cult");
+    this.mainInfo = evilPlayers;
+    this.maxEvilCount = evilPlayers.length;
+    this.truthValue = "Normal";
+  }
+
+  getInfoRaw() {
+    super.getInfoRaw();
+    for(let playerB of this.mainInfo){
+    let tempTempAppearanceMods =
+      playerB.tempAppearanceMods[this.investType];
+    let tempTempAppearance = playerB.tempAppearance[this.investType];
+    let OtherRoles = this.game.PossibleRoles.filter(
+      (r) =>
+        r !=
+          this.game.formatRoleInternal(
+            playerB.role.name,
+            playerB.role.modifier
+          ) &&
+        !this.game.getRoleTags(r).includes("No Investigate") &&
+        !this.game.getRoleTags(r).includes("Exposed")
+    );
+    OtherRoles = Random.randomizeArray(OtherRoles);
+    if (this.truthValue == "Normal") {
+      this.revealTarget();
+    } else if (this.truthValue == "True") {
+      playerB.setTempAppearance(
+        this.investType,
+        this.game.formatRoleInternal(
+          playerB.role.name,
+          playerB.role.modifier
+        )
+      );
+      this.revealTarget();
+    } else if (this.truthValue == "False") {
+      playerB.setTempAppearance(this.investType, OtherRoles[0]);
+      this.revealTarget();
+    } 
+
+    playerB.tempAppearanceMods[this.investType] = tempTempAppearanceMods;
+    playerB.tempAppearance[this.investType] = tempTempAppearance;
+    }
+  }
+
+  getInfoFormated() {
+    this.getInfoRaw();
+  }
+
+  revealTarget(playerToReveal) {
+    if (this.revealTo == "All") {
+        playerToReveal.role.revealToAll();
+    }
+    if (this.revealTo == "Faction") {
+      for (let player of this.game.players) {
+        if (player.faction == this.creator.faction) {
+          playerToReveal.role.revealToPlayer(player);
+        }
+      }
+    }
+    if (this.revealTo == "Self") {
+        playerToReveal.role.revealToPlayer(this.creator);
+    }
+  }
+
+  isTrue() {
+    let players = this.game.players.filter((p) => EVIL_FACTIONS.includes(p.faction)));
+    if (this.mainInfo.length != players.length) {
+      return false;
+    }
+    for (let player of players) {
+      if (!this.mainInfo.includes(player)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  isFalse() {
+    let players = this.game.players.filter((p) => EVIL_FACTIONS.includes(p.faction)));
+    for (let player of players) {
+      if (!this.mainInfo.includes(player)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  isFavorable() {
+      return true;
+  }
+  isUnfavorable() {
+      return true;
+  }
+
+  makeTrue() {
+   let players = this.game.players.filter((p) => EVIL_FACTIONS.includes(p.faction)));
+  this.mainInfo = players;
+  this.truthValue = "True";
+  }
+  makeFalse() {
+  let players = this.game.players.filter((p) => !EVIL_FACTIONS.includes(p.faction) && p != this.creator));
+    players = Random.randomizeArray(players);
+    let goodPlayers = [];
+    for(let x = 0; x < players.length && x < this.maxEvilCount; x++){
+      goodPlayers.push(players[x]);
+    }
+  this.mainInfo = goodPlayers;
+  this.truthValue = "False";
+  }
+  makeFavorable() {
+  }
+  makeUnfavorable() {
+  }
+};

--- a/Games/types/Mafia/information/RevealEvilPlayersInfo.js
+++ b/Games/types/Mafia/information/RevealEvilPlayersInfo.js
@@ -18,7 +18,15 @@ module.exports = class RevealEvilPlayersInfo extends Information {
       revealTo = "Self";
     }
     this.revealTo = revealTo;
-    let evilPlayers = this.game.players.filter((p) => this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")[0]) == "Mafia" || this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")[0]) == "Cult");
+    let evilPlayers = this.game.players.filter(
+      (p) =>
+        this.game.getRoleAlignment(
+          p.getRoleAppearance("reveal").split(" (")[0]
+        ) == "Mafia" ||
+        this.game.getRoleAlignment(
+          p.getRoleAppearance("reveal").split(" (")[0]
+        ) == "Cult"
+    );
     this.mainInfo = evilPlayers;
     this.maxEvilCount = evilPlayers.length;
     this.truthValue = "Normal";
@@ -26,50 +34,62 @@ module.exports = class RevealEvilPlayersInfo extends Information {
 
   getInfoRaw() {
     super.getInfoRaw();
-    let evilPlayers = this.game.players.filter((p) => this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")[0]) == "Mafia" || this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")[0]) == "Cult");
-    let OtherRoles = [];
-    for(let item of evilPlayers){
-      if(item.tempAppearance["reveal"] != null){
-      OtherRoles.push(`${item.tempAppearance["reveal"]}:${item.tempAppearanceMods["reveal"]}`);
-      }
-      else{
-      OtherRoles.push(`${item.role.appearance["reveal"]}:${item.role.appearanceMods["reveal"]}`);
-      }
-    }
-    if(OtherRoles.length < this.mainInfo.length){
-      OtherRoles = this.game.PossibleRoles.filter((r) =>
-        !this.game.getRoleTags(r).includes("No Investigate") &&
-        !this.game.getRoleTags(r).includes("Exposed") 
+    let evilPlayers = this.game.players.filter(
+      (p) =>
+        this.game.getRoleAlignment(
+          p.getRoleAppearance("reveal").split(" (")[0]
+        ) == "Mafia" ||
+        this.game.getRoleAlignment(
+          p.getRoleAppearance("reveal").split(" (")[0]
+        ) == "Cult"
     );
-      OtherRoles = OtherRoles.filter((r) => this.game.getRoleAlignment(r.split(":")[0]) == "Mafia" || this.game.getRoleAlignment(r.split(":")[0]) == "Cult");
+    let OtherRoles = [];
+    for (let item of evilPlayers) {
+      if (item.tempAppearance["reveal"] != null) {
+        OtherRoles.push(
+          `${item.tempAppearance["reveal"]}:${item.tempAppearanceMods["reveal"]}`
+        );
+      } else {
+        OtherRoles.push(
+          `${item.role.appearance["reveal"]}:${item.role.appearanceMods["reveal"]}`
+        );
+      }
     }
-    
+    if (OtherRoles.length < this.mainInfo.length) {
+      OtherRoles = this.game.PossibleRoles.filter(
+        (r) =>
+          !this.game.getRoleTags(r).includes("No Investigate") &&
+          !this.game.getRoleTags(r).includes("Exposed")
+      );
+      OtherRoles = OtherRoles.filter(
+        (r) =>
+          this.game.getRoleAlignment(r.split(":")[0]) == "Mafia" ||
+          this.game.getRoleAlignment(r.split(":")[0]) == "Cult"
+      );
+    }
 
     OtherRoles = Random.randomizeArray(OtherRoles);
     let number = 0;
-    for(let playerB of this.mainInfo){
-    let tempTempAppearanceMods = playerB.tempAppearanceMods["reveal"];
-    let tempTempAppearance = playerB.tempAppearance["reveal"];
-      
-    if (this.truthValue == "Normal") {
-      this.revealTarget(playerB);
-    } else if (this.truthValue == "True") {
-      playerB.setTempAppearance(
-        "reveal",
-        this.game.formatRoleInternal(
-          playerB.role.name,
-          playerB.role.modifier
-        )
-      );
-      this.revealTarget(playerB);
-    } else if (this.truthValue == "False") {
-      playerB.setTempAppearance("reveal", OtherRoles[number]);
-      this.revealTarget(playerB);
-    } 
+    for (let playerB of this.mainInfo) {
+      let tempTempAppearanceMods = playerB.tempAppearanceMods["reveal"];
+      let tempTempAppearance = playerB.tempAppearance["reveal"];
 
-    playerB.tempAppearanceMods["reveal"] = tempTempAppearanceMods;
-    playerB.tempAppearance["reveal"] = tempTempAppearance;
-    number++;
+      if (this.truthValue == "Normal") {
+        this.revealTarget(playerB);
+      } else if (this.truthValue == "True") {
+        playerB.setTempAppearance(
+          "reveal",
+          this.game.formatRoleInternal(playerB.role.name, playerB.role.modifier)
+        );
+        this.revealTarget(playerB);
+      } else if (this.truthValue == "False") {
+        playerB.setTempAppearance("reveal", OtherRoles[number]);
+        this.revealTarget(playerB);
+      }
+
+      playerB.tempAppearanceMods["reveal"] = tempTempAppearanceMods;
+      playerB.tempAppearance["reveal"] = tempTempAppearance;
+      number++;
     }
   }
 
@@ -79,7 +99,7 @@ module.exports = class RevealEvilPlayersInfo extends Information {
 
   revealTarget(playerToReveal) {
     if (this.revealTo == "All") {
-        playerToReveal.role.revealToAll();
+      playerToReveal.role.revealToAll();
     }
     if (this.revealTo == "Faction") {
       for (let player of this.game.players) {
@@ -89,12 +109,14 @@ module.exports = class RevealEvilPlayersInfo extends Information {
       }
     }
     if (this.revealTo == "Self") {
-        playerToReveal.role.revealToPlayer(this.creator);
+      playerToReveal.role.revealToPlayer(this.creator);
     }
   }
 
   isTrue() {
-    let players = this.game.players.filter((p) => EVIL_FACTIONS.includes(p.faction));
+    let players = this.game.players.filter((p) =>
+      EVIL_FACTIONS.includes(p.faction)
+    );
     if (this.mainInfo.length != players.length) {
       return false;
     }
@@ -106,7 +128,9 @@ module.exports = class RevealEvilPlayersInfo extends Information {
     return true;
   }
   isFalse() {
-    let players = this.game.players.filter((p) => EVIL_FACTIONS.includes(p.faction));
+    let players = this.game.players.filter((p) =>
+      EVIL_FACTIONS.includes(p.faction)
+    );
     for (let player of players) {
       if (this.mainInfo.includes(player)) {
         return false;
@@ -115,29 +139,31 @@ module.exports = class RevealEvilPlayersInfo extends Information {
     return true;
   }
   isFavorable() {
-      return true;
+    return true;
   }
   isUnfavorable() {
-      return true;
+    return true;
   }
 
   makeTrue() {
-   let players = this.game.players.filter((p) => EVIL_FACTIONS.includes(p.faction));
-  this.mainInfo = players;
-  this.truthValue = "True";
+    let players = this.game.players.filter((p) =>
+      EVIL_FACTIONS.includes(p.faction)
+    );
+    this.mainInfo = players;
+    this.truthValue = "True";
   }
   makeFalse() {
-  let players = this.game.players.filter((p) => !EVIL_FACTIONS.includes(p.faction) && p != this.creator);
+    let players = this.game.players.filter(
+      (p) => !EVIL_FACTIONS.includes(p.faction) && p != this.creator
+    );
     players = Random.randomizeArray(players);
     let goodPlayers = [];
-    for(let x = 0; x < players.length && x < this.maxEvilCount; x++){
+    for (let x = 0; x < players.length && x < this.maxEvilCount; x++) {
       goodPlayers.push(players[x]);
     }
-  this.mainInfo = goodPlayers;
-  this.truthValue = "False";
+    this.mainInfo = goodPlayers;
+    this.truthValue = "False";
   }
-  makeFavorable() {
-  }
-  makeUnfavorable() {
-  }
+  makeFavorable() {}
+  makeUnfavorable() {}
 };

--- a/Games/types/Mafia/information/RevealEvilPlayersInfo.js
+++ b/Games/types/Mafia/information/RevealEvilPlayersInfo.js
@@ -17,7 +17,7 @@ module.exports = class RevealEvilPlayersInfo extends Information {
     if (revealTo == null) {
       revealTo == "Self";
     }
-    let evilPlayers = this.game.players.filter((p) => this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")) == "Mafia" || this.game.getRoleAlignment(this.game.getRoleAppearance(p).split(" (")) == "Cult");
+    let evilPlayers = this.game.players.filter((p) => this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")) == "Mafia" || this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")) == "Cult");
     this.mainInfo = evilPlayers;
     this.maxEvilCount = evilPlayers.length;
     this.truthValue = "Normal";
@@ -25,26 +25,36 @@ module.exports = class RevealEvilPlayersInfo extends Information {
 
   getInfoRaw() {
     super.getInfoRaw();
-    for(let playerB of this.mainInfo){
-    let tempTempAppearanceMods =
-      playerB.tempAppearanceMods[this.investType];
-    let tempTempAppearance = playerB.tempAppearance[this.investType];
-    let OtherRoles = this.game.PossibleRoles.filter(
-      (r) =>
-        r !=
-          this.game.formatRoleInternal(
-            playerB.role.name,
-            playerB.role.modifier
-          ) &&
+    let evilPlayers = this.game.players.filter((p) => this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")) == "Mafia" || this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")) == "Cult");
+    let OtherRoles = [];
+    for(let item of evilPlayers){
+      if(item.tempAppearance["reveal"] != null){
+      OtherRoles.push(`${item.tempAppearance["reveal"]}:${item.tempAppearanceMods["reveal"];}`);
+      }
+      else{
+      OtherRoles.push(`${item.role.appearance["reveal"]}:${item.role.appearanceMods["reveal"];}`);
+      }
+    }
+    if(OtherRoles.length < this.mainInfo.length){
+      OtherRoles = this.game.PossibleRoles.filter((r) => r != this.game.formatRoleInternal(this.target.role.name, this.target.role.modifier) &&
         !this.game.getRoleTags(r).includes("No Investigate") &&
-        !this.game.getRoleTags(r).includes("Exposed")
+        !this.game.getRoleTags(r).includes("Exposed") && 
     );
+      OtherRoles = OtherRoles.filter((r) => this.game.getRoleAlignment(r.split(":")[0]) != "Mafia" || this.game.getRoleAlignment(r.split(":")[0]) == "Cult");
+    }
+    
+
     OtherRoles = Random.randomizeArray(OtherRoles);
+    let number = 0;
+    for(let playerB of this.mainInfo){
+    let tempTempAppearanceMods = playerB.tempAppearanceMods["reveal"];
+    let tempTempAppearance = playerB.tempAppearance["reveal"];
+      
     if (this.truthValue == "Normal") {
       this.revealTarget();
     } else if (this.truthValue == "True") {
       playerB.setTempAppearance(
-        this.investType,
+        "reveal",
         this.game.formatRoleInternal(
           playerB.role.name,
           playerB.role.modifier
@@ -52,12 +62,13 @@ module.exports = class RevealEvilPlayersInfo extends Information {
       );
       this.revealTarget();
     } else if (this.truthValue == "False") {
-      playerB.setTempAppearance(this.investType, OtherRoles[0]);
+      playerB.setTempAppearance("reveal", OtherRoles[number]);
       this.revealTarget();
     } 
 
-    playerB.tempAppearanceMods[this.investType] = tempTempAppearanceMods;
-    playerB.tempAppearance[this.investType] = tempTempAppearance;
+    playerB.tempAppearanceMods["reveal"] = tempTempAppearanceMods;
+    playerB.tempAppearance["reveal"] = tempTempAppearance;
+    number++;
     }
   }
 

--- a/Games/types/Mafia/information/RevealInfo.js
+++ b/Games/types/Mafia/information/RevealInfo.js
@@ -76,6 +76,9 @@ module.exports = class RevealInfo extends Information {
           (this.game.getRoleAlignment(r.split(":")[0]) == "Independent" &&
             !this.game.getRoleTags(r.split(":")[0]).includes("Hostile"))
       );
+      if(OtherRoles.length <= 0){
+        OtherRoles.push("Villager");
+      }
       OtherRoles = Random.randomizeArray(OtherRoles);
       this.target.setTempAppearance(this.investType, OtherRoles[0]);
       this.revealTarget();
@@ -88,6 +91,9 @@ module.exports = class RevealInfo extends Information {
             !this.game.getRoleTags(r.split(":")[0]).includes("Hostile")
           )
       );
+      if(OtherRoles.length <= 0){
+        OtherRoles.push("Cultist");
+      }
       OtherRoles = Random.randomizeArray(OtherRoles);
       this.target.setTempAppearance(this.investType, OtherRoles[0]);
       this.revealTarget();

--- a/Games/types/Mafia/information/RevealInfo.js
+++ b/Games/types/Mafia/information/RevealInfo.js
@@ -76,7 +76,7 @@ module.exports = class RevealInfo extends Information {
           (this.game.getRoleAlignment(r.split(":")[0]) == "Independent" &&
             !this.game.getRoleTags(r.split(":")[0]).includes("Hostile"))
       );
-      if(OtherRoles.length <= 0){
+      if (OtherRoles.length <= 0) {
         OtherRoles.push("Villager");
       }
       OtherRoles = Random.randomizeArray(OtherRoles);
@@ -91,7 +91,7 @@ module.exports = class RevealInfo extends Information {
             !this.game.getRoleTags(r.split(":")[0]).includes("Hostile")
           )
       );
-      if(OtherRoles.length <= 0){
+      if (OtherRoles.length <= 0) {
         OtherRoles.push("Cultist");
       }
       OtherRoles = Random.randomizeArray(OtherRoles);

--- a/Games/types/Mafia/information/RevealPlayersWithRoleInfo.js
+++ b/Games/types/Mafia/information/RevealPlayersWithRoleInfo.js
@@ -17,12 +17,14 @@ module.exports = class RevealPlayersWithRoleInfo extends Information {
     if (revealTo == null) {
       revealTo = "Self";
     }
-    if(role == null){
+    if (role == null) {
       role = "Villager";
     }
     this.role = role;
     this.revealTo = revealTo;
-    let playersWithRole = this.game.players.filter((p) => p.getRoleAppearance("reveal").split(" (")[0] == this.role);
+    let playersWithRole = this.game.players.filter(
+      (p) => p.getRoleAppearance("reveal").split(" (")[0] == this.role
+    );
     this.mainInfo = playersWithRole;
     this.maxRoleCount = playersWithRole.length;
     this.truthValue = "Normal";
@@ -30,46 +32,49 @@ module.exports = class RevealPlayersWithRoleInfo extends Information {
 
   getInfoRaw() {
     super.getInfoRaw();
-    let playersWithRole = this.game.players.filter((p) =>  p.getRoleAppearance("reveal").split(" (")[0] == this.role);
+    let playersWithRole = this.game.players.filter(
+      (p) => p.getRoleAppearance("reveal").split(" (")[0] == this.role
+    );
     let OtherRoles = [];
-    for(let item of playersWithRole){
-      if(item.tempAppearance["reveal"] != null){
-      OtherRoles.push(`${item.tempAppearance["reveal"]}:${item.tempAppearanceMods["reveal"]}`);
-      }
-      else{
-      OtherRoles.push(`${item.role.appearance["reveal"]}:${item.role.appearanceMods["reveal"]}`);
+    for (let item of playersWithRole) {
+      if (item.tempAppearance["reveal"] != null) {
+        OtherRoles.push(
+          `${item.tempAppearance["reveal"]}:${item.tempAppearanceMods["reveal"]}`
+        );
+      } else {
+        OtherRoles.push(
+          `${item.role.appearance["reveal"]}:${item.role.appearanceMods["reveal"]}`
+        );
       }
     }
-    if(OtherRoles.length < this.mainInfo.length){
-      OtherRoles = this.game.PossibleRoles.filter((r) => r.split(":")[0] == this.role);
+    if (OtherRoles.length < this.mainInfo.length) {
+      OtherRoles = this.game.PossibleRoles.filter(
+        (r) => r.split(":")[0] == this.role
+      );
     }
-    
 
     OtherRoles = Random.randomizeArray(OtherRoles);
     let number = 0;
-    for(let playerB of this.mainInfo){
-    let tempTempAppearanceMods = playerB.tempAppearanceMods["reveal"];
-    let tempTempAppearance = playerB.tempAppearance["reveal"];
-      
-    if (this.truthValue == "Normal") {
-      this.revealTarget(playerB);
-    } else if (this.truthValue == "True") {
-      playerB.setTempAppearance(
-        "reveal",
-        this.game.formatRoleInternal(
-          playerB.role.name,
-          playerB.role.modifier
-        )
-      );
-      this.revealTarget(playerB);
-    } else if (this.truthValue == "False") {
-      playerB.setTempAppearance("reveal", OtherRoles[number]);
-      this.revealTarget(playerB);
-    } 
+    for (let playerB of this.mainInfo) {
+      let tempTempAppearanceMods = playerB.tempAppearanceMods["reveal"];
+      let tempTempAppearance = playerB.tempAppearance["reveal"];
 
-    playerB.tempAppearanceMods["reveal"] = tempTempAppearanceMods;
-    playerB.tempAppearance["reveal"] = tempTempAppearance;
-    number++;
+      if (this.truthValue == "Normal") {
+        this.revealTarget(playerB);
+      } else if (this.truthValue == "True") {
+        playerB.setTempAppearance(
+          "reveal",
+          this.game.formatRoleInternal(playerB.role.name, playerB.role.modifier)
+        );
+        this.revealTarget(playerB);
+      } else if (this.truthValue == "False") {
+        playerB.setTempAppearance("reveal", OtherRoles[number]);
+        this.revealTarget(playerB);
+      }
+
+      playerB.tempAppearanceMods["reveal"] = tempTempAppearanceMods;
+      playerB.tempAppearance["reveal"] = tempTempAppearance;
+      number++;
     }
   }
 
@@ -79,7 +84,7 @@ module.exports = class RevealPlayersWithRoleInfo extends Information {
 
   revealTarget(playerToReveal) {
     if (this.revealTo == "All") {
-        playerToReveal.role.revealToAll();
+      playerToReveal.role.revealToAll();
     }
     if (this.revealTo == "Faction") {
       for (let player of this.game.players) {
@@ -89,7 +94,7 @@ module.exports = class RevealPlayersWithRoleInfo extends Information {
       }
     }
     if (this.revealTo == "Self") {
-        playerToReveal.role.revealToPlayer(this.creator);
+      playerToReveal.role.revealToPlayer(this.creator);
     }
   }
 
@@ -115,29 +120,29 @@ module.exports = class RevealPlayersWithRoleInfo extends Information {
     return true;
   }
   isFavorable() {
-      return true;
+    return true;
   }
   isUnfavorable() {
-      return true;
+    return true;
   }
 
   makeTrue() {
-   let players = this.game.players.filter((p) => p.role.name == this.role);
-  this.mainInfo = players;
-  this.truthValue = "True";
+    let players = this.game.players.filter((p) => p.role.name == this.role);
+    this.mainInfo = players;
+    this.truthValue = "True";
   }
   makeFalse() {
-  let players = this.game.players.filter((p) => p.role.name != this.role && p != this.creator);
+    let players = this.game.players.filter(
+      (p) => p.role.name != this.role && p != this.creator
+    );
     players = Random.randomizeArray(players);
     let goodPlayers = [];
-    for(let x = 0; x < players.length && x < this.maxRoleCount; x++){
+    for (let x = 0; x < players.length && x < this.maxRoleCount; x++) {
       goodPlayers.push(players[x]);
     }
-  this.mainInfo = goodPlayers;
-  this.truthValue = "False";
+    this.mainInfo = goodPlayers;
+    this.truthValue = "False";
   }
-  makeFavorable() {
-  }
-  makeUnfavorable() {
-  }
+  makeFavorable() {}
+  makeUnfavorable() {}
 };

--- a/Games/types/Mafia/information/RevealPlayersWithRoleInfo.js
+++ b/Games/types/Mafia/information/RevealPlayersWithRoleInfo.js
@@ -11,24 +11,28 @@ const {
   FACTION_KILL,
 } = require("../const/FactionList");
 
-module.exports = class RevealEvilPlayersInfo extends Information {
-  constructor(creator, game, revealTo) {
-    super("Reveal Evil Players Info", creator, game);
+module.exports = class RevealPlayersWithRoleInfo extends Information {
+  constructor(creator, game, revealTo, role) {
+    super("Reveal Players Role Info", creator, game);
     if (revealTo == null) {
       revealTo = "Self";
     }
+    if(role == null){
+      role = "Villager";
+    }
+    this.role = role;
     this.revealTo = revealTo;
-    let evilPlayers = this.game.players.filter((p) => this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")[0]) == "Mafia" || this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")[0]) == "Cult");
-    this.mainInfo = evilPlayers;
-    this.maxEvilCount = evilPlayers.length;
+    let playersWithRole = this.game.players.filter((p) => p.getRoleAppearance("reveal").split(" (")[0] == this.role);
+    this.mainInfo = playersWithRole;
+    this.maxRoleCount = playersWithRole.length;
     this.truthValue = "Normal";
   }
 
   getInfoRaw() {
     super.getInfoRaw();
-    let evilPlayers = this.game.players.filter((p) => this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")[0]) == "Mafia" || this.game.getRoleAlignment(p.getRoleAppearance("reveal").split(" (")[0]) == "Cult");
+    let playersWithRole = this.game.players.filter((p) =>  p.getRoleAppearance("reveal").split(" (")[0] == this.role);
     let OtherRoles = [];
-    for(let item of evilPlayers){
+    for(let item of playersWithRole){
       if(item.tempAppearance["reveal"] != null){
       OtherRoles.push(`${item.tempAppearance["reveal"]}:${item.tempAppearanceMods["reveal"]}`);
       }
@@ -37,11 +41,7 @@ module.exports = class RevealEvilPlayersInfo extends Information {
       }
     }
     if(OtherRoles.length < this.mainInfo.length){
-      OtherRoles = this.game.PossibleRoles.filter((r) =>
-        !this.game.getRoleTags(r).includes("No Investigate") &&
-        !this.game.getRoleTags(r).includes("Exposed") 
-    );
-      OtherRoles = OtherRoles.filter((r) => this.game.getRoleAlignment(r.split(":")[0]) == "Mafia" || this.game.getRoleAlignment(r.split(":")[0]) == "Cult");
+      OtherRoles = this.game.PossibleRoles.filter((r) => r.split(":")[0] == this.role);
     }
     
 
@@ -94,7 +94,7 @@ module.exports = class RevealEvilPlayersInfo extends Information {
   }
 
   isTrue() {
-    let players = this.game.players.filter((p) => EVIL_FACTIONS.includes(p.faction));
+    let players = this.game.players.filter((p) => p.role.name == this.role);
     if (this.mainInfo.length != players.length) {
       return false;
     }
@@ -106,7 +106,7 @@ module.exports = class RevealEvilPlayersInfo extends Information {
     return true;
   }
   isFalse() {
-    let players = this.game.players.filter((p) => EVIL_FACTIONS.includes(p.faction));
+    let players = this.game.players.filter((p) => p.role.name == this.role);
     for (let player of players) {
       if (this.mainInfo.includes(player)) {
         return false;
@@ -122,15 +122,15 @@ module.exports = class RevealEvilPlayersInfo extends Information {
   }
 
   makeTrue() {
-   let players = this.game.players.filter((p) => EVIL_FACTIONS.includes(p.faction));
+   let players = this.game.players.filter((p) => p.role.name == this.role);
   this.mainInfo = players;
   this.truthValue = "True";
   }
   makeFalse() {
-  let players = this.game.players.filter((p) => !EVIL_FACTIONS.includes(p.faction) && p != this.creator);
+  let players = this.game.players.filter((p) => p.role.name != this.role && p != this.creator);
     players = Random.randomizeArray(players);
     let goodPlayers = [];
-    for(let x = 0; x < players.length && x < this.maxEvilCount; x++){
+    for(let x = 0; x < players.length && x < this.maxRoleCount; x++){
       goodPlayers.push(players[x]);
     }
   this.mainInfo = goodPlayers;

--- a/Games/types/Mafia/items/Retirement.js
+++ b/Games/types/Mafia/items/Retirement.js
@@ -13,7 +13,7 @@ module.exports = class Retirement extends Item {
         if (player !== this.holder) {
           return;
         }
-
+/*
         let players = this.game.players.filter(
           (p) => p.role.name == this.currRole
         );
@@ -27,12 +27,35 @@ module.exports = class Retirement extends Item {
             `You are a retired ${this.currRole}. You remember a few people you worked with!`
           );
         }
+        */
 
+        let info = this.game.createInformation(
+          "RevealPlayersWithRoleInfo",
+          this.holder,
+          this.game,
+          null,
+          this.currRole
+        );
+        info.processInfo();
+        info.getInfoRaw();
+
+        if (info.mainInfo.length <= 0) {
+          this.holder.queueAlert(
+            `You are a retired ${this.currRole}. You know that no one in this town is a ${this.currRole}`
+          );
+        } else {
+          this.holder.queueAlert(
+            `You are a retired ${this.currRole}. You remember a few people you worked with!`
+          );
+        }
+
+        /*
         for (const player of this.game.players) {
           if (player.role.name == this.currRole) {
             player.role.revealToPlayer(this.holder);
           }
         }
+        */
         this.drop();
       },
     };

--- a/Games/types/Mafia/items/Retirement.js
+++ b/Games/types/Mafia/items/Retirement.js
@@ -13,7 +13,7 @@ module.exports = class Retirement extends Item {
         if (player !== this.holder) {
           return;
         }
-/*
+        /*
         let players = this.game.players.filter(
           (p) => p.role.name == this.currRole
         );

--- a/Games/types/Mafia/roles/cards/BecomeAlignmentOfVisitors.js
+++ b/Games/types/Mafia/roles/cards/BecomeAlignmentOfVisitors.js
@@ -10,6 +10,12 @@ module.exports = class BecomeAlignmentOfVisitors extends Card {
     super(role);
     
     this.listeners = {
+      roleAssigned: function (player) {
+        if (player !== this.player) {
+          return;
+        }
+        this.player.faction = "Village";
+      },
       state: function (stateInfo) {
         if (!this.player.alive) {
           return;

--- a/Games/types/Mafia/roles/cards/BecomeAlignmentOfVisitors.js
+++ b/Games/types/Mafia/roles/cards/BecomeAlignmentOfVisitors.js
@@ -8,7 +8,7 @@ const {
 module.exports = class BecomeAlignmentOfVisitors extends Card {
   constructor(role) {
     super(role);
-    
+
     this.listeners = {
       roleAssigned: function (player) {
         if (player !== this.player) {
@@ -35,19 +35,18 @@ module.exports = class BecomeAlignmentOfVisitors extends Card {
               if (this.dominates(visit)) {
                 this.blockWithMindRot(visit);
               }
-              if(visit.faction == "Independent"){
+              if (visit.faction == "Independent") {
                 this.actor.queueAlert(
-                `After Hitchhiking with a player you feel like Supporting a ${visit.role.name}.`
-              );
-              this.actor.faction = visit.role.name;
-              return;
-              }
-              else{
-              this.actor.queueAlert(
-                `After Hitchhiking with a player you feel like Supporting the ${visit.faction}.`
-              );
-              this.actor.faction = visit.faction;
-              return;
+                  `After Hitchhiking with a player you feel like Supporting a ${visit.role.name}.`
+                );
+                this.actor.faction = visit.role.name;
+                return;
+              } else {
+                this.actor.queueAlert(
+                  `After Hitchhiking with a player you feel like Supporting the ${visit.faction}.`
+                );
+                this.actor.faction = visit.faction;
+                return;
               }
             }
           },

--- a/Games/types/Mafia/roles/cards/BecomeAlignmentOfVisitors.js
+++ b/Games/types/Mafia/roles/cards/BecomeAlignmentOfVisitors.js
@@ -8,30 +8,7 @@ const {
 module.exports = class BecomeAlignmentOfVisitors extends Card {
   constructor(role) {
     super(role);
-    /*
-    this.actions = [
-      {
-        priority: PRIORITY_BLOCK_VISITORS - 1,
-        labels: ["block", "hidden"],
-        run: function () {
-          if (this.game.getStateName() != "Night") return;
-          if (!this.actor.alive) return;
-
-          for (let visit of this.getVisitors(this.actor)) {
-            if (this.dominates(visit)) {
-              this.blockWithMindRot(visit);
-            }
-
-            this.actor.queueAlert(
-              `After Hitchhiking with a player you feel like Supporting the ${visit.faction}.`
-            );
-            this.actor.faction = visit.faction;
-            return;
-          }
-        },
-      },
-    ];
-    */
+    
     this.listeners = {
       state: function (stateInfo) {
         if (!this.player.alive) {
@@ -52,12 +29,20 @@ module.exports = class BecomeAlignmentOfVisitors extends Card {
               if (this.dominates(visit)) {
                 this.blockWithMindRot(visit);
               }
-
+              if(visit.faction == "Independent"){
+                this.actor.queueAlert(
+                `After Hitchhiking with a player you feel like Supporting a ${visit.role.name}.`
+              );
+              this.actor.faction = visit.role.name;
+              return;
+              }
+              else{
               this.actor.queueAlert(
                 `After Hitchhiking with a player you feel like Supporting the ${visit.faction}.`
               );
               this.actor.faction = visit.faction;
               return;
+              }
             }
           },
         });

--- a/Games/types/Mafia/roles/cards/CheckSuccessfulVisit.js
+++ b/Games/types/Mafia/roles/cards/CheckSuccessfulVisit.js
@@ -45,11 +45,6 @@ module.exports = class CheckSuccessfulVisit extends Card {
           run: function () {
             let targets = this.getVisits(this.actor);
             let targetNames = targets.map((t) => t.name);
-
-            if (this.actor.hasEffect("FalseMode")) {
-              if (targetNames.length >= 1) return;
-            }
-
             if (targetNames.length >= 1) {
               this.actor.queueAlert(
                 `:invest: You learn that your visit to ${targetNames.join(

--- a/Games/types/Mafia/roles/cards/ConvertIfVisitsAllMafia.js
+++ b/Games/types/Mafia/roles/cards/ConvertIfVisitsAllMafia.js
@@ -31,12 +31,7 @@ module.exports = class ConvertIfVisitsAllMafia extends Card {
             }
             this.actor.role.visitedMentors.add(this.target);
 
-            if (
-              (this.target.role.alignment == "Mafia" &&
-                !this.actor.hasEffect("FalseMode")) ||
-              (this.actor.hasEffect("FalseMode") &&
-                this.target.role.alignment != "Mafia")
-            ) {
+            if (this.target.role.alignment == "Mafia" ) {
               this.actor.queueAlert(
                 "You successfully trained with a member of the Mafia…"
               );

--- a/Games/types/Mafia/roles/cards/ConvertIfVisitsAllMafia.js
+++ b/Games/types/Mafia/roles/cards/ConvertIfVisitsAllMafia.js
@@ -31,7 +31,7 @@ module.exports = class ConvertIfVisitsAllMafia extends Card {
             }
             this.actor.role.visitedMentors.add(this.target);
 
-            if (this.target.role.alignment == "Mafia" ) {
+            if (this.target.role.alignment == "Mafia") {
               this.actor.queueAlert(
                 "You successfully trained with a member of the Mafia…"
               );

--- a/Games/types/Mafia/roles/cards/FalseModifier.js
+++ b/Games/types/Mafia/roles/cards/FalseModifier.js
@@ -5,6 +5,10 @@ module.exports = class FalseModifier extends Card {
   constructor(role) {
     super(role);
 
+    this.hideModifier = {
+      self: true,
+    };
+
     this.startEffects = ["FalseMode"];
   }
 };

--- a/Games/types/Mafia/roles/cards/FavorableModifier.js
+++ b/Games/types/Mafia/roles/cards/FavorableModifier.js
@@ -5,6 +5,10 @@ module.exports = class FavorableModifier extends Card {
   constructor(role) {
     super(role);
 
+    this.hideModifier = {
+      self: true,
+    };
+
     this.startEffects = ["FavorableMode"];
   }
 };

--- a/Games/types/Mafia/roles/cards/MakeAllVillageInfoFalse.js
+++ b/Games/types/Mafia/roles/cards/MakeAllVillageInfoFalse.js
@@ -29,7 +29,7 @@ module.exports = class MakeAllVillageInfoFalse extends Card {
     this.listeners = {
       SwitchRoleBefore: function (player) {
         if (player != this.player) return;
-      
+
         let players = this.game.players.filter(
           (p) => p.role.alignment == "Village"
         );
@@ -37,7 +37,6 @@ module.exports = class MakeAllVillageInfoFalse extends Card {
         for (let x = 0; x < players.length; x++) {
           players[x].giveEffect("FalseMode", 1);
         }
-      
       },
       state: function (stateInfo) {
         if (!this.player.alive) {

--- a/Games/types/Mafia/roles/cards/MakeAllVillageInfoFalse.js
+++ b/Games/types/Mafia/roles/cards/MakeAllVillageInfoFalse.js
@@ -27,6 +27,18 @@ module.exports = class MakeAllVillageInfoFalse extends Card {
 */
 
     this.listeners = {
+      SwitchRoleBefore: function (player) {
+        if (player != this.player) return;
+      
+        let players = this.game.players.filter(
+          (p) => p.role.alignment == "Village"
+        );
+
+        for (let x = 0; x < players.length; x++) {
+          players[x].giveEffect("FalseMode", 1);
+        }
+      
+      },
       state: function (stateInfo) {
         if (!this.player.alive) {
           return;

--- a/Games/types/Mafia/roles/cards/Omniscient.js
+++ b/Games/types/Mafia/roles/cards/Omniscient.js
@@ -30,8 +30,6 @@ module.exports = class Omiscient extends Card {
             let name;
             let players = this.game.alivePlayers();
             for (let x = 0; x < players.length; x++) {
-
-
               let info = this.game.createInformation(
                 "RevealInfo",
                 this.actor,
@@ -43,12 +41,11 @@ module.exports = class Omiscient extends Card {
               info.processInfo();
               info.getInfoRaw();
 
-
               let info2 = this.game.createInformation(
                 "TrackerInfo",
                 this.actor,
                 this.game,
-                players [x]
+                players[x]
               );
               info2.processInfo();
               this.actor.queueAlert(`:track: ${info2.getInfoFormated()}`);

--- a/Games/types/Mafia/roles/cards/Omniscient.js
+++ b/Games/types/Mafia/roles/cards/Omniscient.js
@@ -6,40 +6,6 @@ const { PRIORITY_INVESTIGATIVE_DEFAULT } = require("../../const/Priority");
 module.exports = class Omiscient extends Card {
   constructor(role) {
     super(role);
-    /*
-    this.actions = [
-      {
-        priority: PRIORITY_INVESTIGATIVE_DEFAULT,
-        labels: ["investigate"],
-        run: function () {
-          if (this.game.getStateName() != "Night") return;
-          if (!this.actor.alive) return;
-          let visits;
-          let visitNames;
-          let role;
-          let name;
-          let players = this.game.alivePlayers();
-          for (let x = 0; x < players.length; x++) {
-            visits = this.getVisits(players[x]);
-            visitNames = visits.map((p) => p.name);
-            role = players[x].role.name;
-            if (this.actor.hasEffect("FalseMode")) {
-              visits = this.getVisits(Random.randArrayVal(players));
-              visitNames = visits.map((p) => p.name);
-              role = Random.randArrayVal(players).role.name;
-            }
-            name = players[x].name;
-            if (visitNames.length == 0) visitNames.push("no one");
-            this.actor.queueAlert(
-              `:track: ${name}'s role is ${role} and they visited ${visitNames.join(
-                ", "
-              )} during the night.`
-            );
-          }
-        },
-      },
-    ];
-*/
 
     this.listeners = {
       state: function (stateInfo) {
@@ -64,21 +30,28 @@ module.exports = class Omiscient extends Card {
             let name;
             let players = this.game.alivePlayers();
             for (let x = 0; x < players.length; x++) {
-              visits = this.getVisits(players[x]);
-              visitNames = visits.map((p) => p.name);
-              role = players[x].role.name;
-              if (this.actor.hasEffect("FalseMode")) {
-                visits = this.getVisits(Random.randArrayVal(players));
-                visitNames = visits.map((p) => p.name);
-                role = Random.randArrayVal(players).role.name;
-              }
-              name = players[x].name;
-              if (visitNames.length == 0) visitNames.push("no one");
-              this.actor.queueAlert(
-                `:track: ${name}'s role is ${role} and they visited ${visitNames.join(
-                  ", "
-                )} during the night.`
+
+
+              let info = this.game.createInformation(
+                "RevealInfo",
+                this.actor,
+                this.game,
+                players[x],
+                null,
+                "Self"
               );
+              info.processInfo();
+              info.getInfoRaw();
+
+
+              let info2 = this.game.createInformation(
+                "TrackerInfo",
+                this.actor,
+                this.game,
+                players [x]
+              );
+              info2.processInfo();
+              this.actor.queueAlert(`:track: ${info2.getInfoFormated()}`);
             }
           },
         });

--- a/Games/types/Mafia/roles/cards/RevealEvilPlayersToSelf.js
+++ b/Games/types/Mafia/roles/cards/RevealEvilPlayersToSelf.js
@@ -25,7 +25,14 @@ module.exports = class RevealEvilPlayersToSelf extends Card {
           return;
         }
 
-        this.methods.revealEvilPlayers();
+        let info = this.game.createInformation(
+          "RevealEvilPlayersInfo",
+          this.player,
+          this.game
+        );
+        info.processInfo();
+        info.getInfoRaw();
+        //this.methods.revealEvilPlayers();
       },
     };
   }

--- a/Games/types/Mafia/roles/cards/TrueModifier.js
+++ b/Games/types/Mafia/roles/cards/TrueModifier.js
@@ -5,6 +5,10 @@ module.exports = class TrueModifier extends Card {
   constructor(role) {
     super(role);
 
+    this.hideModifier = {
+      self: true,
+    };
+
     this.startEffects = ["TrueMode"];
   }
 };

--- a/Games/types/Mafia/roles/cards/UnfavorableModifier.js
+++ b/Games/types/Mafia/roles/cards/UnfavorableModifier.js
@@ -5,6 +5,10 @@ module.exports = class UnfavorableModifier extends Card {
   constructor(role) {
     super(role);
 
+    this.hideModifier = {
+      self: true,
+    };
+
     this.startEffects = ["UnfavorableMode"];
   }
 };

--- a/Games/types/Mafia/roles/cards/WinWithCurrentAlignment.js
+++ b/Games/types/Mafia/roles/cards/WinWithCurrentAlignment.js
@@ -9,10 +9,7 @@ module.exports = class WinWithCurrentAlignment extends Card {
       priority: PRIORITY_WIN_CHECK_DEFAULT + 2,
       againOnFinished: true,
       check: function (counts, winners) {
-        if (
-          (this.player.alive || this.player.role.name == "Hitchhiker") &&
-          winners.groups[this.player.faction]
-        ) {
+        if (winners.groups[this.player.faction]) {
           winners.addPlayer(this.player, this.name);
         }
       },

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -557,7 +557,7 @@ const modifierData = {
       description:
         "If killed at night, a player with this modifier learns that 1 of 2 players is evil.",
     },
-    
+
     False: {
       internal: ["FalseModifier"],
       tags: ["FalseMode"],

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -557,7 +557,7 @@ const modifierData = {
       description:
         "If killed at night, a player with this modifier learns that 1 of 2 players is evil.",
     },
-    /*
+    
     False: {
       internal: ["FalseModifier"],
       tags: ["FalseMode"],
@@ -580,6 +580,7 @@ const modifierData = {
       description:
         "All Information made by this role will be favorable to the player being checked..",
     },
+    /*
     Red: {
       internal: ["BecomeRedMafia"],
       tags: ["Alignments"],

--- a/data/roles.js
+++ b/data/roles.js
@@ -499,7 +499,7 @@ const roleData = {
       category: "Investigative",
       tags: ["Investigative", "Information"],
       description: [
-        "Each night learns the number of players that created False Infomation.",
+        "Each night learns the number of False Infomation Created.",
       ],
       SpecialInteractions: {
         Journalist: ["Forensicist will not count Journalist info"],


### PR DESCRIPTION
(The Modifiers make the info do the thing) for all info excluding Statistician

Politician can now win when dead. 

Hitchhiker can win with Independent roles that visit it.

Removed the checking False Mode and the Picciotto False Mode.

Nyarlathotep can False Mode Seer and Retired roles now.

Notes: Rotten is the same as False for all info roles except Caroler, Comedian, Neighbor, and Santa.
