### PR TITLE
Added support for animated custom emtoes

### DIFF
--- a/react_main/src/components/Form.jsx
+++ b/react_main/src/components/Form.jsx
@@ -140,7 +140,13 @@ export default function Form(props) {
         const yourEmotes = Object.keys(value).map((key) => (
           <div className="existing-custom-emote">
             <div>{key}</div>
-            <img src={"/" + value[key].path} key={key} />
+            <div
+              className="emote"
+              title={key}
+              style={{
+                backgroundImage: `url('/${value[key].path}')`,
+              }}
+            />
             <IconButton
               onClick={() =>
                 field.onCustomEmoteDelete(value[key].id, props.deps)
@@ -431,7 +437,13 @@ class EmoteUpload extends React.Component {
         <>
           <div className="emote-preview">
             <div>Preview of :{this.state.emoteText}:</div>
-            <img width={20} height={20} src={this.state.imageURI}></img>
+            <div
+              className="emote"
+              title={this.state.emoteText}
+              style={{
+                backgroundImage: `url('${this.state.imageURI}')`,
+              }}
+            />
             <div
               className="btn btn-theme"
               onClick={(e) => {

--- a/react_main/src/css/settings.css
+++ b/react_main/src/css/settings.css
@@ -92,6 +92,6 @@
   padding: 8px;
 }
 
-.settings .your-emotes img {
+.settings .your-emotes .emote {
   align-self: center;
 }


### PR DESCRIPTION
- Fixed the issue where custom emotes couldn't be animated
- Increased upload size of emotes to 30x30. In most contexts they will be resized to 20x20, but the quality is still better than if they were uploaded at 20x20
- Touched up displays of emotes on settings page to match the way that they're rendered in game

HOWEVER:
- animation is disabled if the uploaded file is greater than 30 height or width px, this is because the sharp library's resize image operation disables animation. Users will want to resize their animated files to 30x30 themselves. I see no workaround for this.
- animated GIFs with transparency don't seem to play nice with this library, e.g. ditto.gif. Users will want to find their own means of converting their GIF to webp with the correct transparency themselves. I haven't seen anyone else complaining about this issue with the library, so I'm not sure how it would be resolved