### PR TITLE
tailor and Gunrunner changes

### DIFF
--- a/Games/types/Mafia/items/Gun.js
+++ b/Games/types/Mafia/items/Gun.js
@@ -73,7 +73,8 @@ module.exports = class Gun extends Item {
             }
 
             // kill
-            if (mafiaImmune && this.target.faction != this.actor.faction) return;
+            if (mafiaImmune && this.target.faction != this.actor.faction)
+              return;
 
             if (this.dominates()) {
               this.target.kill("gun", this.actor, true);

--- a/Games/types/Mafia/items/Gun.js
+++ b/Games/types/Mafia/items/Gun.js
@@ -73,7 +73,7 @@ module.exports = class Gun extends Item {
             }
 
             // kill
-            if (mafiaImmune && this.target.role.alignment == "Mafia") return;
+            if (mafiaImmune && this.target.faction != this.actor.faction) return;
 
             if (this.dominates()) {
               this.target.kill("gun", this.actor, true);

--- a/Games/types/Mafia/roles/cards/GiveTommyGun.js
+++ b/Games/types/Mafia/roles/cards/GiveTommyGun.js
@@ -9,7 +9,7 @@ module.exports = class GiveTommyGun extends Card {
       "Give Tommy Gun": {
         states: ["Night"],
         flags: ["voting"],
-        targets: { include: ["alive"], exclude: ["Mafia"] },
+        targets: { include: ["alive", "self"]},
         action: {
           labels: ["giveItem", "gun"],
           priority: PRIORITY_ITEM_GIVER_DEFAULT,

--- a/Games/types/Mafia/roles/cards/GiveTommyGun.js
+++ b/Games/types/Mafia/roles/cards/GiveTommyGun.js
@@ -9,7 +9,7 @@ module.exports = class GiveTommyGun extends Card {
       "Give Tommy Gun": {
         states: ["Night"],
         flags: ["voting"],
-        targets: { include: ["alive", "self"]},
+        targets: { include: ["alive", "self"] },
         action: {
           labels: ["giveItem", "gun"],
           priority: PRIORITY_ITEM_GIVER_DEFAULT,

--- a/Games/types/Mafia/roles/cards/TailorSuit.js
+++ b/Games/types/Mafia/roles/cards/TailorSuit.js
@@ -18,7 +18,7 @@ module.exports = class TailorSuit extends Card {
             }
 
             this.target.holdItem("Suit", { type: this.actor.role.data.suit });
-            this.target.queueAlert(":suit: You have received a suit!");
+            //this.target.queueAlert(":suit: You have received a suit!");
             delete this.actor.role.data.suit;
           },
         },

--- a/data/roles.js
+++ b/data/roles.js
@@ -1856,7 +1856,7 @@ const roleData = {
       tags: ["Gifting", "Killing", "Items", "Gun", "Tommy", "Visiting"],
       description: [
         "Gives out a tommy gun each night.",
-        "Tommy gun will only kill the target if not aligned with the Mafia.",
+        "Tommy gun will only kill the target if aligned with the shooter.",
         "The gunned player will not know the gun is a tommy gun.",
       ],
     },
@@ -2720,9 +2720,9 @@ const roleData = {
       category: "Chaos",
       tags: ["Win Con", "Essential", "Voting", "Condemn"],
       description: [
-        "If a Cult role that kills the team on death dies, the Zealot will prevent those deaths.",
-        "On the Day following the Zealots death prevention, If a Village Aligned player is condemned, Cult Wins.",
-        "If no one is condemned or a Non-Village player is condemned on the day following the Zealots death prevention, All Cult-aligned players die.",
+        "If a Demonic or Lichpin Cult role is condemned and the game would have ended, the game will continue for 1 more day.",
+        "On the following Day, If a Village Aligned player is condemned, Cult Wins.",
+        "If no one is condemned or a Non-Village player is condemned on the following day, All Cult-aligned players die.",
       ],
     },
     Gremlin: {

--- a/data/roles.js
+++ b/data/roles.js
@@ -2721,8 +2721,8 @@ const roleData = {
       tags: ["Win Con", "Essential", "Voting", "Condemn"],
       description: [
         "If a Demonic or Lichpin Cult role is condemned and the game would have ended, the game will continue for 1 more day.",
-        "On the following Day, If a Village Aligned player is condemned, Cult Wins.",
-        "If no one is condemned or a Non-Village player is condemned on the following day, All Cult-aligned players die.",
+        "On the extra Day, If a Village Aligned player is condemned, Cult Wins.",
+        "If no one is condemned or a Non-Village player is condemned on the extra day, All Cult-aligned players die.",
       ],
     },
     Gremlin: {


### PR DESCRIPTION
Tailor does not tell players about suits
Old tailor can be made with Clumsy

Gunrunner guns now can only kill players of the same alignment as the shooter. (Village can only kill Village, Mafia can only kill mafia, etc)
Gunrunner can now gun mafia and themselves.
Old Gunrunner can be made with disloyal.

Zealot description improvement (I think)