### PR TITLE
Resistance: all should approve team to avoid force nl

### DIFF
--- a/Games/types/Resistance/items/Leader.js
+++ b/Games/types/Resistance/items/Leader.js
@@ -31,7 +31,7 @@ module.exports = class Leader extends Item {
             for (let target of this.target)
               target.role.meetings["Mission Success"].disabled = false;
 
-            this.actor.role.meetings["Approve Team"].disabled = true;
+            // this.actor.role.meetings["Approve Team"].disabled = true;
 
             var selectedNames = this.target.map((t) => t.name);
             // for displaying mission history


### PR DESCRIPTION
bug: 
currently in 5p resistance setup with 3 town and 2 mafias, the leader isn't participating in the team approval meeting.
This leads to forced nl situation where both mafias simply vote 'no' forever.

solution:
let leader vote too


I haven't tested this change, just did a ctr+f and comment out, so need a review