### PR TITLE
fix(emotes): null check

### DIFF
--- a/react_main/src/components/EmotePicker.jsx
+++ b/react_main/src/components/EmotePicker.jsx
@@ -31,16 +31,16 @@ export default function EmotePicker(props) {
     panelRef.current.style.visibility = "visible";
   });
 
-  const customEmotesMap = Object.keys(user.settings.customEmotes || {});
+  const userCustomEmotes = user.settings.customEmotes || {};
   const customEmotes = (
     <>
-      {customEmotesMap.map((customEmote) => (
+      {Object.keys(userCustomEmotes).map((customEmote) => (
         <div
           className="emote"
           key={customEmote}
           onClick={(e) => selectEmote(e, customEmote)}
         >
-          {emotify(customEmote, user.settings.customEmotes)}
+          {emotify(customEmote, userCustomEmotes)}
         </div>
       ))}
     </>

--- a/react_main/src/components/EmotePicker.jsx
+++ b/react_main/src/components/EmotePicker.jsx
@@ -31,7 +31,7 @@ export default function EmotePicker(props) {
     panelRef.current.style.visibility = "visible";
   });
 
-  const userCustomEmotes = user.settings.customEmotes || {};
+  const userCustomEmotes = user.settings?.customEmotes || {};
   const customEmotes = (
     <>
       {Object.keys(userCustomEmotes).map((customEmote) => (


### PR DESCRIPTION
guests are getting critical error and staring at a blank screen

0.chunk.js:217627 Uncaught TypeError: Cannot read properties of undefined (reading 'customEmotes')
    at EmotePicker (1.chunk.js:1800:42)
    at renderWithHooks (0.chunk.js:183740:22)
    at mountIndeterminateComponent (0.chunk.js:186069:17)
    at beginWork (0.chunk.js:187006:20)
    at HTMLUnknownElement.callCallback (0.chunk.js:171043:18)
    at Object.invokeGuardedCallbackDev (0.chunk.js:171087:20)
    at invokeGuardedCallback (0.chunk.js:171135:35)
    at beginWork$1 (0.chunk.js:190906:11)
    at performUnitOfWork (0.chunk.js:190030:16)
    at workLoopSync (0.chunk.js:190006:26)
    at performSyncWorkOnRoot (0.chunk.js:189676:13)
    at 0.chunk.js:180652:28
    at unstable_runWithPriority (0.chunk.js:218042:16)
    at runWithPriority$1 (0.chunk.js:180607:14)
    at flushSyncCallbackQueueImpl (0.chunk.js:180648:11)
    at flushSyncCallbackQueue (0.chunk.js:180638:7)
    at flushPassiveEffectsImpl (0.chunk.js:190639:7)
    at unstable_runWithPriority (0.chunk.js:218042:16)
    at runWithPriority$1 (0.chunk.js:180607:14)
    at flushPassiveEffects (0.chunk.js:190589:16)
    at 0.chunk.js:190486:15
    at workLoop (0.chunk.js:217997:38)
    at flushWork (0.chunk.js:217959:20)
    at MessagePort.performWorkUntilDeadline (0.chunk.js:217614:31)