### PR TITLE
10 of Spades fix + Facehugger Role + Botc Leech + Holy and Unholy Modifers

### DIFF
--- a/Games/types/Mafia/Player.js
+++ b/Games/types/Mafia/Player.js
@@ -27,6 +27,7 @@ module.exports = class MafiaPlayer extends Player {
     this.data.Block = 0;
     this.data.ConversionProgress = 0;
     this.data.Charge = 0;
+    this.data.StylePoints = 0;
     this.Gold = 0;
   }
 

--- a/Games/types/Mafia/Winners.js
+++ b/Games/types/Mafia/Winners.js
@@ -145,6 +145,8 @@ module.exports = class MafiaWinners extends Winners {
         return "Here's a little lesson in trickery, this is going down in history. If you wanna be a villain number one, then look no further than the Supervillain.";
       case "Survivor":
         return "Through the carnage, the Survivor drifted on.";
+      case "Style Points":
+          return "When you are the most stylish you can't really lose.";
       case "Tofurkey":
         return ":turkey: The grain shipments arrived in town a day too late. The streets were filled with wild Turkeys…";
       case "Turkey":

--- a/Games/types/Mafia/const/ImportantMeetings.js
+++ b/Games/types/Mafia/const/ImportantMeetings.js
@@ -9,7 +9,7 @@ const IMPORTANT_MEETINGS_NIGHT = [
   "*",
   "Leaders",
   "Hostage Swap",
-  "Choose Vessal",
+  "Choose Vessel",
 ];
 const INVITED_MEETINGS = ["Party!", "Hot Springs", "Banquet", "Superhero"];
 const STARTS_WITH_MEETINGS = [

--- a/Games/types/Mafia/const/ImportantMeetings.js
+++ b/Games/types/Mafia/const/ImportantMeetings.js
@@ -9,6 +9,7 @@ const IMPORTANT_MEETINGS_NIGHT = [
   "*",
   "Leaders",
   "Hostage Swap",
+  "Choose Vessal",
 ];
 const INVITED_MEETINGS = ["Party!", "Hot Springs", "Banquet", "Superhero"];
 const STARTS_WITH_MEETINGS = [

--- a/Games/types/Mafia/effects/BecomeRoleOnDeath.js
+++ b/Games/types/Mafia/effects/BecomeRoleOnDeath.js
@@ -22,7 +22,7 @@ module.exports = class BecomeRoleOnDeath extends Effect {
           actor: this.infector,
           target: this.player,
           game: this.game,
-          effect: this
+          effect: this,
           run: function () {
             if (this.dominates()){
               let roleName = this.effect.role.split(":")[0];
@@ -53,12 +53,5 @@ module.exports = class BecomeRoleOnDeath extends Effect {
     };
 
     
-  }
-
-  
-
-  remove() {
-    super.remove();
-    this.action.cancel(true);
   }
 };

--- a/Games/types/Mafia/effects/BecomeRoleOnDeath.js
+++ b/Games/types/Mafia/effects/BecomeRoleOnDeath.js
@@ -1,0 +1,64 @@
+const Effect = require("../Effect");
+const Action = require("../Action");
+const modifiers = require("../../../../data/modifiers");
+
+module.exports = class BecomeRoleOnDeath extends Effect {
+  constructor(infector, role) {
+    super("BecomeRoleOnDeath");
+    this.infector = infector;
+    this.role = role;
+
+
+
+    this.listeners = {
+      death: function (player, killer, deathType, instant){
+        if (this.player != player) return;
+        //if(this.word == "Complete") return;
+          if (!this.infector.hasAbility(["Convert"])) {
+          return;
+         }
+        var action = new Action({
+          labels: ["hidden", "convert"],
+          actor: this.infector,
+          target: this.player,
+          game: this.game,
+          effect: this
+          run: function () {
+            if (this.dominates()){
+              let roleName = this.effect.role.split(":")[0];
+              let modifiers = this.effect.role.split(":")[1];
+              if(!modifiers || modifiers.length <= 0){
+                  this.target.setRole(
+                  `${roleName}:Transcendent`,                   
+                    null,
+                    false,
+                    false,
+                    false,
+                    this.actor.faction);
+              }
+              else{
+                this.target.setRole(
+                  `${this.effect.role}/Transcendent`,                   
+                    null,
+                    false,
+                    false,
+                    false,
+                    this.actor.faction);
+              }
+          }
+          },
+        });
+       action.do();
+      },
+    };
+
+    
+  }
+
+  
+
+  remove() {
+    super.remove();
+    this.action.cancel(true);
+  }
+};

--- a/Games/types/Mafia/effects/Delirious.js
+++ b/Games/types/Mafia/effects/Delirious.js
@@ -22,10 +22,11 @@ module.exports = class Delirious extends Effect {
           actor: this.effecter,
           target: this.player,
           game: this.player.game,
+          effect: this,
           priority: PRIORITY_NIGHT_ROLE_BLOCKER + 1,
           labels: ["block", "hidden"],
           run: function () {
-            if (this.actor.hasAbility(["Delirium"])) {
+            if (this.actor.hasAbility(this.effect.types)) {
               this.blockWithDelirium(this.target, true);
             }
           },

--- a/Games/types/Mafia/effects/StylePoints.js
+++ b/Games/types/Mafia/effects/StylePoints.js
@@ -2,16 +2,16 @@ const Effect = require("../Effect");
 const Action = require("../Action");
 
 module.exports = class StylePoints extends Effect {
-  constructor(actor, player, lifespan) {
+  constructor(actor, player) {
     super("StylePoints");
     this.actor = actor;
-    this.word = player.role.name;
+    this.player = player;
     this.StylePointsToday = 0;
 
     this.listeners = {
       state: function () {
         if(this.game.getStateName() == "Day"){
-          this.effect.StylePointsToday = 0;
+          this.StylePointsToday = 0;
         }
         if (this.game.getStateName() != "Night") return;
         if (!this.player.alive) return;
@@ -24,8 +24,8 @@ module.exports = class StylePoints extends Effect {
   }
 
   speak(message) {
-    let players = this.game.players.filter((p) => p.alive && p.faction == this.actor.faction);
-    if (players.length > 1 && this.player && this.player.faction == this.actor.faction && message.content.replace(" ", "").toLowerCase().includes(this.player.role.name)) {
+    let players = this.game.alivePlayers().filter((p) => p.faction == this.actor.faction);
+    if (players.length > 1 && this.player.faction == this.actor.faction && message.content.replace(" ", "").toLowerCase().includes(this.player.role.name.toLowerCase()) && this.game.getStateName() == "Day") {
       var action = new Action({
         actor: this.player,
         target: this.player,
@@ -34,7 +34,7 @@ module.exports = class StylePoints extends Effect {
         labels: ["hidden"],
         run: function () {
           this.effect.StylePointsToday += 1;
-          this.target.queueAlert(`You gain 1 Style Point!`);
+          this.actor.queueAlert(`You gain 1 Style Point!`);
         },
       });
 

--- a/Games/types/Mafia/effects/StylePoints.js
+++ b/Games/types/Mafia/effects/StylePoints.js
@@ -24,8 +24,8 @@ module.exports = class StylePoints extends Effect {
   }
 
   speak(message) {
-
-    if (this.player && this.player.faction == this.actor.faction && message.content.replace(" ", "").toLowerCase().includes(this.player.role.name)) {
+    let players = this.game.players.filter((p) => p.alive && p.faction == this.actor.faction);
+    if (players.length > 1 && this.player && this.player.faction == this.actor.faction && message.content.replace(" ", "").toLowerCase().includes(this.player.role.name)) {
       var action = new Action({
         actor: this.player,
         target: this.player,

--- a/Games/types/Mafia/effects/StylePoints.js
+++ b/Games/types/Mafia/effects/StylePoints.js
@@ -2,7 +2,7 @@ const Effect = require("../Effect");
 const Action = require("../Action");
 
 module.exports = class StylePoints extends Effect {
-  constructor(actor, player) {
+  constructor(actor, player, lifespan) {
     super("StylePoints");
     this.actor = actor;
     this.word = player.role.name;
@@ -15,13 +15,17 @@ module.exports = class StylePoints extends Effect {
         }
         if (this.game.getStateName() != "Night") return;
         if (!this.player.alive) return;
-        this.actor.data.StylePoints += this.StylePointsToday;
+        this.player.data.StylePoints += this.StylePointsToday;
+        if(!this.actor.hasAbility(["WhenDead"])){
+          this.remove();
+        }
       },
     };
   }
 
   speak(message) {
-    if (this.player && message.content.replace(" ", "").toLowerCase().includes(this.player.role.name)) {
+
+    if (this.player && this.player.faction == this.actor.faction && message.content.replace(" ", "").toLowerCase().includes(this.player.role.name)) {
       var action = new Action({
         actor: this.player,
         target: this.player,
@@ -36,5 +40,6 @@ module.exports = class StylePoints extends Effect {
 
       this.game.instantAction(action);
     }
+  
   }
 };

--- a/Games/types/Mafia/effects/StylePoints.js
+++ b/Games/types/Mafia/effects/StylePoints.js
@@ -1,0 +1,40 @@
+const Effect = require("../Effect");
+const Action = require("../Action");
+
+module.exports = class StylePoints extends Effect {
+  constructor(actor, player) {
+    super("StylePoints");
+    this.actor = actor;
+    this.word = player.role.name;
+    this.StylePointsToday = 0;
+
+    this.listeners = {
+      state: function () {
+        if(this.game.getStateName() == "Day"){
+          this.effect.StylePointsToday = 0;
+        }
+        if (this.game.getStateName() != "Night") return;
+        if (!this.player.alive) return;
+        this.actor.data.StylePoints += this.StylePointsToday;
+      },
+    };
+  }
+
+  speak(message) {
+    if (this.player && message.content.replace(" ", "").toLowerCase().includes(this.player.role.name)) {
+      var action = new Action({
+        actor: this.player,
+        target: this.player,
+        game: this.game,
+        effect: this,
+        labels: ["hidden"],
+        run: function () {
+          this.effect.StylePointsToday += 1;
+          this.target.queueAlert(`You gain 1 Style Point!`);
+        },
+      });
+
+      this.game.instantAction(action);
+    }
+  }
+};

--- a/Games/types/Mafia/roles/Cult/DreamEater.js
+++ b/Games/types/Mafia/roles/Cult/DreamEater.js
@@ -1,0 +1,22 @@
+const Role = require("../../Role");
+
+module.exports = class DreamEater extends Role {
+  constructor(player, data) {
+    super("Dream Eater", player, data);
+
+    this.alignment = "Cult";
+    this.cards = [
+      "VillageCore",
+      "WinWithFaction",
+      "MeetingFaction",
+      "HauntDreams",
+      "NightKiller",
+    ];
+    this.meetingMods = {
+      "Solo Kill": {
+        actionName: "Rip Apart",
+        targets: { include: ["alive"] },
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/Cult/Facehugger.js
+++ b/Games/types/Mafia/roles/Cult/Facehugger.js
@@ -1,0 +1,15 @@
+const Role = require("../../Role");
+
+module.exports = class Facehugger extends Role {
+  constructor(player, data) {
+    super("Facehugger", player, data);
+
+    this.alignment = "Cult";
+    this.cards = [
+      "VillageCore",
+      "WinWithFaction",
+      "MeetingFaction",
+      "ConvertToChosenRoleOnDeath",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/Mafia/Stylist.js
+++ b/Games/types/Mafia/roles/Mafia/Stylist.js
@@ -1,0 +1,15 @@
+const Role = require("../../Role");
+
+module.exports = class Stylist extends Role {
+  constructor(player, data) {
+    super("Stylist", player, data);
+
+    this.alignment = "Mafia";
+    this.cards = [
+      "VillageCore",
+      "WinWithFaction",
+      "MeetingFaction",
+      "StyleContest",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/cards/AppearAsVanillaEvil.js
+++ b/Games/types/Mafia/roles/cards/AppearAsVanillaEvil.js
@@ -11,7 +11,7 @@ module.exports = class AppearAsVanillaEvil extends Card {
         role.game.getRoleAlignment(r) === "Mafia"
     );
 
-    const randomEvilRole = Random.randArrayVal(evilRoles);
+    let randomEvilRole = Random.randArrayVal(evilRoles);
 
     if (this.game.getRoleAlignment(randomEvilRole) == "Cult") {
       randomEvilRole = "Cultist";

--- a/Games/types/Mafia/roles/cards/ConvertToChosenRoleOnDeath.js
+++ b/Games/types/Mafia/roles/cards/ConvertToChosenRoleOnDeath.js
@@ -1,0 +1,60 @@
+const Card = require("../../Card");
+const { PRIORITY_CONVERT_DEFAULT } = require("../../const/Priority");
+const { addArticle } = require("../../../../core/Utils");
+module.exports = class ConvertToChosenRole extends Card {
+  constructor(role) {
+    super(role);
+    //const targetOptions = this.game.PossibleRoles.filter((r) => r);
+    this.meetings = {
+      "Select Player": {
+        states: ["Night"],
+        flags: ["voting"],
+        targets: { include: ["alive", "self"] },
+        action: {
+          priority: PRIORITY_CONVERT_DEFAULT - 1,
+          run: function () {
+            this.actor.role.data.targetPlayer = this.target;
+          },
+        },
+      },
+      "Role to Become": {
+        states: ["Night"],
+        flags: ["voting"],
+        inputType: "custom",
+        action: {
+          labels: ["convert", "role"],
+          priority: PRIORITY_CONVERT_DEFAULT,
+          run: function () {
+            let targetPlayer = this.actor.role.data.targetPlayer;
+            if (targetPlayer) {
+                if (this.dominates(targetPlayer)) {
+                  targetPlayer.giveEffect("BecomeRoleOnDeath", this.actor, this.target);
+                }
+              
+              delete this.actor.role.data.targetPlayer;
+            }
+          },
+        },
+      },
+    };
+
+    this.listeners = {
+      roleAssigned: function (player) {
+        if (player !== this.player) {
+          return;
+        }
+
+        this.data.ConvertOptions = this.game.PossibleRoles.filter((r) => this.game.getRoleAlignment(r) == "Cult" && r.split(":")[0] != this.player.role.name && !this.game.getRoleTags(r).includes("Demonic"));
+      },
+      // refresh cooldown
+      state: function (stateInfo) {
+        if (!stateInfo.name.match(/Night/)) {
+          return;
+        }
+        var ConvertOptions = this.data.ConvertOptions;
+
+        this.meetings["Role to Become"].targets = ConvertOptions;
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/HauntDreams.js
+++ b/Games/types/Mafia/roles/cards/HauntDreams.js
@@ -1,7 +1,7 @@
 const Card = require("../../Card");
 const Action = require("../../Action");
 const Random = require("../../../../../lib/Random");
-const { PRIORITY_NIGHT_SAVER } = require("../../const/Priority");
+const { PRIORITY_NIGHT_ROLE_BLOCKER } = require("../../const/Priority");
 
 module.exports = class HauntDreams extends Card {
   constructor(role) {
@@ -11,14 +11,17 @@ module.exports = class HauntDreams extends Card {
       "Choose Vessal": {
         actionName: "Choose Vessal",
         states: ["Night"],
-        flags: ["voting"],
+        flags: ["voting", "mustAct"],
+        targets: { include: ["alive", "self"] },
         action: {
-          priority: PRIORITY_EFFECT_GIVER_DEFAULT,
+          priority: PRIORITY_NIGHT_ROLE_BLOCKER,
           labels: ["absolute"],
           run: function () {
             this.actor.role.loved = true;
             this.actor.role.data.DreamHost = this.target;
             this.actor.passiveEffects.push(this.target.giveEffect("Delirious", this.actor, Infinity));
+            this.blockWithDelirium(this.target);
+            this.game.events.emit("AbilityToggle", this.actor);
           },
         },
         shouldMeet() {
@@ -29,10 +32,7 @@ module.exports = class HauntDreams extends Card {
     
     this.listeners = {
       AbilityToggle: function (player) {
-        if (player != this.player) {
-          return;
-        }
-        if (this.player.hasAbility(["OnlyWhenAlive"]) && this.player.role.data.DreamHost.alive) {
+        if (this.player.hasAbility(["OnlyWhenAlive"]) && this.player.role.data.DreamHost && this.player.role.data.DreamHost.alive) {
           if (
             this.DreamImmortalEffect == null ||
             !this.player.effects.includes(this.DreamImmortalEffect)
@@ -55,7 +55,7 @@ module.exports = class HauntDreams extends Card {
           }
         }
 
-        if (this.player.hasAbility(["OnlyWhenAlive"]) && !this.player.role.data.DreamHost.alive){
+        if (this.player.hasAbility(["OnlyWhenAlive"]) && this.player.role.data.DreamHost && !this.player.role.data.DreamHost.alive){
           let action = new Action({
             actor: this.player,
             target: this.player,

--- a/Games/types/Mafia/roles/cards/HauntDreams.js
+++ b/Games/types/Mafia/roles/cards/HauntDreams.js
@@ -8,8 +8,8 @@ module.exports = class HauntDreams extends Card {
     super(role);
 
       this.meetings = {
-      "Choose Vessal": {
-        actionName: "Choose Vessal",
+      "Choose Vessel": {
+        actionName: "Choose Vessel",
         states: ["Night"],
         flags: ["voting", "mustAct"],
         targets: { include: ["alive", "self"] },

--- a/Games/types/Mafia/roles/cards/HauntDreams.js
+++ b/Games/types/Mafia/roles/cards/HauntDreams.js
@@ -8,8 +8,8 @@ module.exports = class HauntDreams extends Card {
     super(role);
 
       this.meetings = {
-      "Haunt Dreams": {
-        actionName: "Invade Dreams",
+      "Choose Vessal": {
+        actionName: "Choose Vessal",
         states: ["Night"],
         flags: ["voting"],
         action: {

--- a/Games/types/Mafia/roles/cards/HauntDreams.js
+++ b/Games/types/Mafia/roles/cards/HauntDreams.js
@@ -1,0 +1,74 @@
+const Card = require("../../Card");
+const Action = require("../../Action");
+const Random = require("../../../../../lib/Random");
+const { PRIORITY_NIGHT_SAVER } = require("../../const/Priority");
+
+module.exports = class HauntDreams extends Card {
+  constructor(role) {
+    super(role);
+
+      this.meetings = {
+      "Haunt Dreams": {
+        actionName: "Invade Dreams",
+        states: ["Night"],
+        flags: ["voting"],
+        action: {
+          priority: PRIORITY_EFFECT_GIVER_DEFAULT,
+          labels: ["absolute"],
+          run: function () {
+            this.actor.role.loved = true;
+            this.actor.role.data.DreamHost = this.target;
+            this.actor.passiveEffects.push(this.target.giveEffect("Delirious", this.actor, Infinity));
+          },
+        },
+        shouldMeet() {
+          return !this.loved;
+        },
+      },
+    };
+    
+    this.listeners = {
+      AbilityToggle: function (player) {
+        if (player != this.player) {
+          return;
+        }
+        if (this.player.hasAbility(["OnlyWhenAlive"]) && this.player.role.data.DreamHost.alive) {
+          if (
+            this.DreamImmortalEffect == null ||
+            !this.player.effects.includes(this.DreamImmortalEffect)
+          ) {
+            this.DreamImmortalEffect = this.player.giveEffect(
+              "Immortal",
+              5,
+              Infinity
+            );
+            this.player.passiveEffects.push(this.DreamImmortalEffect);
+          }
+        } else {
+          var index = this.player.passiveEffects.indexOf(this.DreamImmortalEffect);
+          if (index != -1) {
+            this.player.passiveEffects.splice(index, 1);
+          }
+          if (this.DreamImmortalEffect != null) {
+            this.DreamImmortalEffect.remove();
+            this.DreamImmortalEffect = null;
+          }
+        }
+
+        if (this.player.hasAbility(["OnlyWhenAlive"]) && !this.player.role.data.DreamHost.alive){
+          let action = new Action({
+            actor: this.player,
+            target: this.player,
+            game: this.game,
+            labels: ["kill", "hidden"],
+            power: 5,
+            run: function () {
+              if (this.dominates()) this.target.kill("basic", this.actor, true);
+            },
+          });
+          this.game.instantAction(action);
+        }
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/Holy.js
+++ b/Games/types/Mafia/roles/cards/Holy.js
@@ -3,7 +3,7 @@ const Action = require("../../Action");
 const Player = require("../../../../core/Player");
 const { PRIORITY_NIGHT_ROLE_BLOCKER } = require("../../const/Priority");
 
-module.exports = class Disloyal extends Card {
+module.exports = class Holy extends Card {
   constructor(role) {
     super(role);
 
@@ -45,7 +45,7 @@ module.exports = class Disloyal extends Card {
                 toCheck[0] instanceof Player
               ) {
                 for (let y = 0; y < toCheck.length; y++) {
-                  if (toCheck[y].role.alignment == this.actor.role.alignment) {
+                  if (toCheck[y].isDemonic(true)) {
                     if (
                       action.priority > this.priority &&
                       !action.hasLabel("absolute")

--- a/Games/types/Mafia/roles/cards/StyleContest.js
+++ b/Games/types/Mafia/roles/cards/StyleContest.js
@@ -7,15 +7,13 @@ module.exports = class StyleContest extends Card {
     super(role);
 
 
-
-    
     this.listeners = {
       AbilityToggle: function (player) {
         if (this.player.hasAbility(["WhenDead"])){
           for(let player of this.game.players){
             if(player.faction == this.player.faction){
               if(!player.hasEffect("StylePoints")){
-              let effect = player.giveEffect("Immortal", 5, Infinity);
+              let effect = player.giveEffect("StylePoints", this.player, player);
               this.player.passiveEffects.push(effect);
               }
             }

--- a/Games/types/Mafia/roles/cards/StyleContest.js
+++ b/Games/types/Mafia/roles/cards/StyleContest.js
@@ -1,0 +1,46 @@
+const Card = require("../../Card");
+const Action = require("../../Action");
+const { PRIORITY_NIGHT_SAVER } = require("../../const/Priority");
+
+module.exports = class StyleContest extends Card {
+  constructor(role) {
+    super(role);
+
+
+
+    
+    this.listeners = {
+      AbilityToggle: function (player) {
+        if (this.player.hasAbility(["WhenDead"])){
+          for(let player of this.game.players){
+            if(player.faction == this.player.faction){
+              if(!player.hasEffect("StylePoints")){
+              let effect = player.giveEffect("Immortal", 5, Infinity);
+              this.player.passiveEffects.push(effect);
+              }
+            }
+          }
+        }
+      },
+      handleWinWith: function (winners) {
+        if (!this.player.hasAbility(["Win-Con", "WhenDead"])) {
+          return;
+        }
+        let stylePlayers = [];
+        let highScore = 1;
+        for(let player of this.game.players){
+          if(player.data.StylePoints == highScore){
+            stylePlayers.push(player);
+          }
+          else if(player.data.StylePoints > highScore){
+            stylePlayers = [];
+            highScore = player.data.StylePoints;
+          }
+        }
+        if(stylePlayers.length == 1){
+        winners.addPlayer(stylePlayers[0], "Style Points");
+        }
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/Unholy.js
+++ b/Games/types/Mafia/roles/cards/Unholy.js
@@ -3,7 +3,7 @@ const Action = require("../../Action");
 const Player = require("../../../../core/Player");
 const { PRIORITY_NIGHT_ROLE_BLOCKER } = require("../../const/Priority");
 
-module.exports = class Disloyal extends Card {
+module.exports = class Unholy extends Card {
   constructor(role) {
     super(role);
 
@@ -45,7 +45,7 @@ module.exports = class Disloyal extends Card {
                 toCheck[0] instanceof Player
               ) {
                 for (let y = 0; y < toCheck.length; y++) {
-                  if (toCheck[y].role.alignment == this.actor.role.alignment) {
+                  if (!toCheck[y].isDemonic(true)) {
                     if (
                       action.priority > this.priority &&
                       !action.hasLabel("absolute")

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -244,6 +244,13 @@ const modifierData = {
       description:
         "If this player is shot or targeted for a kill, will bleed and then die in one day.",
     },
+    Holy: {
+      internal: ["Holy"],
+      tags: ["Visits", "Block Self", "Modifiers"],
+      description:
+        "If this player visits a player with a Demonic role, their secondary actions will be blocked.",
+      incompatible: ["Unholy"],
+    },
     Humble: {
       internal: ["Humble"],
       tags: ["Vanilla"],
@@ -570,6 +577,13 @@ const modifierData = {
       tags: ["Villager", "Deception"],
       description: "Appears as Villager when condemned or on death.",
       incompatible: ["Shady", "Faceless", "Suspect"],
+    },
+    Unholy: {
+      internal: ["Unholy"],
+      tags: ["Visits", "Block Self", "Modifiers"],
+      description:
+        "If this player visits a player with a non-Demonic role, their secondary actions will be blocked.",
+      incompatible: ["Holy"],
     },
     Unkillable: {
       internal: ["KillImmune"],

--- a/data/roles.js
+++ b/data/roles.js
@@ -2283,6 +2283,20 @@ const roleData = {
       ],
       RolesMadeBy: ["President"],
     },
+    Stylist: {
+      alignment: "Mafia",
+      tags: [
+        "Mini-game",
+        "Essential",
+        "Style Points",
+        "Win-Con",
+      ],
+      description: [
+        "At the end of each day, Any Living Mafia players will gain 1 Style Point for everytime they said their role in chat.",
+        "Style Points cannot be earned if only 1 Mafia player is alive.",
+        "At the end of the game reguardless of who Won, The player with the most Style Points will also Win.",
+      ],
+    },
     Prankster: {
       alignment: "Mafia",
       category: "Gaming",
@@ -2869,6 +2883,23 @@ const roleData = {
       description: [
         "Each night, may choose a player to kill.",
         "A Satyr's starting Non-banished Village-aligned neighbors are Delirious.",
+      ],
+    },
+    "Dream Eater": {
+      alignment: "Cult",
+      category: "Demon",
+      tags: [
+        "Killing",
+        "Delirium",
+        "Visiting",
+        "Night Killer",
+        "Condemn Immune",
+      ],
+      description: [
+        "Each night, may choose a player to kill.",
+        "On the first night chooses a player as a Vessal.",
+        "The Vessal is Delirious."
+        "A Dream Eater can only be killed if their Vessal is killed."
       ],
     },
     Shoggoth: {

--- a/data/roles.js
+++ b/data/roles.js
@@ -199,7 +199,7 @@ const roleData = {
       ],
       description: [
         "Each night, operates on one player to prevent them from dying or being converted.",
-        "If attacked, kills one of their killers",
+        "If that player is attacked, the Surgeon kills one of their attackers",
       ],
     },
     "Tea Lady": {
@@ -2898,8 +2898,8 @@ const roleData = {
       description: [
         "Each night, may choose a player to kill.",
         "On the first night chooses a player as a Vessal.",
-        "The Vessal is Delirious."
-        "A Dream Eater can only be killed if their Vessal is killed."
+        "The Vessal is Delirious.",
+        "A Dream Eater can only be killed if their Vessal is killed.",
       ],
     },
     Shoggoth: {

--- a/data/roles.js
+++ b/data/roles.js
@@ -2592,6 +2592,23 @@ const roleData = {
         "Independant roles can only be converted to other Independant roles.",
       ],
     },
+    "Facehugger": {
+      alignment: "Cult",
+      category: "Manipulative",
+      tags: [
+        "Night-acting",
+        "Conversion",
+        "Roles",
+        "Manipulative",
+        "Visiting",
+        "Effect",
+      ],
+      description: [
+        "Each night chooses a player and a non-Demonic Cult role.",
+        "When that player dies they will be converted to that role and become Transcendent.",
+      ],
+      graveyardParticipation: "all",
+    },
     "Queen Bee": {
       alignment: "Cult",
       category: "Manipulative",

--- a/data/roles.js
+++ b/data/roles.js
@@ -2897,8 +2897,8 @@ const roleData = {
       ],
       description: [
         "Each night, may choose a player to kill.",
-        "On the first night chooses a player as a Vessal.",
-        "The Vessal is Delirious.",
+        "On the first night chooses a player as a Vessel.",
+        "The Vessel is Delirious.",
         "A Dream Eater can only be killed if their Vessal is killed.",
       ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,34 +5,34 @@
   "requires": true,
   "dependencies": {
     "@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "optional": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "optional": true
     },
     "@babel/parser": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.1.tgz",
+      "integrity": "sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==",
       "optional": true,
       "requires": {
-        "@babel/types": "^7.27.0"
+        "@babel/types": "^7.27.1"
       }
     },
     "@babel/types": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
+      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
       "optional": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       }
     },
     "@braintree/wrap-promise": {
@@ -233,9 +233,9 @@
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
-      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
       "optional": true,
       "requires": {
         "lodash.camelcase": "^4.3.0",
@@ -585,6 +585,32 @@
         }
       }
     },
+    "@pm2/pm2-version-check": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@pm2/pm2-version-check/-/pm2-version-check-1.0.4.tgz",
+      "integrity": "sha512-SXsM27SGH3yTWKc2fKR4SYNxsmnvuBQ9dd6QHtEWmiZ/VqaOYPAIlS8+vMcn27YLtAEBGvNRSh3TPNvtjZgfqA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+          "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -786,11 +812,11 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "@types/node": {
-      "version": "22.13.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
-      "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
+      "version": "22.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
+      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
       "requires": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "@types/qs": {
@@ -1210,9 +1236,9 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
     "bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
+      "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
       "optional": true
     },
     "binary-extensions": {
@@ -1887,9 +1913,9 @@
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
     },
     "detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="
     },
     "diff": {
       "version": "7.0.0",
@@ -3249,9 +3275,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.9.tgz",
-      "integrity": "sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw=="
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA=="
     },
     "http-proxy-agent": {
       "version": "5.0.0",
@@ -4095,9 +4121,9 @@
       }
     },
     "long": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
-      "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "optional": true
     },
     "loose-envify": {
@@ -4505,9 +4531,9 @@
       }
     },
     "module-details-from-path": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "dev": true
     },
     "mongodb": {
@@ -4681,9 +4707,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "3.74.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz",
-      "integrity": "sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==",
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
       "requires": {
         "semver": "^7.3.5"
       }
@@ -4933,9 +4959,9 @@
       },
       "dependencies": {
         "axios": {
-          "version": "1.8.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-          "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+          "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
           "requires": {
             "follow-redirects": "^1.15.6",
             "form-data": "^4.0.0",
@@ -5312,15 +5338,6 @@
         "yamljs": "0.3.0"
       },
       "dependencies": {
-        "@pm2/pm2-version-check": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/@pm2/pm2-version-check/-/pm2-version-check-1.0.4.tgz",
-          "integrity": "sha512-SXsM27SGH3yTWKc2fKR4SYNxsmnvuBQ9dd6QHtEWmiZ/VqaOYPAIlS8+vMcn27YLtAEBGvNRSh3TPNvtjZgfqA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.3.1"
-          }
-        },
         "chalk": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -5601,9 +5618,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.0.tgz",
+      "integrity": "sha512-Z2E/kOY1QjoMlCytmexzYfDm/w5fKAiRwpSzGtdnXW1zC88Z2yXazHHrOtwCzn+7wSxyE8PYM4rvVcMphF9sOA==",
       "optional": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -7206,9 +7223,9 @@
       "optional": true
     },
     "undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "unherit": {
       "version": "1.1.3",

--- a/react_main/src/css/gameCardGames.css
+++ b/react_main/src/css/gameCardGames.css
@@ -236,7 +236,7 @@
   background-position: -586px -130px;
 }
 .c10-Spades {
-  background-position: -586px -130px;
+  background-position: -586px -194px;
 }
 
 .cJack-Hearts {

--- a/react_main/src/css/roles.css
+++ b/react_main/src/css/roles.css
@@ -1723,7 +1723,7 @@
 }
 
 .role-icon-scheme-vivid .role-Mafia-Lightning-Strike {
-  background-image: url("/images/roles/lightningstrike-vivid.png");
+  background-image: url("/images/roles/lightning-strike-vivid.png");
 }
 
 .role-icon-scheme-vivid .role-Mafia-Volcanic-Eruption {


### PR DESCRIPTION
10 of spades no longer uses 10 of clubs sprite

Facehugger from discord message Golbolco sent me.

BOTC leech as Dream Eater, Each night can kill a player. On night 1 chooses a player as Vessel, The vessel is delirious. The dream eater can only be killed by killing the vessel.

Holy- Can only target non-demonic players
Unholy- Can only target demonic players.



I also gave into my intrusive thoughts and added the Stylist role. It lets the mafia member who says their role in chat the most win even if mafia loses.