### PR TITLE
More Delirum Changes + Oracle Fix

### DIFF
--- a/Games/types/Mafia/roles/cards/CauseBanishedEventsOnDeath.js
+++ b/Games/types/Mafia/roles/cards/CauseBanishedEventsOnDeath.js
@@ -13,7 +13,10 @@ module.exports = class CauseBanishedEventsOnDeath extends Card {
         if (this.player.alive) {
           return;
         }
-
+        if (!this.player.hasAbility(["Event", "WhenDead"])) {
+          return;
+        }
+        
         if (!stateInfo.name.match(/Night/)) {
           return;
         }

--- a/Games/types/Mafia/roles/cards/CauseBanishedEventsOnDeath.js
+++ b/Games/types/Mafia/roles/cards/CauseBanishedEventsOnDeath.js
@@ -16,7 +16,7 @@ module.exports = class CauseBanishedEventsOnDeath extends Card {
         if (!this.player.hasAbility(["Event", "WhenDead"])) {
           return;
         }
-        
+
         if (!stateInfo.name.match(/Night/)) {
           return;
         }

--- a/Games/types/Mafia/roles/cards/ChoosePlayerOnDeath.js
+++ b/Games/types/Mafia/roles/cards/ChoosePlayerOnDeath.js
@@ -22,9 +22,13 @@ module.exports = class ChoosePlayerOnDeath extends Card {
             //this.hasChoosen = true;
             this.actor.role.revived = true;
 
+            if (!this.actor.hasAbility(["Win-Con", "WhenDead"])) {
+            return;
+            }
+
             if (this.target.role.alignment != "Village") {
               for (let p of this.game.alivePlayers()) {
-                if (p.role.alignment === "Village") {
+                if (p.faction === this.actor.faction) {
                   p.kill("basic", this.actor, true);
                 }
               }

--- a/Games/types/Mafia/roles/cards/ChoosePlayerOnDeath.js
+++ b/Games/types/Mafia/roles/cards/ChoosePlayerOnDeath.js
@@ -23,7 +23,7 @@ module.exports = class ChoosePlayerOnDeath extends Card {
             this.actor.role.revived = true;
 
             if (!this.actor.hasAbility(["Win-Con", "WhenDead"])) {
-            return;
+              return;
             }
 
             if (this.target.role.alignment != "Village") {

--- a/Games/types/Mafia/roles/cards/ConvertTownBlueOnDeath.js
+++ b/Games/types/Mafia/roles/cards/ConvertTownBlueOnDeath.js
@@ -7,7 +7,7 @@ module.exports = class ConvertTownBlueOnDeath extends Card {
       death: function (player, killer, instant) {
         if (!this.player.hasAbility(["Convert", "WhenDead"])) {
           return;
-         }
+        }
         if (player == this.player) {
           this.game.queueAlert(
             "The Schoolmarm has died… who will be left to teach anyone?"

--- a/Games/types/Mafia/roles/cards/ConvertTownBlueOnDeath.js
+++ b/Games/types/Mafia/roles/cards/ConvertTownBlueOnDeath.js
@@ -5,6 +5,9 @@ module.exports = class ConvertTownBlueOnDeath extends Card {
     super(role);
     this.listeners = {
       death: function (player, killer, instant) {
+        if (!this.player.hasAbility(["Convert", "WhenDead"])) {
+          return;
+         }
         if (player == this.player) {
           this.game.queueAlert(
             "The Schoolmarm has died… who will be left to teach anyone?"

--- a/Games/types/Mafia/roles/cards/DisableVotingIfDeadAtNight.js
+++ b/Games/types/Mafia/roles/cards/DisableVotingIfDeadAtNight.js
@@ -11,7 +11,7 @@ module.exports = class DisableVotingIfDeadAtNight extends Card {
         }
         if (!this.player.hasAbility(["WhenDead"])) {
           return;
-         }
+        }
 
         if (this.game.getStateName() != "Night") {
           return;

--- a/Games/types/Mafia/roles/cards/DisableVotingIfDeadAtNight.js
+++ b/Games/types/Mafia/roles/cards/DisableVotingIfDeadAtNight.js
@@ -9,6 +9,9 @@ module.exports = class DisableVotingIfDeadAtNight extends Card {
         if (player != this.player) {
           return;
         }
+        if (!this.player.hasAbility(["WhenDead"])) {
+          return;
+         }
 
         if (this.game.getStateName() != "Night") {
           return;

--- a/Games/types/Mafia/roles/cards/EclipseOnDeath.js
+++ b/Games/types/Mafia/roles/cards/EclipseOnDeath.js
@@ -6,6 +6,9 @@ module.exports = class EclipseOnDeath extends Card {
 
     this.listeners = {
       death: function (player, killer, killType) {
+        if (!this.player.hasAbility(["Effect", "WhenDead"])) {
+          return;
+         }
         if (player == this.player) this.data.causeEclipse = true;
       },
       state: function (stateInfo) {

--- a/Games/types/Mafia/roles/cards/EclipseOnDeath.js
+++ b/Games/types/Mafia/roles/cards/EclipseOnDeath.js
@@ -8,7 +8,7 @@ module.exports = class EclipseOnDeath extends Card {
       death: function (player, killer, killType) {
         if (!this.player.hasAbility(["Effect", "WhenDead"])) {
           return;
-         }
+        }
         if (player == this.player) this.data.causeEclipse = true;
       },
       state: function (stateInfo) {

--- a/Games/types/Mafia/roles/cards/GiveShavingCreamOnDeath.js
+++ b/Games/types/Mafia/roles/cards/GiveShavingCreamOnDeath.js
@@ -7,11 +7,10 @@ module.exports = class GiveShavingCreamOnDeath extends Card {
     this.listeners = {
       death: function (player, killer, instant) {
         if (player == this.player) {
+          if (!this.player.hasAbility(["Item", "WhenDead"])) {
+            return;
+          }
 
-        if (!this.player.hasAbility(["Item", "WhenDead"])) {
-          return;
-        }
-          
           let alive = this.game.alivePlayers();
           var evilPlayers = alive.filter(
             (p) =>

--- a/Games/types/Mafia/roles/cards/GiveShavingCreamOnDeath.js
+++ b/Games/types/Mafia/roles/cards/GiveShavingCreamOnDeath.js
@@ -7,6 +7,11 @@ module.exports = class GiveShavingCreamOnDeath extends Card {
     this.listeners = {
       death: function (player, killer, instant) {
         if (player == this.player) {
+
+        if (!this.player.hasAbility(["Item", "WhenDead"])) {
+          return;
+        }
+          
           let alive = this.game.alivePlayers();
           var evilPlayers = alive.filter(
             (p) =>

--- a/Games/types/Mafia/roles/cards/IfVotedForceCondemn.js
+++ b/Games/types/Mafia/roles/cards/IfVotedForceCondemn.js
@@ -5,7 +5,7 @@ const { PRIORITY_OVERTHROW_VOTE } = require("../../const/Priority");
 module.exports = class IfVotedForceCondemn extends Card {
   constructor(role) {
     super(role);
-    
+
     this.listeners = {
       vote: function (vote) {
         if (vote.meeting.name === "Village" && vote.target === this.player.id) {
@@ -14,8 +14,8 @@ module.exports = class IfVotedForceCondemn extends Card {
           this.player.role.data.hasBeenVoted = true;
           this.player.role.data.playerVoter = 0;
           if (!this.player.hasAbility(["Condemn"])) {
-          return;
-         }
+            return;
+          }
           if (
             this.game.getRoleAlignment(
               vote.voter.getRoleAppearance().split(" (")[0]

--- a/Games/types/Mafia/roles/cards/IfVotedForceCondemn.js
+++ b/Games/types/Mafia/roles/cards/IfVotedForceCondemn.js
@@ -5,40 +5,7 @@ const { PRIORITY_OVERTHROW_VOTE } = require("../../const/Priority");
 module.exports = class IfVotedForceCondemn extends Card {
   constructor(role) {
     super(role);
-    /*
-    this.actions = [
-      {
-        priority: PRIORITY_OVERTHROW_VOTE - 1,
-        labels: ["hidden", "absolute", "condemn", "overthrow"],
-        run: function () {
-          if (this.game.getStateName() != "Day") return;
-
-          //let villageMeeting = this.game.getMeetingByName("Village");
-
-          if (
-            !this.actor.role.data.hasBeenVoted ||
-            this.actor.role.data.playerVoter == 0
-          ) {
-            return;
-          }
-
-          //New code
-          for (let action of this.game.actions[0]) {
-            if (action.hasLabel("condemn") && !action.hasLabel("overthrow")) {
-              // Only one village vote can be overthrown
-              action.cancel(true);
-              break;
-            }
-          }
-
-          if (this.dominates(this.actor.role.data.playerVoter)) {
-            this.actor.role.data.playerVoter.kill("condemn", this.actor);
-          }
-          this.actor.role.data.playerVoter = 0;
-        },
-      },
-    ];
-*/
+    
     this.listeners = {
       vote: function (vote) {
         if (vote.meeting.name === "Village" && vote.target === this.player.id) {
@@ -46,7 +13,9 @@ module.exports = class IfVotedForceCondemn extends Card {
 
           this.player.role.data.hasBeenVoted = true;
           this.player.role.data.playerVoter = 0;
-
+          if (!this.player.hasAbility(["Condemn"])) {
+          return;
+         }
           if (
             this.game.getRoleAlignment(
               vote.voter.getRoleAppearance().split(" (")[0]
@@ -95,42 +64,6 @@ module.exports = class IfVotedForceCondemn extends Card {
         if (!stateInfo.name.match(/Day/)) {
           return;
         }
-        /*
-        var action = new Action({
-          actor: this.player,
-          game: this.player.game,
-          priority: PRIORITY_OVERTHROW_VOTE - 1,
-          labels: ["hidden", "absolute", "condemn", "overthrow"],
-          run: function () {
-            if (this.game.getStateName() != "Day") return;
-
-            //let villageMeeting = this.game.getMeetingByName("Village");
-
-            if (
-              !this.actor.role.data.hasBeenVoted ||
-              this.actor.role.data.playerVoter == 0
-            ) {
-              return;
-            }
-
-            //New code
-            for (let action of this.game.actions[0]) {
-              if (action.hasLabel("condemn") && !action.hasLabel("overthrow")) {
-                // Only one village vote can be overthrown
-                action.cancel(true);
-                break;
-              }
-            }
-
-            if (this.dominates(this.actor.role.data.playerVoter)) {
-              this.actor.role.data.playerVoter.kill("condemn", this.actor);
-            }
-            this.actor.role.data.playerVoter = 0;
-          },
-        });
-
-        this.game.queueAction(action);
-        */
       },
     };
   }

--- a/Games/types/Mafia/roles/cards/KillVillagePlayerOnDeath.js
+++ b/Games/types/Mafia/roles/cards/KillVillagePlayerOnDeath.js
@@ -26,9 +26,9 @@ module.exports = class KillVillagePlayerOnDeath extends Card {
             this.game.queueAlert(
               `${this.actor.name} the ${this.actor.role.name} has selected ${this.target.name}. If ${this.target.name} is Village Aligned they will die tonight.`
             );
-            
+
             if (!this.actor.hasAbility(["Kill", "WhenDead"])) {
-            return;
+              return;
             }
             //this.hasChoosen = true;
             this.actor.role.SelectedPlayer = this.target;

--- a/Games/types/Mafia/roles/cards/KillVillagePlayerOnDeath.js
+++ b/Games/types/Mafia/roles/cards/KillVillagePlayerOnDeath.js
@@ -26,6 +26,10 @@ module.exports = class KillVillagePlayerOnDeath extends Card {
             this.game.queueAlert(
               `${this.actor.name} the ${this.actor.role.name} has selected ${this.target.name}. If ${this.target.name} is Village Aligned they will die tonight.`
             );
+            
+            if (!this.actor.hasAbility(["Kill", "WhenDead"])) {
+            return;
+            }
             //this.hasChoosen = true;
             this.actor.role.SelectedPlayer = this.target;
           },

--- a/Games/types/Mafia/roles/cards/ResetRolesOnDeath.js
+++ b/Games/types/Mafia/roles/cards/ResetRolesOnDeath.js
@@ -9,6 +9,10 @@ module.exports = class ResetRolesOnDeath extends Card {
           return;
         }
 
+        if (!this.player.hasAbility(["Convert", "WhenDead"])) {
+          return;
+        }
+
         for (let _player of this.game.players) {
           if (_player.alive) {
             _player.setRole(

--- a/Games/types/Mafia/roles/cards/RevealTargetOnDeath.js
+++ b/Games/types/Mafia/roles/cards/RevealTargetOnDeath.js
@@ -22,7 +22,7 @@ module.exports = class RevealTargetOnDeath extends Card {
     this.listeners = {
       state: function (stateInfo) {
         if (stateInfo.name.match(/Night/)) {
-          this.data.playerToReveal == null;
+          this.data.playerToReveal = null;
         }
       },
       death: function (player, killer, deathType) {

--- a/Games/types/Mafia/roles/cards/RevealTargetOnDeath.js
+++ b/Games/types/Mafia/roles/cards/RevealTargetOnDeath.js
@@ -20,6 +20,11 @@ module.exports = class RevealTargetOnDeath extends Card {
       },
     };
     this.listeners = {
+      state: function (stateInfo) {
+        if (stateInfo.name.match(/Night/)) {
+          this.data.playerToReveal == null;
+        }
+      },
       death: function (player, killer, deathType) {
         if (player == this.player && this.data.playerToReveal) {
           let info = this.game.createInformation(

--- a/Games/types/Mafia/roles/cards/RevealTargetOnDeath.js
+++ b/Games/types/Mafia/roles/cards/RevealTargetOnDeath.js
@@ -27,6 +27,9 @@ module.exports = class RevealTargetOnDeath extends Card {
       },
       death: function (player, killer, deathType) {
         if (player == this.player && this.data.playerToReveal) {
+          if (!this.player.hasAbility(["Reveal", "WhenDead"])) {
+            return;
+          }
           let info = this.game.createInformation(
             "RevealInfo",
             this.player,

--- a/Games/types/Mafia/roles/cards/SacrificeSameRole.js
+++ b/Games/types/Mafia/roles/cards/SacrificeSameRole.js
@@ -9,9 +9,12 @@ module.exports = class SacrificeSameRole extends Card {
         if (player != this.player) {
           return;
         }
+        if (!this.player.hasAbility(["Kill", "WhenDead"])) {
+          return;
+        }
 
         for (const player of this.game.players) {
-          if (player.alive && player.role.name === "Sheep") {
+          if (player.alive && player.role.name === "Sheep" && player.hasAbility(["Kill", "WhenDead"]) {
             player.kill("sheep", this.player, instant);
           }
         }

--- a/Games/types/Mafia/roles/cards/SacrificeSameRole.js
+++ b/Games/types/Mafia/roles/cards/SacrificeSameRole.js
@@ -14,7 +14,11 @@ module.exports = class SacrificeSameRole extends Card {
         }
 
         for (const player of this.game.players) {
-          if (player.alive && player.role.name === "Sheep" && player.hasAbility(["Kill", "WhenDead"])) {
+          if (
+            player.alive &&
+            player.role.name === "Sheep" &&
+            player.hasAbility(["Kill", "WhenDead"])
+          ) {
             player.kill("sheep", this.player, instant);
           }
         }

--- a/Games/types/Mafia/roles/cards/SacrificeSameRole.js
+++ b/Games/types/Mafia/roles/cards/SacrificeSameRole.js
@@ -14,7 +14,7 @@ module.exports = class SacrificeSameRole extends Card {
         }
 
         for (const player of this.game.players) {
-          if (player.alive && player.role.name === "Sheep" && player.hasAbility(["Kill", "WhenDead"]) {
+          if (player.alive && player.role.name === "Sheep" && player.hasAbility(["Kill", "WhenDead"])) {
             player.kill("sheep", this.player, instant);
           }
         }

--- a/Games/types/Mafia/roles/cards/VotesAnonymousOnDeath.js
+++ b/Games/types/Mafia/roles/cards/VotesAnonymousOnDeath.js
@@ -8,7 +8,7 @@ module.exports = class VotesAnonymousOnDeath extends Card {
       death: function (player, killer, killType) {
         if (!this.player.hasAbility(["Effect", "WhenDead"])) {
           return;
-         }
+        }
         if (player == this.player) this.data.causeVoteAnonymous = true;
       },
       state: function (stateInfo) {

--- a/Games/types/Mafia/roles/cards/VotesAnonymousOnDeath.js
+++ b/Games/types/Mafia/roles/cards/VotesAnonymousOnDeath.js
@@ -6,6 +6,9 @@ module.exports = class VotesAnonymousOnDeath extends Card {
 
     this.listeners = {
       death: function (player, killer, killType) {
+        if (!this.player.hasAbility(["Effect", "WhenDead"])) {
+          return;
+         }
         if (player == this.player) this.data.causeVoteAnonymous = true;
       },
       state: function (stateInfo) {


### PR DESCRIPTION
Delirum now disable the abilites of Typist, Lightkeeper, Schoolmarm, Secretary, Sheep, Gatekeeper, Butterfly, Barber, Mooncalf, Benandante, and Princess. 

Oracle- Can now be blocked properly if not resolute. (Before it would use target from previous day) 
