### PR TITLE
Fixed Events in Multi-Setups + Famine Event now makes players start with bread + Added Option to allow players to choose how many events occur each night

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -1000,7 +1000,7 @@ module.exports = class Game {
     if (this.anonymousGame) {
       this.makeGameAnonymous();
     }
-    
+
     var roleset = this.generateRoleset();
     let players = this.players.array();
 
@@ -1068,7 +1068,9 @@ module.exports = class Game {
       if (this.PossibleEvents[z].split(":")[0] == "Famine") {
         this.FamineEventPossible = true;
       }
-      if (this.getRoleTags(this.PossibleEvents[z]).includes("Pregame Actions")) {
+      if (
+        this.getRoleTags(this.PossibleEvents[z]).includes("Pregame Actions")
+      ) {
         this.HaveDuskOrDawn = true;
       }
       if (this.getSpecialInteractions(this.PossibleEvents[z]) != null) {
@@ -1196,7 +1198,7 @@ module.exports = class Game {
       this.rollQueue.shift();
     }
 
-    if(this.FamineEventPossible){
+    if (this.FamineEventPossible) {
       this.players.map((p) => p.holdItem("Bread"));
       this.players.map((p) => p.queueGetItemAlert("Bread"));
     }

--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -785,6 +785,7 @@ module.exports = class Game {
     this.banishedRoles = [];
     this.PossibleRoles = [];
     this.PossibleEvents = [];
+    this.CurrentEvents = [];
     this.BanishedEvents = [];
 
     for (let role in this.setup.roles[0]) {
@@ -847,6 +848,7 @@ module.exports = class Game {
     this.banishedRoles = [];
     this.PossibleRoles = [];
     this.PossibleEvents = [];
+    this.CurrentEvents = [];
     this.BanishedEvents = [];
 
     for (let i in this.setup.roles) {
@@ -938,6 +940,7 @@ module.exports = class Game {
     var roleset;
     this.PossibleRoles = [];
     this.PossibleEvents = [];
+    this.CurrentEvents = [];
     this.BanishedEvents = [];
 
     for (let i in this.setup.roles) {
@@ -997,7 +1000,7 @@ module.exports = class Game {
     if (this.anonymousGame) {
       this.makeGameAnonymous();
     }
-
+    
     var roleset = this.generateRoleset();
     let players = this.players.array();
 
@@ -1059,6 +1062,17 @@ module.exports = class Game {
       }
       if (this.getSpecialInteractions(this.PossibleRoles[z]) != null) {
         this.SpecialInteractionRoles.push(this.PossibleRoles[z]);
+      }
+    }
+    for (let z = 0; z < this.PossibleEvents.length; z++) {
+      if (this.PossibleEvents[z].split(":")[0] == "Famine") {
+        this.FamineEventPossible = true;
+      }
+      if (this.getRoleTags(this.PossibleEvents[z]).includes("Pregame Actions")) {
+        this.HaveDuskOrDawn = true;
+      }
+      if (this.getSpecialInteractions(this.PossibleEvents[z]) != null) {
+        this.SpecialInteractionRoles.push(this.PossibleEvents[z]);
       }
     }
     if (this.setup.closed && this.setup.banished > 0) {
@@ -1180,6 +1194,11 @@ module.exports = class Game {
     while (this.rollQueue.length < 0) {
       this.events.emit("SwitchRoleBefore", rollQueue[0]);
       this.rollQueue.shift();
+    }
+
+    if(this.FamineEventPossible){
+      this.players.map((p) => p.holdItem("Bread"));
+      this.players.map((p) => p.queueGetItemAlert("Bread"));
     }
 
     this.players.map((p) => p.role.revealToSelf(false));

--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -1008,8 +1008,8 @@ module.exports = class Game {
       let role = roleName.split(":")[0];
       if (this.getRoleAlignment(role) == "Event") {
         toDelete.push(roleName);
-        if(!this.BanishedEvents.includes(roleName)){
-        this.CurrentEvents.push(roleName);
+        if (!this.BanishedEvents.includes(roleName)) {
+          this.CurrentEvents.push(roleName);
         }
       }
       if (role != "Host") {

--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -838,7 +838,7 @@ module.exports = class Game {
         roleset[role]++;
       }
     }
-
+    this.CurrentEvents = this.PossibleEvents.filter((e) => e);
     return roleset;
   }
 
@@ -892,7 +892,7 @@ module.exports = class Game {
         finalRoleset[role]++;
       }
     }
-
+    this.CurrentEvents = this.PossibleEvents.filter((e) => e);
     return finalRoleset;
   }
 
@@ -1008,6 +1008,9 @@ module.exports = class Game {
       let role = roleName.split(":")[0];
       if (this.getRoleAlignment(role) == "Event") {
         toDelete.push(roleName);
+        if(!this.BanishedEvents.includes(roleName)){
+        this.CurrentEvents.push(roleName);
+        }
       }
       if (role != "Host") {
         continue;

--- a/Games/core/Meeting.js
+++ b/Games/core/Meeting.js
@@ -219,7 +219,10 @@ module.exports = class Meeting {
     var member = this.members[playerId] || {};
     var votes = {};
     var voteRecord = [];
-    var isExcludeSelf = this.targetsDescription && this.targetsDescription["exclude"] && this.targetsDescription["exclude"].includes("self");
+    var isExcludeSelf =
+      this.targetsDescription &&
+      this.targetsDescription["exclude"] &&
+      this.targetsDescription["exclude"].includes("self");
 
     if (this.voting) {
       if (member.id) {
@@ -259,8 +262,7 @@ module.exports = class Meeting {
           personalizedTargets.splice(indexOfSelf, 1);
         }
       }
-    }
-    else {
+    } else {
       personalizedTargets = this.targets;
     }
 
@@ -708,7 +710,10 @@ module.exports = class Meeting {
 
     this.finished = true;
 
-    var isExcludeSelf = this.targetsDescription && this.targetsDescription["exclude"] && this.targetsDescription["exclude"].includes("self");
+    var isExcludeSelf =
+      this.targetsDescription &&
+      this.targetsDescription["exclude"] &&
+      this.targetsDescription["exclude"].includes("self");
     var count = {};
     var highest = { targets: [], votes: 1 };
     var finalTarget;

--- a/Games/types/Mafia/Event.js
+++ b/Games/types/Mafia/Event.js
@@ -31,8 +31,8 @@ module.exports = class MafiaEvent extends Event {
         this.modifiers.includes("One Shot") &&
         !this.modifiers.includes("Banished")
       ) {
-        this.game.PossibleEvents.splice(
-          this.game.PossibleEvents.indexOf(this.fullName),
+        this.game.CurrentEvents.splice(
+          this.game.CurrentEvents.indexOf(this.fullName),
           1
         );
       } else if (

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -184,29 +184,31 @@ module.exports = class MafiaGame extends Game {
       this.alivePlayers()[0].holdItem("EventManager", 1);
       this.events.emit("ManageRandomEvents");
       */
-      for(let x = 0; (x < this.EventsPerNight && this.game.CurrentEvents.filter(
-            (e) =>
-              this.checkEvent(e.split(":")[0], e.split(":")[1]) == true
-          ).length > 0); x++){
+      for (
+        let x = 0;
+        x < this.EventsPerNight &&
+        this.game.CurrentEvents.filter(
+          (e) => this.checkEvent(e.split(":")[0], e.split(":")[1]) == true
+        ).length > 0;
+        x++
+      ) {
         let event;
         let eventMods;
         let eventName;
-        
-        let Events = this.game.CurrentEvents.filter(
-            (e) =>
-              this.checkEvent(e.split(":")[0], e.split(":")[1]) == true
-          );
-          if (Events.length <= 0) {
-            break;
-          }
-          event = Random.randArrayVal(Events);
-          eventMods = event.split(":")[1];
-          eventName = event.split(":")[0];
-          //this.game.queueAlert(`Manager ${eventMods}`);
-          event = this.createGameEvent(eventName, eventMods);
-          event.doEvent();
-          event = null;
 
+        let Events = this.game.CurrentEvents.filter(
+          (e) => this.checkEvent(e.split(":")[0], e.split(":")[1]) == true
+        );
+        if (Events.length <= 0) {
+          break;
+        }
+        event = Random.randArrayVal(Events);
+        eventMods = event.split(":")[1];
+        eventName = event.split(":")[0];
+        //this.game.queueAlert(`Manager ${eventMods}`);
+        event = this.createGameEvent(eventName, eventMods);
+        event.doEvent();
+        event = null;
       }
       this.selectedEvent = true;
     }

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -60,6 +60,7 @@ module.exports = class MafiaGame extends Game {
     this.RoomTwo = [];
     this.FinalRound = 3;
     this.CurrentRound = 0;
+    this.EventsPerNight = this.setup.EventsPerNight;
     this.lastNightVisits = [];
     this.infoLog = [];
   }
@@ -179,8 +180,35 @@ module.exports = class MafiaGame extends Game {
     }
     if (this.getStateName() == "Night" && this.PossibleEvents.length > 0) {
       this.selectedEvent = false;
+      /*
       this.alivePlayers()[0].holdItem("EventManager", 1);
       this.events.emit("ManageRandomEvents");
+      */
+      for(let x = 0; (x < this.EventsPerNight && this.game.CurrentEvents.filter(
+            (e) =>
+              this.checkEvent(e.split(":")[0], e.split(":")[1]) == true
+          ).length > 0); x++){
+        let event;
+        let eventMods;
+        let eventName;
+        
+        let Events = this.game.CurrentEvents.filter(
+            (e) =>
+              this.checkEvent(e.split(":")[0], e.split(":")[1]) == true
+          );
+          if (Events.length <= 0) {
+            break;
+          }
+          event = Random.randArrayVal(Events);
+          eventMods = event.split(":")[1];
+          eventName = event.split(":")[0];
+          //this.game.queueAlert(`Manager ${eventMods}`);
+          event = this.createGameEvent(eventName, eventMods);
+          event.doEvent();
+          event = null;
+
+      }
+      this.selectedEvent = true;
     }
     if (
       this.getStateName() == "Day" &&

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -2,6 +2,7 @@ const Game = require("../../core/Game");
 const Utils = require("../../core/Utils");
 const Player = require("./Player");
 const Event = require("./Event");
+const Random = require("../../../lib/Random");
 const Queue = require("../../core/Queue");
 const Winners = require("./Winners");
 const Action = require("./Action");
@@ -187,7 +188,7 @@ module.exports = class MafiaGame extends Game {
       for (
         let x = 0;
         x < this.EventsPerNight &&
-        this.game.CurrentEvents.filter(
+        this.CurrentEvents.filter(
           (e) => this.checkEvent(e.split(":")[0], e.split(":")[1]) == true
         ).length > 0;
         x++
@@ -196,7 +197,7 @@ module.exports = class MafiaGame extends Game {
         let eventMods;
         let eventName;
 
-        let Events = this.game.CurrentEvents.filter(
+        let Events = this.CurrentEvents.filter(
           (e) => this.checkEvent(e.split(":")[0], e.split(":")[1]) == true
         );
         if (Events.length <= 0) {

--- a/Games/types/Mafia/events/Feast.js
+++ b/Games/types/Mafia/events/Feast.js
@@ -28,12 +28,13 @@ module.exports = class Feast extends Event {
       run: function () {
         if (this.game.SilentEvents != false) {
           this.game.queueAlert(
-            `Event: Feast, The Town discovered a hidden create a Grand Feast will be Held!`
+            `Event: Feast, The Town discovered hidden rations a Grand Feast will be Held!`
           );
         }
         for (let person of this.game.players) {
           if (person.alive && person.role.name !== "Turkey") {
             person.holdItem("Food", "Bread");
+            person.queueGetItemAlert("Bread");
           }
         }
       },

--- a/Games/types/Mafia/items/CaveIn.js
+++ b/Games/types/Mafia/items/CaveIn.js
@@ -35,6 +35,7 @@ module.exports = class CaveIn extends Item {
               for (let person of this.game.players) {
                 if (person.alive && person.role.name !== "Turkey") {
                   person.holdItem("Food", "Fresh Meat");
+                  person.queueGetItemAlert("Mystery Meat");
                 }
               }
             }

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -148,6 +148,7 @@ var schemas = {
     AlignmentShare: Boolean,
     PrivateShare: Boolean,
     PublicShare: Boolean,
+    EventsPerNight: Number,
     swapAmt: Number,
     roundAmt: Number,
     firstTeamSize: Number,

--- a/react_main/src/pages/Play/CreateSetup/CreateMafiaSetup.jsx
+++ b/react_main/src/pages/Play/CreateSetup/CreateMafiaSetup.jsx
@@ -198,6 +198,14 @@ export default function CreateMafiaSetup() {
       value: false,
       type: "boolean",
     },
+    {
+      label: "Events Per Night",
+      ref: "EventsPerNight",
+      type: "number",
+      value: "1",
+      min: "0",
+      max: "5",
+    },
   ]);
 
   const formFieldValueMods = {
@@ -247,6 +255,7 @@ export default function CreateMafiaSetup() {
         AlignmentShare: formFields[26].value,
         PrivateShare: formFields[27].value,
         PublicShare: formFields[28].value,
+        EventsPerNight: formFields[29].value,
         editing: editing,
         id: params.get("edit"),
       })

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -405,6 +405,7 @@ router.post("/create", async function (req, res) {
     setup.AlignmentShare = Boolean(setup.AlignmentShare);
     setup.PrivateShare = Boolean(setup.PrivateShare);
     setup.PublicShare = Boolean(setup.PublicShare);
+    setup.EventsPerNight = Number(setup.EventsPerNight || 0);
 
     if (
       !routeUtils.validProp(setup.gameType) ||


### PR DESCRIPTION
Players can choose to allow 0-5 Events to occur each night.

Events will now only Occur within there setup. Closed setups unchanged.

If the Famine Event can Occur all players start with 1 bread.