### PR TITLE
Fixed defaults not persisting, spectating default enabled, refactored

### DIFF
--- a/react_main/src/pages/Play/Host/HostAcrotopia.jsx
+++ b/react_main/src/pages/Play/Host/HostAcrotopia.jsx
@@ -3,7 +3,7 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
-import getDefaults from "./HostDefaults";
+import { getDefaults, persistDefaults } from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
@@ -73,6 +73,7 @@ export default function HostAcrotopia() {
       label: "Private",
       ref: "private",
       type: "boolean",
+      value: defaults.private,
     },
     {
       label: "Anonymous Game",
@@ -91,11 +92,13 @@ export default function HostAcrotopia() {
       label: "Allow Guests",
       ref: "guests",
       type: "boolean",
+      value: defaults.guests,
     },
     {
       label: "Spectating",
       ref: "spectating",
       type: "boolean",
+      value: defaults.spectating,
     },
     {
       label: "Scheduled",
@@ -106,6 +109,7 @@ export default function HostAcrotopia() {
       label: "Ready Check",
       ref: "readyCheck",
       type: "boolean",
+      value: defaults.readyCheck,
     },
     {
       label: "Start Date",
@@ -120,6 +124,7 @@ export default function HostAcrotopia() {
       label: "Configure Duration",
       ref: "configureDuration",
       type: "boolean",
+      value: defaults.configureDuration,
     },
     {
       label: "Night Length (minutes)",
@@ -184,9 +189,18 @@ export default function HostAcrotopia() {
         })
         .catch(errorAlert);
 
+      defaults.private = getFormFieldValue("private");
+      defaults.guests = getFormFieldValue("guests");
+      defaults.spectating = getFormFieldValue("spectating");
+      defaults.readyCheck = getFormFieldValue("readyCheck");
       defaults.anonymousGame = getFormFieldValue("anonymousGame");
       defaults.anonymousDeckId = getFormFieldValue("anonymousDeckId");
-      localStorage.setItem("otherHostOptions", JSON.stringify(defaults));
+      defaults.roundAmt = getFormFieldValue("roundAmt");
+      defaults.acronymSize = getFormFieldValue("acronymSize");
+      defaults.enablePunctuation = getFormFieldValue("enablePunctuation");
+      defaults.standardiseCapitalisation = getFormFieldValue("standardiseCapitalisation");
+      defaults.turnOnCaps = getFormFieldValue("turnOnCaps");
+      persistDefaults(gameType, defaults);
     } else errorAlert("You must choose a setup");
   }
 

--- a/react_main/src/pages/Play/Host/HostCardGames.jsx
+++ b/react_main/src/pages/Play/Host/HostCardGames.jsx
@@ -3,7 +3,7 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
-import getDefaults from "./HostDefaults";
+import { getDefaults, persistDefaults } from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
@@ -62,6 +62,7 @@ export default function HostCardGames() {
       label: "Private",
       ref: "private",
       type: "boolean",
+      value: defaults.private,
     },
     {
       label: "Anonymous Game",
@@ -80,11 +81,13 @@ export default function HostCardGames() {
       label: "Allow Guests",
       ref: "guests",
       type: "boolean",
+      value: defaults.guests,
     },
     {
       label: "Spectating",
       ref: "spectating",
       type: "boolean",
+      value: defaults.spectating,
     },
     {
       label: "Scheduled",
@@ -95,6 +98,7 @@ export default function HostCardGames() {
       label: "Ready Check",
       ref: "readyCheck",
       type: "boolean",
+      value: defaults.readyCheck,
     },
     {
       label: "Start Date",
@@ -109,6 +113,7 @@ export default function HostCardGames() {
       label: "Configure Duration",
       ref: "configureDuration",
       type: "boolean",
+      value: defaults.configureDuration,
     },
     {
       label: "Place Bets (minutes)",
@@ -168,9 +173,13 @@ export default function HostCardGames() {
         })
         .catch(errorAlert);
 
+      defaults.private = getFormFieldValue("private");
+      defaults.guests = getFormFieldValue("guests");
+      defaults.spectating = getFormFieldValue("spectating");
+      defaults.readyCheck = getFormFieldValue("readyCheck");
       defaults.anonymousGame = getFormFieldValue("anonymousGame");
       defaults.anonymousDeckId = getFormFieldValue("anonymousDeckId");
-      localStorage.setItem("otherHostOptions", JSON.stringify(defaults));
+      persistDefaults(gameType, defaults);
     } else errorAlert("You must choose a setup");
   }
 

--- a/react_main/src/pages/Play/Host/HostDefaults.js
+++ b/react_main/src/pages/Play/Host/HostDefaults.js
@@ -1,64 +1,80 @@
-import { Lobbies, PreferredDeckId } from "../../../Constants";
+import { PreferredDeckId } from "../../../Constants";
 
-const otherHostOptions = JSON.parse(
-  localStorage.getItem("otherHostOptions") || null
-) || {
+function getStorageKey(gameType) {
+  return `${gameType.toLowerCase()} persisted options`;
+}
+
+// increment a number here to force people's hosting preferences to be reset one time only for that game type
+const HOST_OPTIONS_VERSIONS = {
+  Mafia: 1,
+  Acrotopia: 1,
+  Ghost: 1,
+  Jotto: 1,
+  "Liars Dice": 1,
+  "Card Games": 1,
+  Resistance: 1,
+  "Secret Dictator": 1,
+  "Wacky Words": 1,
+};
+
+// Associate all of the existing saved options per game type into a map
+var existingHostOptions = {};
+Object.keys(HOST_OPTIONS_VERSIONS).forEach(function (gameType) {
+  const storageKey = getStorageKey(gameType);
+  const _existingHostOptions = JSON.parse(localStorage.getItem(storageKey) || null);
+
+  // If the version doesn't match, delete the item from storage and null it out in the map
+  if (_existingHostOptions && _existingHostOptions.hostOptionsVersion !== HOST_OPTIONS_VERSIONS[gameType]) {
+    localStorage.removeItem(storageKey);
+    existingHostOptions[gameType] = null;
+  }
+  else {
+    existingHostOptions[gameType] = _existingHostOptions;
+  }
+});
+
+// These options are common to all
+const commonHostOptions = {
   private: false,
   guests: false,
-  spectating: false,
-  scheduled: false,
+  spectating: true,
   readyCheck: false,
+  configureDuration: false,
   anonymousGame: false,
   anonymousDeckId: PreferredDeckId,
 };
 
-// Delete pre-existing incompatible settings
-var existingMafiaHostOptions = JSON.parse(
-  localStorage.getItem("mafiaHostOptions") || null
-);
-if (
-  existingMafiaHostOptions &&
-  existingMafiaHostOptions.stateLengths === undefined
-) {
-  localStorage.removeItem("mafiaHostOptions");
-  existingMafiaHostOptions = null;
-}
-
 var defaultOptions = {
-  Mafia: existingMafiaHostOptions || {
-    ...otherHostOptions,
+  Mafia: existingHostOptions["Mafia"] || {
+    ...commonHostOptions,
     ranked: false,
     competitive: false,
     broadcastClosedRoles: false,
     noVeg: false,
     pregameWaitLength: 1,
     extendLength: 3,
-    stateLengths: {
-      Day: 10,
-      Night: 2,
-    },
+    dayLength: 10,
+    nightLength: 2,
   },
-  Acrotopia: {
-    ...otherHostOptions,
+  Acrotopia: existingHostOptions["Acrotopia"] || {
+    ...commonHostOptions,
     roundAmt: 5,
     acronymSize: 5,
     enablePunctuation: true,
     standardiseCapitalisation: true,
     turnOnCaps: true,
   },
-  Ghost: {
-    ...otherHostOptions,
+  Ghost: existingHostOptions["Ghost"] || {
+    ...commonHostOptions,
     configureWords: false,
     wordLength: 5,
     guessWordLength: 2,
     giveClueLength: 2,
-    stateLengths: {
-      Day: 5,
-      Night: 0.5,
-    },
+    dayLength: 5,
+    nightLength: 0.5,
   },
-  Jotto: {
-    ...otherHostOptions,
+  Jotto: existingHostOptions["Jotto"] || {
+    ...commonHostOptions,
     wordLength: 5,
     duplicateLetters: false,
     competitiveMode: false,
@@ -67,56 +83,58 @@ var defaultOptions = {
     selectWordLength: 1,
     guessWordLength: 1,
   },
-  "Liars Dice": {
-    ...otherHostOptions,
+  "Liars Dice": existingHostOptions["Liars Dice"] || {
+    ...commonHostOptions,
     startingDice: 5,
     wildOnes: true,
     spotOn: false,
     guessDiceLength: 2,
   },
-  "Card Games": {
-    ...otherHostOptions,
+  "Card Games": existingHostOptions["Card Games"] || {
+    ...commonHostOptions,
     startingChips: 6,
     minimumBet: 2,
     placeBetsLength: 2,
     showdownLength: 2,
   },
-  Resistance: {
-    ...otherHostOptions,
+  Resistance: existingHostOptions["Resistance"] || {
+    ...commonHostOptions,
     teamSelLength: 2,
     teamApprovalLength: 0.5,
     missionLength: 0.5,
   },
-  "Secret Dictator": {
-    ...otherHostOptions,
+  "Secret Dictator": existingHostOptions["Secret Dictator"] || {
+    ...commonHostOptions,
     nominationLength: 1,
     electionLength: 2,
     legislativeSessionLength: 2,
     executiveActionLength: 1,
     specialNominationLength: 1,
   },
-  "Wacky Words": {
-    ...otherHostOptions,
+  "Wacky Words": existingHostOptions["Wacky Words"] || {
+    ...commonHostOptions,
     roundAmt: 5,
     acronymSize: 5,
     enablePunctuation: true,
     standardiseCapitalisation: true,
     turnOnCaps: true,
-    stateLengths: {
-      Day: 5,
-      Night: 2,
-    },
+    dayLength: 5,
+    nightLength: 2,
   },
 };
 
-export default function getDefaults(gameType) {
+export function getDefaults(gameType) {
   const defaults = defaultOptions[gameType];
   if (defaults) {
     return defaults;
   } else {
-    console.error(
-      `Could not find default options for: ${gameType}. Please report this error.`
-    );
+    console.error(`Could not find default options for: ${gameType}. Please report this error.`);
     return null;
   }
+}
+
+export function persistDefaults(gameType, defaults) {
+  const storageKey = getStorageKey(gameType);
+  defaults.hostOptionsVersion = HOST_OPTIONS_VERSIONS[gameType];
+  localStorage.setItem(storageKey, JSON.stringify(defaults));
 }

--- a/react_main/src/pages/Play/Host/HostGhost.jsx
+++ b/react_main/src/pages/Play/Host/HostGhost.jsx
@@ -3,7 +3,7 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
-import getDefaults from "./HostDefaults";
+import { getDefaults, persistDefaults } from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
@@ -74,6 +74,7 @@ export default function HostGhost() {
       label: "Private",
       ref: "private",
       type: "boolean",
+      value: defaults.private,
     },
     {
       label: "Anonymous Game",
@@ -92,11 +93,13 @@ export default function HostGhost() {
       label: "Allow Guests",
       ref: "guests",
       type: "boolean",
+      value: defaults.guests,
     },
     {
       label: "Spectating",
       ref: "spectating",
       type: "boolean",
+      value: defaults.spectating,
     },
     {
       label: "Scheduled",
@@ -107,6 +110,7 @@ export default function HostGhost() {
       label: "Ready Check",
       ref: "readyCheck",
       type: "boolean",
+      value: defaults.readyCheck,
     },
     {
       label: "Start Date",
@@ -121,13 +125,14 @@ export default function HostGhost() {
       label: "Configure Duration",
       ref: "configureDuration",
       type: "boolean",
+      value: defaults.configureDuration,
     },
     {
       label: "Night Length (minutes)",
       ref: "nightLength",
       type: "number",
       showIf: "configureDuration",
-      value: defaults.stateLengths["Night"],
+      value: defaults.nightLength,
       min: 0.5,
       max: 1,
       step: 0.5,
@@ -147,7 +152,7 @@ export default function HostGhost() {
       ref: "dayLength",
       type: "number",
       showIf: "configureDuration",
-      value: defaults.stateLengths["Day"],
+      value: defaults.dayLength,
       min: 2,
       max: 5,
       step: 1,
@@ -206,9 +211,13 @@ export default function HostGhost() {
         })
         .catch(errorAlert);
 
-      defaults.anonymousGame = getFormFieldValue("anonymousGame");
-      defaults.anonymousDeckId = getFormFieldValue("anonymousDeckId");
-      localStorage.setItem("otherHostOptions", JSON.stringify(defaults));
+      Object.keys(defaults).forEach(function(key) {
+        const submittedValue = getFormFieldValue(key);
+        if (submittedValue) {
+          defaults[key] = submittedValue;
+        }
+      });
+      persistDefaults(gameType, defaults);
     } else errorAlert("You must choose a setup");
   }
 

--- a/react_main/src/pages/Play/Host/HostJotto.jsx
+++ b/react_main/src/pages/Play/Host/HostJotto.jsx
@@ -3,7 +3,7 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
-import getDefaults from "./HostDefaults";
+import { getDefaults, persistDefaults } from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
@@ -81,6 +81,7 @@ export default function HostJotto() {
       label: "Private",
       ref: "private",
       type: "boolean",
+      value: defaults.private,
     },
     {
       label: "Anonymous Game",
@@ -99,11 +100,13 @@ export default function HostJotto() {
       label: "Allow Guests",
       ref: "guests",
       type: "boolean",
+      value: defaults.guests,
     },
     {
       label: "Spectating",
       ref: "spectating",
       type: "boolean",
+      value: defaults.spectating,
     },
     {
       label: "Scheduled",
@@ -114,6 +117,7 @@ export default function HostJotto() {
       label: "Ready Check",
       ref: "readyCheck",
       type: "boolean",
+      value: defaults.readyCheck,
     },
     {
       label: "Start Date",
@@ -128,6 +132,7 @@ export default function HostJotto() {
       label: "Configure Duration",
       ref: "configureDuration",
       type: "boolean",
+      value: defaults.configureDuration,
     },
     {
       label: "Select Word Length (minutes)",
@@ -190,9 +195,13 @@ export default function HostJotto() {
         })
         .catch(errorAlert);
 
-      defaults.anonymousGame = getFormFieldValue("anonymousGame");
-      defaults.anonymousDeckId = getFormFieldValue("anonymousDeckId");
-      localStorage.setItem("otherHostOptions", JSON.stringify(defaults));
+      Object.keys(defaults).forEach(function(key) {
+        const submittedValue = getFormFieldValue(key);
+        if (submittedValue) {
+          defaults[key] = submittedValue;
+        }
+      });
+      persistDefaults(gameType, defaults);
     } else errorAlert("You must choose a setup");
   }
 

--- a/react_main/src/pages/Play/Host/HostLiarsDice.jsx
+++ b/react_main/src/pages/Play/Host/HostLiarsDice.jsx
@@ -3,7 +3,7 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
-import getDefaults from "./HostDefaults";
+import { getDefaults, persistDefaults } from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
@@ -66,6 +66,7 @@ export default function HostLiarsDice() {
       label: "Private",
       ref: "private",
       type: "boolean",
+      value: defaults.private,
     },
     {
       label: "Anonymous Game",
@@ -84,11 +85,13 @@ export default function HostLiarsDice() {
       label: "Allow Guests",
       ref: "guests",
       type: "boolean",
+      value: defaults.guests,
     },
     {
       label: "Spectating",
       ref: "spectating",
       type: "boolean",
+      value: defaults.spectating,
     },
     {
       label: "Scheduled",
@@ -99,6 +102,7 @@ export default function HostLiarsDice() {
       label: "Ready Check",
       ref: "readyCheck",
       type: "boolean",
+      value: defaults.readyCheck,
     },
     {
       label: "Start Date",
@@ -113,6 +117,7 @@ export default function HostLiarsDice() {
       label: "Configure Duration",
       ref: "configureDuration",
       type: "boolean",
+      value: defaults.configureDuration,
     },
     {
       label: "Guess Dice Length (minutes)",
@@ -162,9 +167,13 @@ export default function HostLiarsDice() {
         })
         .catch(errorAlert);
 
-      defaults.anonymousGame = getFormFieldValue("anonymousGame");
-      defaults.anonymousDeckId = getFormFieldValue("anonymousDeckId");
-      localStorage.setItem("otherHostOptions", JSON.stringify(defaults));
+      Object.keys(defaults).forEach(function(key) {
+        const submittedValue = getFormFieldValue(key);
+        if (submittedValue) {
+          defaults[key] = submittedValue;
+        }
+      });
+      persistDefaults(gameType, defaults);
     } else errorAlert("You must choose a setup");
   }
 

--- a/react_main/src/pages/Play/Host/HostMafia.jsx
+++ b/react_main/src/pages/Play/Host/HostMafia.jsx
@@ -3,7 +3,7 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
-import getDefaults from "./HostDefaults";
+import { getDefaults, persistDefaults } from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { Lobbies } from "../../../Constants";
@@ -113,10 +113,17 @@ export default function HostMafia() {
       type: "boolean",
     },
     {
+      label: "Configure Duration",
+      ref: "configureDuration",
+      type: "boolean",
+      value: defaults.configureDuration,
+    },
+    {
       label: "Day Length (minutes)",
       ref: "dayLength",
       type: "number",
-      value: defaults.stateLengths["Day"],
+      showIf: "configureDuration",
+      value: defaults.dayLength,
       min: 1,
       max: 30,
     },
@@ -124,7 +131,8 @@ export default function HostMafia() {
       label: "Night Length (minutes)",
       ref: "nightLength",
       type: "number",
-      value: defaults.stateLengths["Night"],
+      showIf: "configureDuration",
+      value: defaults.nightLength,
       min: 1,
       max: 10,
     },
@@ -132,6 +140,7 @@ export default function HostMafia() {
       label: "Pregame Wait (hours)",
       ref: "pregameWaitLength",
       type: "number",
+      showIf: "configureDuration",
       value: defaults.pregameWaitLength || 1,
       min: 1,
       max: 6,
@@ -140,6 +149,7 @@ export default function HostMafia() {
       label: "Extension Length (minutes)",
       ref: "extendLength",
       type: "number",
+      showIf: "configureDuration",
       value: defaults.extendLength,
       min: 1,
       max: 5,
@@ -195,7 +205,6 @@ export default function HostMafia() {
       defaults.ranked = getFormFieldValue("ranked");
       defaults.competitive = getFormFieldValue("competitive");
       defaults.spectating = getFormFieldValue("spectating");
-      // defaults.scheduled = getFormFieldValue("scheduled");
       defaults.readyCheck = getFormFieldValue("readyCheck");
       defaults.noVeg = getFormFieldValue("noVeg");
       defaults.dayLength = getFormFieldValue("dayLength");
@@ -205,7 +214,7 @@ export default function HostMafia() {
       defaults.anonymousGame = getFormFieldValue("anonymousGame");
       defaults.anonymousDeckId = getFormFieldValue("anonymousDeckId");
       defaults.broadcastClosedRoles = getFormFieldValue("broadcastClosedRoles");
-      localStorage.setItem("mafiaHostOptions", JSON.stringify(defaults));
+      persistDefaults(gameType, defaults);
     } else errorAlert("You must choose a setup");
   }
 

--- a/react_main/src/pages/Play/Host/HostResistance.jsx
+++ b/react_main/src/pages/Play/Host/HostResistance.jsx
@@ -3,7 +3,7 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
-import getDefaults from "./HostDefaults";
+import { getDefaults, persistDefaults } from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
@@ -47,6 +47,7 @@ export default function HostResistance() {
       label: "Private",
       ref: "private",
       type: "boolean",
+      value: defaults.private,
     },
     {
       label: "Anonymous Game",
@@ -65,11 +66,13 @@ export default function HostResistance() {
       label: "Allow Guests",
       ref: "guests",
       type: "boolean",
+      value: defaults.guests,
     },
     {
       label: "Spectating",
       ref: "spectating",
       type: "boolean",
+      value: defaults.spectating,
     },
     {
       label: "Scheduled",
@@ -80,6 +83,7 @@ export default function HostResistance() {
       label: "Ready Check",
       ref: "readyCheck",
       type: "boolean",
+      value: defaults.readyCheck,
     },
     {
       label: "Start Date",
@@ -91,9 +95,16 @@ export default function HostResistance() {
       max: Date.now() + 4 * 7 * 24 * 60 * 60 * 1000,
     },
     {
+      label: "Configure Duration",
+      ref: "configureDuration",
+      type: "boolean",
+      value: defaults.configureDuration,
+    },
+    {
       label: "Team Selection Length (minutes)",
       ref: "teamSelLength",
       type: "number",
+      showIf: "configureDuration",
       value: defaults.teamSelLength,
       min: 1,
       max: 5,
@@ -102,6 +113,7 @@ export default function HostResistance() {
       label: "Team Approval Length (minutes)",
       ref: "teamApprovalLength",
       type: "number",
+      showIf: "configureDuration",
       value: defaults.teamApprovalLength,
       min: 0.1,
       max: 2,
@@ -111,6 +123,7 @@ export default function HostResistance() {
       label: "Mission Length (minutes)",
       ref: "missionLength",
       type: "number",
+      showIf: "configureDuration",
       value: defaults.missionLength,
       min: 0.1,
       max: 1,
@@ -123,7 +136,7 @@ export default function HostResistance() {
   }, []);
 
   function onHostGame() {
-    var scheduled = formFields[6].value;
+    var scheduled = getFormFieldValue("scheduled");
 
     if (selSetup.id) {
       axios
@@ -153,9 +166,13 @@ export default function HostResistance() {
         })
         .catch(errorAlert);
 
-      defaults.anonymousGame = getFormFieldValue("anonymousGame");
-      defaults.anonymousDeckId = getFormFieldValue("anonymousDeckId");
-      localStorage.setItem("otherHostOptions", JSON.stringify(defaults));
+      Object.keys(defaults).forEach(function(key) {
+        const submittedValue = getFormFieldValue(key);
+        if (submittedValue) {
+          defaults[key] = submittedValue;
+        }
+      });
+      persistDefaults(gameType, defaults);
     } else errorAlert("You must choose a setup");
   }
 

--- a/react_main/src/pages/Play/Host/HostSecretDictator.jsx
+++ b/react_main/src/pages/Play/Host/HostSecretDictator.jsx
@@ -3,7 +3,7 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
-import getDefaults from "./HostDefaults";
+import { getDefaults, persistDefaults } from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
@@ -46,6 +46,7 @@ export default function HostSecretDictator() {
       label: "Private",
       ref: "private",
       type: "boolean",
+      value: defaults.private,
     },
     {
       label: "Anonymous Game",
@@ -64,11 +65,13 @@ export default function HostSecretDictator() {
       label: "Allow Guests",
       ref: "guests",
       type: "boolean",
+      value: defaults.guests,
     },
     {
       label: "Spectating",
       ref: "spectating",
       type: "boolean",
+      value: defaults.spectating,
     },
     {
       label: "Scheduled",
@@ -79,6 +82,7 @@ export default function HostSecretDictator() {
       label: "Ready Check",
       ref: "readyCheck",
       type: "boolean",
+      value: defaults.readyCheck,
     },
     {
       label: "Start Date",
@@ -93,6 +97,7 @@ export default function HostSecretDictator() {
       label: "Configure Duration",
       ref: "configureDuration",
       type: "boolean",
+      value: defaults.configureDuration,
     },
     {
       label: "Nomination Length (minutes)",
@@ -185,9 +190,13 @@ export default function HostSecretDictator() {
         })
         .catch(errorAlert);
 
-      defaults.anonymousGame = getFormFieldValue("anonymousGame");
-      defaults.anonymousDeckId = getFormFieldValue("anonymousDeckId");
-      localStorage.setItem("otherHostOptions", JSON.stringify(defaults));
+      Object.keys(defaults).forEach(function(key) {
+        const submittedValue = getFormFieldValue(key);
+        if (submittedValue) {
+          defaults[key] = submittedValue;
+        }
+      });
+      persistDefaults(gameType, defaults);
     } else errorAlert("You must choose a setup");
   }
 

--- a/react_main/src/pages/Play/Host/HostWackyWords.jsx
+++ b/react_main/src/pages/Play/Host/HostWackyWords.jsx
@@ -3,7 +3,7 @@ import { Redirect } from "react-router-dom";
 import axios from "axios";
 
 import HostBrowser from "./HostBrowser";
-import getDefaults from "./HostDefaults";
+import { getDefaults, persistDefaults } from "./HostDefaults";
 import { useForm } from "../../../components/Form";
 import { useErrorAlert } from "../../../components/Alerts";
 import { SiteInfoContext } from "../../../Contexts";
@@ -73,6 +73,7 @@ export default function HostWackyWords() {
       label: "Private",
       ref: "private",
       type: "boolean",
+      value: defaults.private,
     },
     {
       label: "Anonymous Game",
@@ -91,11 +92,13 @@ export default function HostWackyWords() {
       label: "Allow Guests",
       ref: "guests",
       type: "boolean",
+      value: defaults.guests,
     },
     {
       label: "Spectating",
       ref: "spectating",
       type: "boolean",
+      value: defaults.spectating,
     },
     {
       label: "Scheduled",
@@ -106,6 +109,7 @@ export default function HostWackyWords() {
       label: "Ready Check",
       ref: "readyCheck",
       type: "boolean",
+      value: defaults.readyCheck,
     },
     {
       label: "Start Date",
@@ -120,13 +124,14 @@ export default function HostWackyWords() {
       label: "Configure Duration",
       ref: "configureDuration",
       type: "boolean",
+      value: defaults.configureDuration,
     },
     {
       label: "Night Length (minutes)",
       ref: "nightLength",
       type: "number",
       showIf: "configureDuration",
-      value: defaults.stateLengths["Night"],
+      value: defaults.nightLength,
       min: 1,
       max: 5,
       step: 1,
@@ -136,7 +141,7 @@ export default function HostWackyWords() {
       ref: "dayLength",
       type: "number",
       showIf: "configureDuration",
-      value: defaults.stateLengths["Day"],
+      value: defaults.dayLength,
       min: 2,
       max: 5,
       step: 1,
@@ -184,9 +189,13 @@ export default function HostWackyWords() {
         })
         .catch(errorAlert);
 
-      defaults.anonymousGame = getFormFieldValue("anonymousGame");
-      defaults.anonymousDeckId = getFormFieldValue("anonymousDeckId");
-      localStorage.setItem("otherHostOptions", JSON.stringify(defaults));
+      Object.keys(defaults).forEach(function(key) {
+        const submittedValue = getFormFieldValue(key);
+        if (submittedValue) {
+          defaults[key] = submittedValue;
+        }
+      });
+      persistDefaults(gameType, defaults);
     } else errorAlert("You must choose a setup");
   }
 

--- a/react_main/src/pages/Play/LobbyBrowser/RecentlyPlayedSetups.jsx
+++ b/react_main/src/pages/Play/LobbyBrowser/RecentlyPlayedSetups.jsx
@@ -5,7 +5,7 @@ import { Box, Card, IconButton, Typography } from "@mui/material";
 import { UserContext } from "../../../Contexts";
 import { useErrorAlert } from "../../../components/Alerts";
 import { getRecentlyPlayedSetups } from "../../../services/gameService";
-import getDefaults from "../Host/HostDefaults";
+import { getDefaults } from "../Host/HostDefaults";
 import Setup from "../../../components/Setup";
 import { getRecentlyPlayedSetupsChart } from "./getRecentlyPlayedSetupsChart";
 import { useTheme } from "@mui/styles";


### PR DESCRIPTION
I was originally going to just enable spectating by default but then I found that that doesn't actually work. I ended up refactoring a bunch of stuff:

- enabled spectating by default
- added configureDuration to the common options
- removed scheduled from the common options
- fixed a bug in resistance where it was always scheduling the game if spectating was on
- tracked the persisted options of each game type separately
- added a gimmick that will let us force reset user's persisted options by gametype

All users will have their saved options reset after this change because I restructured the way that they're stored. I was going to do that no matter what because I wanted the default spectating enabled to take effect.

I tested each game type to verify that my options were being saved.