### PR TITLE
Added rehost button to most popular setups, refactored default options

### DIFF
--- a/react_main/src/pages/Play/Host/HostAcrotopia.jsx
+++ b/react_main/src/pages/Play/Host/HostAcrotopia.jsx
@@ -3,10 +3,11 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
+import getDefaults from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
-import { Lobbies, PreferredDeckId } from "../../../Constants";
+import { Lobbies } from "../../../Constants";
 
 import "../../../css/host.css";
 
@@ -16,18 +17,8 @@ export default function HostAcrotopia() {
   const [redirect, setRedirect] = useState(false);
   const siteInfo = useContext(SiteInfoContext);
   const errorAlert = useErrorAlert();
-
-  const defaults = JSON.parse(
-    localStorage.getItem("otherHostOptions") || null
-  ) || {
-    private: false,
-    guests: false,
-    spectating: false,
-    scheduled: false,
-    readyCheck: false,
-    anonymousGame: false,
-    anonymousDeckId: PreferredDeckId,
-  };
+  
+  const defaults = getDefaults(gameType);
 
   const [formFields, updateFormFields] = useForm([
     {
@@ -40,7 +31,7 @@ export default function HostAcrotopia() {
       label: "Round Amount",
       ref: "roundAmt",
       type: "number",
-      value: 5,
+      value: defaults.roundAmt,
       min: 3,
       max: 10,
     },
@@ -48,7 +39,7 @@ export default function HostAcrotopia() {
       label: "Acronym Size",
       ref: "acronymSize",
       type: "number",
-      value: 5,
+      value: defaults.acronymSize,
       min: 3,
       max: 7,
     },
@@ -56,19 +47,19 @@ export default function HostAcrotopia() {
       label: "Enable Punctuation",
       ref: "enablePunctuation",
       type: "boolean",
-      value: true,
+      value: defaults.enablePunctuation,
     },
     {
       label: "Standardise Capitalisation",
       ref: "standardiseCapitalisation",
       type: "boolean",
-      value: true,
+      value: defaults.standardiseCapitalisation,
     },
     {
       label: "Turn On Caps",
       ref: "turnOnCaps",
       type: "boolean",
-      value: true,
+      value: defaults.turnOnCaps,
       showIf: "standardiseCapitalisation",
     },
     {

--- a/react_main/src/pages/Play/Host/HostDefaults.js
+++ b/react_main/src/pages/Play/Host/HostDefaults.js
@@ -1,0 +1,109 @@
+import { Lobbies, PreferredDeckId } from "../../../Constants";
+
+const otherHostOptions = JSON.parse(
+    localStorage.getItem("otherHostOptions") || null
+) || {
+    private: false,
+    guests: false,
+    spectating: false,
+    scheduled: false,
+    readyCheck: false,
+    anonymousGame: false,
+    anonymousDeckId: PreferredDeckId,
+};
+
+// Delete pre-existing incompatible settings
+var existingMafiaHostOptions = JSON.parse(localStorage.getItem("mafiaHostOptions") || null);
+if (existingMafiaHostOptions && existingMafiaHostOptions.stateLengths === undefined) {
+    localStorage.removeItem("mafiaHostOptions");
+    existingMafiaHostOptions = null;
+}
+
+var defaultOptions = {
+    "Mafia": existingMafiaHostOptions || {
+        ...otherHostOptions,
+        ranked: false,
+        competitive: false,
+        broadcastClosedRoles: false,
+        noVeg: false,
+        pregameWaitLength: 1,
+        extendLength: 3,
+        stateLengths: {
+            Day: 10,
+            Night: 2,
+        },
+    },
+    "Acrotopia": {
+        ...otherHostOptions,
+        roundAmt: 5,
+        acronymSize: 5,
+        enablePunctuation: true,
+        standardiseCapitalisation: true,
+        turnOnCaps: true,
+    },
+    "Ghost": {
+        ...otherHostOptions,
+        configureWords: false,
+        wordLength: 5,
+        guessWordLength: 2,
+        giveClueLength: 2,
+        stateLengths: {
+            Day: 5,
+            Night: .5,
+        },
+    },
+    "Jotto": {
+        ...otherHostOptions,
+        wordLength: 5,
+        duplicateLetters: false,
+        competitiveMode: false,
+        winOnAnagrams: true,
+        numAnagramsRequired: 3,
+        selectWordLength: 1,
+        guessWordLength: 1,
+    },
+    "Liars Dice": {
+        ...otherHostOptions,
+        startingDice: 5,
+        wildOnes: true,
+        spotOn: false,
+        guessDiceLength: 2,
+    },
+    "Resistance": {
+        ...otherHostOptions,
+        teamSelLength: 2,
+        teamApprovalLength: 0.5,
+        missionLength: 0.5,
+    },
+    "Secret Dictator": {
+        ...otherHostOptions,
+        nominationLength: 1,
+        electionLength: 2,
+        legislativeSessionLength: 2,
+        executiveActionLength: 1,
+        specialNominationLength: 1,
+    },
+    "Wacky Words": {
+        ...otherHostOptions,
+        roundAmt: 5,
+        acronymSize: 5,
+        enablePunctuation: true,
+        standardiseCapitalisation: true,
+        turnOnCaps: true,
+        stateLengths: {
+            Day: 5,
+            Night: 2,
+        },
+    },
+};
+
+export default function getDefaults(gameType) {
+    const defaults = defaultOptions[gameType];
+    if(defaults) {
+        return defaults;
+    }
+    else {
+        console.error(`Could not find default options for: ${gameType}. Please report this error.`)
+        return null;
+    }
+}

--- a/react_main/src/pages/Play/Host/HostGhost.jsx
+++ b/react_main/src/pages/Play/Host/HostGhost.jsx
@@ -3,10 +3,11 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
+import getDefaults from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
-import { Lobbies, PreferredDeckId } from "../../../Constants";
+import { Lobbies } from "../../../Constants";
 
 import "../../../css/host.css";
 
@@ -17,17 +18,7 @@ export default function HostGhost() {
   const siteInfo = useContext(SiteInfoContext);
   const errorAlert = useErrorAlert();
 
-  const defaults = JSON.parse(
-    localStorage.getItem("otherHostOptions") || null
-  ) || {
-    private: false,
-    guests: false,
-    spectating: false,
-    scheduled: false,
-    readyCheck: false,
-    anonymousGame: false,
-    anonymousDeckId: PreferredDeckId,
-  };
+  const defaults = getDefaults(gameType);
 
   let defaultLobby = localStorage.getItem("lobby");
   if (
@@ -49,13 +40,13 @@ export default function HostGhost() {
       label: "Configure Words",
       ref: "configureWords",
       type: "boolean",
-      value: false,
+      value: defaults.configureWords,
     },
     {
       label: "Word Length",
       ref: "wordLength",
       type: "number",
-      value: 5,
+      value: defaults.wordLength,
       min: 3,
       max: 10,
       showIf: "configureWords",
@@ -136,7 +127,7 @@ export default function HostGhost() {
       ref: "nightLength",
       type: "number",
       showIf: "configureDuration",
-      value: 0.5,
+      value: defaults.stateLengths["Night"],
       min: 0.5,
       max: 1,
       step: 0.5,
@@ -146,7 +137,7 @@ export default function HostGhost() {
       ref: "giveClueLength",
       type: "number",
       showIf: "configureDuration",
-      value: 2,
+      value: defaults.giveClueLength,
       min: 1,
       max: 2,
       step: 0.5,
@@ -156,7 +147,7 @@ export default function HostGhost() {
       ref: "dayLength",
       type: "number",
       showIf: "configureDuration",
-      value: 5,
+      value: defaults.stateLengths["Day"],
       min: 2,
       max: 5,
       step: 1,
@@ -166,7 +157,7 @@ export default function HostGhost() {
       ref: "guessWordLength",
       type: "number",
       showIf: "configureDuration",
-      value: 2,
+      value: defaults.guessWordLength,
       min: 1,
       max: 3,
       step: 0.5,

--- a/react_main/src/pages/Play/Host/HostJotto.jsx
+++ b/react_main/src/pages/Play/Host/HostJotto.jsx
@@ -3,10 +3,11 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
+import getDefaults from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
-import { Lobbies, PreferredDeckId } from "../../../Constants";
+import { Lobbies } from "../../../Constants";
 
 import "../../../css/host.css";
 
@@ -17,17 +18,7 @@ export default function HostJotto() {
   const siteInfo = useContext(SiteInfoContext);
   const errorAlert = useErrorAlert();
 
-  const defaults = JSON.parse(
-    localStorage.getItem("otherHostOptions") || null
-  ) || {
-    private: false,
-    guests: false,
-    spectating: false,
-    scheduled: false,
-    readyCheck: false,
-    anonymousGame: false,
-    anonymousDeckId: PreferredDeckId,
-  };
+  const defaults = getDefaults(gameType);
 
   let defaultLobby = localStorage.getItem("lobby");
   if (
@@ -48,7 +39,7 @@ export default function HostJotto() {
       label: "Word Length",
       ref: "wordLength",
       type: "number",
-      value: 5,
+      value: defaults.wordLength,
       min: 4,
       max: 5,
     },
@@ -56,25 +47,25 @@ export default function HostJotto() {
       label: "Duplicate Letters",
       ref: "duplicateLetters",
       type: "boolean",
-      value: false,
+      value: defaults.duplicateLetters,
     },
     {
       label: "Competitive Mode",
       ref: "competitiveMode",
       type: "boolean",
-      value: false,
+      value: defaults.competitiveMode,
     },
     {
       label: "Win With Anagrams",
       ref: "winOnAnagrams",
       type: "boolean",
-      value: true,
+      value: defaults.winOnAnagrams,
     },
     {
       label: "No. Anagrams Required",
       ref: "numAnagramsRequired",
       type: "number",
-      value: 3,
+      value: defaults.numAnagramsRequired,
       min: 1,
       max: 4,
       showIf: "winOnAnagrams",
@@ -143,7 +134,7 @@ export default function HostJotto() {
       ref: "selectWordLength",
       type: "number",
       showIf: "configureDuration",
-      value: 1,
+      value: defaults.selectWordLength,
       min: 0.5,
       max: 5,
       step: 0.5,
@@ -153,7 +144,7 @@ export default function HostJotto() {
       ref: "guessWordLength",
       type: "number",
       showIf: "configureDuration",
-      value: 1,
+      value: defaults.guessWordLength,
       min: 0.5,
       max: 5,
       step: 0.5,

--- a/react_main/src/pages/Play/Host/HostLiarsDice.jsx
+++ b/react_main/src/pages/Play/Host/HostLiarsDice.jsx
@@ -3,10 +3,11 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
+import getDefaults from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
-import { Lobbies, PreferredDeckId } from "../../../Constants";
+import { Lobbies } from "../../../Constants";
 
 import "../../../css/host.css";
 
@@ -17,17 +18,7 @@ export default function HostLiarsDice() {
   const siteInfo = useContext(SiteInfoContext);
   const errorAlert = useErrorAlert();
 
-  const defaults = JSON.parse(
-    localStorage.getItem("otherHostOptions") || null
-  ) || {
-    private: false,
-    guests: false,
-    spectating: false,
-    scheduled: false,
-    readyCheck: false,
-    anonymousGame: false,
-    anonymousDeckId: PreferredDeckId,
-  };
+  const defaults = getDefaults(gameType);
 
   let defaultLobby = localStorage.getItem("lobby");
   if (
@@ -48,19 +39,19 @@ export default function HostLiarsDice() {
       label: "Wild Ones",
       ref: "wildOnes",
       type: "boolean",
-      value: true,
+      value: defaults.wildOnes,
     },
     {
       label: "Spot On",
       ref: "spotOn",
       type: "boolean",
-      value: false,
+      value: defaults.spotOn,
     },
     {
       label: "Starting Dice",
       ref: "startingDice",
       type: "number",
-      value: 5,
+      value: defaults.startingDice,
       min: 1,
       max: 20,
     },
@@ -128,7 +119,7 @@ export default function HostLiarsDice() {
       ref: "guessDiceLength",
       type: "number",
       showIf: "configureDuration",
-      value: 2,
+      value: defaults.guessDiceLength,
       min: 0.5,
       max: 5,
       step: 0.5,

--- a/react_main/src/pages/Play/Host/HostMafia.jsx
+++ b/react_main/src/pages/Play/Host/HostMafia.jsx
@@ -3,9 +3,10 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
+import getDefaults from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
-import { Lobbies, PreferredDeckId } from "../../../Constants";
+import { Lobbies } from "../../../Constants";
 
 import "../../../css/host.css";
 
@@ -14,26 +15,7 @@ export default function HostMafia() {
   const [selSetup, setSelSetup] = useState({});
   const [redirect, setRedirect] = useState(false);
 
-  const defaults = JSON.parse(
-    localStorage.getItem("mafiaHostOptions") || null
-  ) || {
-    private: false,
-    guests: false,
-    ranked: false,
-    competitive: false,
-    spectating: false,
-    broadcastClosedRoles: false,
-    scheduled: false,
-    readyCheck: false,
-    noVeg: false,
-    pregameWaitLength: 1,
-    dayLength: 10,
-    nightLength: 2,
-    extendLength: 3,
-    anonymousGame: false,
-    anonymousDeckId: PreferredDeckId,
-    noVeg: false,
-  };
+  const defaults = getDefaults(gameType);
 
   const errorAlert = useErrorAlert();
   const [formFields, updateFormFields] = useForm([
@@ -134,7 +116,7 @@ export default function HostMafia() {
       label: "Day Length (minutes)",
       ref: "dayLength",
       type: "number",
-      value: defaults.dayLength,
+      value: defaults.stateLengths["Day"],
       min: 1,
       max: 30,
     },
@@ -142,7 +124,7 @@ export default function HostMafia() {
       label: "Night Length (minutes)",
       ref: "nightLength",
       type: "number",
-      value: defaults.nightLength,
+      value: defaults.stateLengths["Night"],
       min: 1,
       max: 10,
     },

--- a/react_main/src/pages/Play/Host/HostResistance.jsx
+++ b/react_main/src/pages/Play/Host/HostResistance.jsx
@@ -3,10 +3,11 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
+import getDefaults from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
-import { Lobbies, PreferredDeckId } from "../../../Constants";
+import { Lobbies } from "../../../Constants";
 
 import "../../../css/host.css";
 
@@ -17,17 +18,7 @@ export default function HostResistance() {
   const siteInfo = useContext(SiteInfoContext);
   const errorAlert = useErrorAlert();
 
-  const defaults = JSON.parse(
-    localStorage.getItem("otherHostOptions") || null
-  ) || {
-    private: false,
-    guests: false,
-    spectating: false,
-    scheduled: false,
-    readyCheck: false,
-    anonymousGame: false,
-    anonymousDeckId: PreferredDeckId,
-  };
+  const defaults = getDefaults(gameType);
 
   let defaultLobby = localStorage.getItem("lobby");
   if (
@@ -103,7 +94,7 @@ export default function HostResistance() {
       label: "Team Selection Length (minutes)",
       ref: "teamSelLength",
       type: "number",
-      value: 2,
+      value: defaults.teamSelLength,
       min: 1,
       max: 5,
     },
@@ -111,7 +102,7 @@ export default function HostResistance() {
       label: "Team Approval Length (minutes)",
       ref: "teamApprovalLength",
       type: "number",
-      value: 0.5,
+      value: defaults.teamApprovalLength,
       min: 0.1,
       max: 2,
       step: 0.1,
@@ -120,7 +111,7 @@ export default function HostResistance() {
       label: "Mission Length (minutes)",
       ref: "missionLength",
       type: "number",
-      value: 0.5,
+      value: defaults.missionLength,
       min: 0.1,
       max: 1,
       step: 0.1,

--- a/react_main/src/pages/Play/Host/HostSecretDictator.jsx
+++ b/react_main/src/pages/Play/Host/HostSecretDictator.jsx
@@ -3,6 +3,7 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
+import getDefaults from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
@@ -17,17 +18,7 @@ export default function HostSecretDictator() {
   const siteInfo = useContext(SiteInfoContext);
   const errorAlert = useErrorAlert();
 
-  const defaults = JSON.parse(
-    localStorage.getItem("otherHostOptions") || null
-  ) || {
-    private: false,
-    guests: false,
-    spectating: false,
-    scheduled: false,
-    readyCheck: false,
-    anonymousGame: false,
-    anonymousDeckId: PreferredDeckId,
-  };
+  const defaults = getDefaults(gameType);
 
   let defaultLobby = localStorage.getItem("lobby");
   if (
@@ -108,7 +99,7 @@ export default function HostSecretDictator() {
       ref: "nominationLength",
       type: "number",
       showIf: "configureDuration",
-      value: 1,
+      value: defaults.nominationLength,
       min: 0.5,
       max: 30,
       step: 0.5,
@@ -118,7 +109,7 @@ export default function HostSecretDictator() {
       ref: "electionLength",
       type: "number",
       showIf: "configureDuration",
-      value: 2,
+      value: defaults.electionLength,
       min: 0.5,
       max: 30,
       step: 0.5,
@@ -128,7 +119,7 @@ export default function HostSecretDictator() {
       ref: "legislativeSessionLength",
       type: "number",
       showIf: "configureDuration",
-      value: 2,
+      value: defaults.legislativeSessionLength,
       min: 0.5,
       max: 30,
       step: 0.5,
@@ -138,7 +129,7 @@ export default function HostSecretDictator() {
       ref: "executiveActionLength",
       type: "number",
       showIf: "configureDuration",
-      value: 1,
+      value: defaults.executiveActionLength,
       min: 0.5,
       max: 30,
       step: 0.5,
@@ -148,7 +139,7 @@ export default function HostSecretDictator() {
       ref: "specialNominationLength",
       type: "number",
       showIf: "configureDuration",
-      value: 1,
+      value: defaults.specialNominationLength,
       min: 0.5,
       max: 30,
       step: 0.5,

--- a/react_main/src/pages/Play/Host/HostWackyWords.jsx
+++ b/react_main/src/pages/Play/Host/HostWackyWords.jsx
@@ -3,6 +3,7 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
+import getDefaults from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
@@ -17,17 +18,7 @@ export default function HostWackyWords() {
   const siteInfo = useContext(SiteInfoContext);
   const errorAlert = useErrorAlert();
 
-  const defaults = JSON.parse(
-    localStorage.getItem("otherHostOptions") || null
-  ) || {
-    private: false,
-    guests: false,
-    spectating: false,
-    scheduled: false,
-    readyCheck: false,
-    anonymousGame: false,
-    anonymousDeckId: PreferredDeckId,
-  };
+  const defaults = getDefaults(gameType);
 
   const [formFields, updateFormFields] = useForm([
     {
@@ -40,7 +31,7 @@ export default function HostWackyWords() {
       label: "Round Amount",
       ref: "roundAmt",
       type: "number",
-      value: 5,
+      value: defaults.roundAmt,
       min: 3,
       max: 15,
     },
@@ -48,7 +39,7 @@ export default function HostWackyWords() {
       label: "Acronym Size",
       ref: "acronymSize",
       type: "number",
-      value: 5,
+      value: defaults.acronymSize,
       min: 3,
       max: 7,
     },
@@ -56,19 +47,19 @@ export default function HostWackyWords() {
       label: "Enable Punctuation",
       ref: "enablePunctuation",
       type: "boolean",
-      value: true,
+      value: defaults.enablePunctuation,
     },
     {
       label: "Standardise Capitalisation",
       ref: "standardiseCapitalisation",
       type: "boolean",
-      value: true,
+      value: defaults.standardiseCapitalisation,
     },
     {
       label: "Turn On Caps",
       ref: "turnOnCaps",
       type: "boolean",
-      value: true,
+      value: defaults.turnOnCaps,
       showIf: "standardiseCapitalisation",
     },
     {
@@ -135,7 +126,7 @@ export default function HostWackyWords() {
       ref: "nightLength",
       type: "number",
       showIf: "configureDuration",
-      value: 2,
+      value: defaults.stateLengths["Night"],
       min: 1,
       max: 5,
       step: 1,
@@ -145,7 +136,7 @@ export default function HostWackyWords() {
       ref: "dayLength",
       type: "number",
       showIf: "configureDuration",
-      value: 5,
+      value: defaults.stateLengths["Day"],
       min: 2,
       max: 5,
       step: 1,

--- a/react_main/src/pages/Play/LobbyBrowser/RecentlyPlayedSetups.jsx
+++ b/react_main/src/pages/Play/LobbyBrowser/RecentlyPlayedSetups.jsx
@@ -1,14 +1,25 @@
-import React, { useEffect, useRef, useState } from "react";
-import { Box, Card, Typography } from "@mui/material";
+import React, { useEffect, useRef, useState, useContext } from "react";
+import axios from "axios";
+import { Redirect } from "react-router-dom";
+import { Box, Card, IconButton, Typography } from "@mui/material";
+import { UserContext } from "../../../Contexts";
+import { useErrorAlert } from "../../../components/Alerts";
 import { getRecentlyPlayedSetups } from "../../../services/gameService";
+import getDefaults from "../Host/HostDefaults";
 import Setup from "../../../components/Setup";
 import { getRecentlyPlayedSetupsChart } from "./getRecentlyPlayedSetupsChart";
 import { useTheme } from "@mui/styles";
+import { useIsPhoneDevice } from "../../../hooks/useIsPhoneDevice";
 
 export const RecentlyPlayedSetups = ({ daysInterval = 7 }) => {
   const theme = useTheme();
   const svgRef = useRef();
   const [setups, setSetups] = useState([]);
+  const [redirect, setRedirect] = useState(false);
+
+  const user = useContext(UserContext);
+  const errorAlert = useErrorAlert();
+  const isPhoneDevice = useIsPhoneDevice();
 
   useEffect(() => {
     (async () => {
@@ -31,8 +42,35 @@ export const RecentlyPlayedSetups = ({ daysInterval = 7 }) => {
     return "";
   }
 
-  const setupRows = setups.map((setup) => (
-    <Box
+  const setupRows = setups.map((setup) => {
+    const onRehostClick = () => {
+      let lobby = localStorage.getItem("lobby") || "All";
+      let gameType = setup.setupDetails.gameType;
+  
+      const defaults = getDefaults(gameType);
+  
+      if (lobby === "All") lobby = "Main";
+      if (gameType !== "Mafia" && lobby === "Main") {
+        lobby = "Games";
+      }
+
+      axios
+        .post("/game/host", {
+          gameType: gameType,
+          setup: setup.setupDetails.id,
+          lobby: lobby,
+          ranked: setup.setupDetails.ranked,
+          ...defaults
+        })
+        .then((res) => setRedirect(`/game/${res.data}`))
+        .catch(errorAlert);
+    };
+
+    if (redirect) return <Redirect to={redirect} />;
+
+    const showRedoButton = isPhoneDevice ? user.loggedIn : true;
+
+    return (<Box
       key={`recently-played-${setup._id}`}
       sx={{
         display: "flex",
@@ -42,8 +80,17 @@ export const RecentlyPlayedSetups = ({ daysInterval = 7 }) => {
     >
       <Setup setup={setup.setupDetails} />
       <Typography variant="body2">{setup.setupDetails.name}</Typography>
+      {showRedoButton && (
+        <Box style={{ mx: 1, width: "32px", textAlign: "center" }}>
+          {user.loggedIn && (
+            <IconButton color="primary" onClick={onRehostClick}>
+              <i className="rehost fas fa-redo" title="Rehost" />
+            </IconButton>
+          )}
+        </Box>
+      )}
     </Box>
-  ));
+  )});
 
   return (
     <Card variant="outlined">


### PR DESCRIPTION
I had to refactor the default options quite a bit since the most played setups component has no context for what options it should use for hosted setups, unlike the existing game browser rehost button which can just pull them from the finished game.

The defaults will be used when rehosting via popular setups. This might not be ideal for certain modes such as liar's dice - you can't use that rehost button to start a lobby with spot on turned on for example.

I tested the hosting of each minigame to make sure things didn't break.