### PR TITLE
Reworked Setup component

### DIFF
--- a/react_main/src/Main.jsx
+++ b/react_main/src/Main.jsx
@@ -55,6 +55,7 @@ import {
 } from "./constants/themes";
 import { Announcement } from "./components/alerts/Announcement";
 import { BadTextContrast } from "./components/alerts/BadTextContrast";
+import { useIsPhoneDevice } from "./hooks/useIsPhoneDevice";
 
 function Main() {
   var cacheVal = window.localStorage.getItem("cacheVal");
@@ -70,6 +71,8 @@ function Main() {
   const openAnnouncements = () => {
     setShowAnnouncementTemporarily(true);
   };
+
+  const isPhoneDevice = useIsPhoneDevice();
 
   const user = useUser();
   const siteInfo = useSiteInfo({
@@ -197,6 +200,10 @@ function Main() {
     return <NewLoading />;
   }
 
+  const style = isPhoneDevice
+    ? { padding: "8px" }
+    : { padding: "24px" };
+
   return (
     <UserContext.Provider value={user}>
       <SiteInfoContext.Provider value={siteInfo}>
@@ -211,7 +218,7 @@ function Main() {
               </Route>
               <Route path="/">
                 <div className="site-wrapper">
-                  <div className="main-container">
+                  <div className="main-container" style={style}>
                     <Header
                       setShowAnnouncementTemporarily={
                         setShowAnnouncementTemporarily

--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -124,6 +124,9 @@
 
 .game .misc-wrapper .setup {
   align-self: center;
+
+  margin-bottom: 8px;
+  margin-right: 8px;
 }
 
 .game .misc-wrapper .setup .role-count-wrap {
@@ -149,16 +152,6 @@
 
 .game .misc-wrapper .misc-icon.fa-microphone:hover {
   opacity: 1;
-}
-
-.game .misc-wrapper .game-buttons {
-  display: flex;
-  gap: 8px;
-}
-
-.leave-game,
-.rehost-game {
-  margin-left: 10px;
 }
 
 .game .options .player-count i,

--- a/react_main/src/css/host.css
+++ b/react_main/src/css/host.css
@@ -26,26 +26,6 @@
   background-color: var(--theme-color-sec);
 }
 
-.host .row .setup-wrapper {
-  display: flex;
-  flex-flow: row nowrap;
-  align-items: stretch;
-  justify-content: flex-start;
-
-  width: 500px;
-  height: 100%;
-}
-
-.host .row .setup-name {
-  width: 300px;
-  margin-left: 5px;
-
-  overflow-x: hidden;
-  font-weight: bold;
-  opacity: 0.6;
-  white-space: nowrap;
-}
-
 .host .row i:hover {
   opacity: 0.8;
 }

--- a/react_main/src/css/play.css
+++ b/react_main/src/css/play.css
@@ -54,7 +54,6 @@
   align-items: center;
   justify-content: flex-start;
   background-color: var(--scheme-color);
-  height: var(--rowHeight);
   padding: 8px;
 }
 .row.odd {

--- a/react_main/src/css/setup.css
+++ b/react_main/src/css/setup.css
@@ -4,25 +4,15 @@
   display: flex;
   flex-flow: row nowrap;
   align-items: center;
-  flex-wrap: nowrap;
 
-  height: 100%;
-  max-width: 100%;
   border-radius: 3px;
-  overflow: hidden;
+  overflow: visible;
+  
+  margin-left: 4px;
+  margin-right: 4px;
 
-  color: var(--scheme-color-text);
+  background-color: #121212;
   cursor: pointer;
-}
-
-.setup .fa-ellipsis-h {
-  align-self: flex-end;
-  margin-left: 5px;
-}
-
-.setup .multi-setup-icon {
-  font-size: 20px;
-  margin-right: 5px;
 }
 
 .popover .setup,

--- a/react_main/src/css/user.css
+++ b/react_main/src/css/user.css
@@ -104,7 +104,7 @@ iframe {
 
 .love {
   display: inline-flex;
-  flex-flow: row;
+  flex-flow: row wrap;
   align-items: center;
   justify-content: right;
   margin: 8px;

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -59,6 +59,7 @@ import {
   ButtonGroup,
   TextField,
   Typography,
+  Stack,
 } from "@mui/material";
 import { useTheme } from "@mui/styles";
 import BattlesnakesGame from "./BattlesnakesGame";
@@ -783,6 +784,9 @@ export function BotBar(props) {
       });
   }
 
+  const maxRolesCount = isPhoneDevice ? 5 : 10;
+  const gameButtonStackDirection = isPhoneDevice ? "column" : "row";
+
   return (
     <div className="top">
       {!isPhoneDevice && (
@@ -812,8 +816,7 @@ export function BotBar(props) {
             : {}
         }
       >
-        {props.setup && <Setup setup={props.setup} maxRolesCount={10} />}
-
+        {props.setup && <Setup setup={props.setup} maxRolesCount={maxRolesCount} fixedWidth />}
         <div className="misc-left">
           <div className="misc-buttons">
             <i
@@ -857,7 +860,7 @@ export function BotBar(props) {
             )}
           </div>
         </div>
-        <div className="game-buttons">
+        <Stack direction={gameButtonStackDirection} spacing={1}>
           {props.review && (
             <Button
               className="btn btn-theme-sec archive-game"
@@ -880,7 +883,7 @@ export function BotBar(props) {
               Rehost
             </Button>
           )}
-        </div>
+        </Stack>
       </div>
     </div>
   );

--- a/react_main/src/pages/Play/Host/HostBrowser.jsx
+++ b/react_main/src/pages/Play/Host/HostBrowser.jsx
@@ -12,6 +12,8 @@ import { useErrorAlert } from "../../../components/Alerts";
 import "../../../css/host.css";
 import { BotBarLink } from "../Play";
 import { clamp } from "../../../lib/MathExt";
+import { useIsPhoneDevice } from "../../../hooks/useIsPhoneDevice";
+import { Stack } from "@mui/material";
 
 export default function HostBrowser(props) {
   const gameType = props.gameType;
@@ -293,6 +295,7 @@ export default function HostBrowser(props) {
 
 function SetupRow(props) {
   const user = useContext(UserContext);
+  const isPhoneDevice = useIsPhoneDevice();
 
   let selIconFormat = "far";
   let favIconFormat = "far";
@@ -300,6 +303,8 @@ function SetupRow(props) {
   if (props.sel.id === props.setup.id) selIconFormat = "fas";
 
   if (props.setup.favorite) favIconFormat = "fas";
+
+  const maxRolesCount = isPhoneDevice ? 6 : 12;
 
   return (
     <div className={`row ${props.odd ? "odd" : ""}`}>
@@ -309,36 +314,36 @@ function SetupRow(props) {
           onClick={() => props.onSelect(props.setup)}
         />
       )}
-      <div className="setup-wrapper">
-        <Setup setup={props.setup} />
-      </div>
-      <div className="setup-name">
-        {filterProfanity(props.setup.name, user.settings)}
-      </div>
-      {user.loggedIn && (
-        <i
-          className={`setup-btn fav-setup fa-star ${favIconFormat}`}
-          onClick={() => props.onFav(props.setup)}
-        />
-      )}
-      {user.loggedIn && props.setup.creator?.id === user.id && (
-        <i
-          className={`setup-btn edit-setup fa-pen-square fas`}
-          onClick={() => props.onEdit(props.setup)}
-        />
-      )}
-      {user.loggedIn && (
-        <i
-          className={`setup-btn copy-setup fa-copy fas`}
-          onClick={() => props.onCopy(props.setup)}
-        />
-      )}
-      {user.loggedIn && props.setup.creator?.id === user.id && (
-        <i
-          className={`setup-btn del-setup fa-times-circle fas`}
-          onClick={() => props.onDel(props.setup)}
-        />
-      )}
+      <Setup setup={props.setup} maxRolesCount={maxRolesCount} fixedWidth />
+      <Stack direction="row" sx={{
+        marginLeft: "auto",
+        marginTop: "8px"
+      }}>
+        {user.loggedIn && (
+          <i
+            className={`setup-btn fav-setup fa-star ${favIconFormat}`}
+            onClick={() => props.onFav(props.setup)}
+          />
+        )}
+        {user.loggedIn && props.setup.creator?.id === user.id && (
+          <i
+            className={`setup-btn edit-setup fa-pen-square fas`}
+            onClick={() => props.onEdit(props.setup)}
+          />
+        )}
+        {user.loggedIn && (
+          <i
+            className={`setup-btn copy-setup fa-copy fas`}
+            onClick={() => props.onCopy(props.setup)}
+          />
+        )}
+        {user.loggedIn && props.setup.creator?.id === user.id && (
+          <i
+            className={`setup-btn del-setup fa-times-circle fas`}
+            onClick={() => props.onDel(props.setup)}
+          />
+        )}
+      </Stack>
     </div>
   );
 }

--- a/react_main/src/pages/Play/LobbyBrowser/GameRow.jsx
+++ b/react_main/src/pages/Play/LobbyBrowser/GameRow.jsx
@@ -11,16 +11,159 @@ import {
   Button,
   IconButton,
   ListItemButton,
+  Stack,
   Typography,
 } from "@mui/material";
 import { useIsPhoneDevice } from "../../../hooks/useIsPhoneDevice";
 
+const GameStatus = (props) => {
+  const user = useContext(UserContext);
+  const isPhoneDevice = useIsPhoneDevice();
+
+  const canShowGameButton =
+    (user.loggedIn || props.status === "Finished") &&
+    !props.game.broken &&
+    !props.game.private;
+  const gameButtonDisabled =
+    props?.status === "In Progress" && !props.game.spectating;
+  const stackedVertically = props.stackedVertically;
+  const showGameTypeIcon = props.showGameTypeIcon;
+
+  let buttonUrl, buttonText, buttonVariant, buttonColor;
+  if (props.game.status === "Open") {
+    buttonUrl = `/game/${props.game.id}`;
+    buttonText = "Join";
+    buttonColor = "secondary";
+    buttonVariant = "contained";
+  } else if (props.game.status === "In Progress") {
+    if (props.game.spectating || user.perms.canSpectateAny) {
+      buttonUrl = `/game/${props.game.id}`;
+      buttonText = "Spectate";
+      buttonColor = "info";
+      buttonVariant = "outlined";
+    } else {
+      buttonUrl = "/play";
+      buttonText = "In Progress";
+      buttonColor = "secondary";
+      buttonVariant = "outlined";
+    }
+  } else if (props.game.status === "Finished") {
+    buttonUrl = `/game/${props.game.id}`;
+    buttonText = "Review";
+    buttonColor = "primary";
+    buttonVariant = "outlined";
+  }
+
+  const GameTypeIcon = (
+    <Box
+      sx={{
+        textAlign: "center",
+        minWidth: "20px",
+      }}
+    >
+      {props.game.ranked && (
+        <i
+          className="fas fa-heart"
+          title="Ranked game"
+          style={{ color: "#e23b3b" }}
+        />
+      )}
+      {props.game.competitive && (
+        <i
+          className="fas fa-heart"
+          title="Competitive game"
+          style={{ color: "#edb334" }}
+        />
+      )}
+    </Box>
+  );
+
+  const GameButton = (
+    <Link to={buttonUrl} disabled={gameButtonDisabled}>
+      <Button
+        variant={buttonVariant}
+        color={buttonColor}
+        sx={{
+          p: 0.5,
+          textTransform: "none",
+          width: "100%",
+          ...(props?.game?.status === "In Progress"
+            ? { cursor: "default" }
+            : {}),
+          transform: "translate3d(0,0,0)",
+          fontWeight: "800",
+        }}
+      >
+        {buttonText}
+      </Button>
+    </Link>
+  );
+
+  const gameButtonWrapped = (
+    <Box sx={{ minWidth: isPhoneDevice || props.small ? "88px" : "100px", ml: 0.5 }}>
+      {canShowGameButton && GameButton}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+        }}
+      >
+        {props.game.broken && (
+          <i
+            className="fas fa-car-crash"
+            style={{ fontSize: "24px" }}
+            title="Broken"
+          />
+        )}
+        {props.game.private && (
+          <i
+            className="fas fa-lock"
+            style={{ fontSize: "24px" }}
+            title="Private"
+          />
+        )}
+      </div>
+    </Box>
+  );
+
+  return (
+    <>
+      <Stack direction="column" spacing={0.5} sx={{
+        ml: isPhoneDevice || props?.small ? 0.5 : 1,
+      }}>
+        {showGameTypeIcon && GameTypeIcon}
+        {props.game.anonymousGame && (<i className="fas fa-theater-masks" title="Anonymous game" />)}
+      </Stack>
+      <Stack direction={stackedVertically ? "column" : "row"} spacing={1}
+        sx={{
+          alignItems: "center",
+          justifyContent: "space-around",
+          height: stackedVertically ? "100%" : undefined,
+          ml: "8px",
+          mr: "8px",
+        }}>
+        <PlayerCount game={props.game} small={props?.small} />
+        {gameButtonWrapped}
+      </Stack>
+    </>
+  );
+};
+
 export const GameRow = (props) => {
   const isPhoneDevice = useIsPhoneDevice();
   const [redirect, setRedirect] = useState(false);
-
   const user = useContext(UserContext);
   const errorAlert = useErrorAlert();
+
+  const showLobbyName = props.showLobbyName;
+  const showGameTypeIcon = props.showGameTypeIcon;
+  const showRedoButton = isPhoneDevice
+    ? !props.small && props.game.status === "Finished" && user.loggedIn
+    : !props.small;
+  const stackedVertically = props?.small || isPhoneDevice;
+  const setupOnNewRow = isPhoneDevice || props.small;
+  const maxRolesCount = props.maxRolesCount || undefined;
+  const lobbyName = "";
 
   const onRehostClick = () => {
     var stateLengths = {};
@@ -57,123 +200,23 @@ export const GameRow = (props) => {
       .catch(errorAlert);
   };
 
-  const canShowGameButton =
-    (user.loggedIn || props.status === "Finished") &&
-    !props.game.broken &&
-    !props.game.private;
-  const gameButtonDisabled =
-    props?.status === "In Progress" && !props.game.spectating;
-
-  let buttonUrl, buttonText, buttonVariant, buttonColor;
-  if (props.game.status === "Open") {
-    buttonUrl = `/game/${props.game.id}`;
-    buttonText = "Join";
-    buttonColor = "secondary";
-    buttonVariant = "contained";
-  } else if (props.game.status === "In Progress") {
-    if (props.game.spectating || user.perms.canSpectateAny) {
-      buttonUrl = `/game/${props.game.id}`;
-      buttonText = "Spectate";
-      buttonColor = "info";
-      buttonVariant = "outlined";
-    } else {
-      buttonUrl = "/play";
-      buttonText = "In Progress";
-      buttonColor = "secondary";
-      buttonVariant = "outlined";
-    }
-  } else if (props.game.status === "Finished") {
-    buttonUrl = `/game/${props.game.id}`;
-    buttonText = "Review";
-    buttonColor = "primary";
-    buttonVariant = "outlined";
-  }
-  const GameButton = (
-    <Link to={buttonUrl} disabled={gameButtonDisabled}>
-      <Button
-        variant={buttonVariant}
-        color={buttonColor}
-        sx={{
-          p: 0.5,
-          textTransform: "none",
-          width: "100%",
-          ...(props?.game?.status === "In Progress"
-            ? { cursor: "default" }
-            : {}),
-          transform: "translate3d(0,0,0)",
-          fontWeight: "800",
-        }}
-      >
-        {buttonText}
-      </Button>
-    </Link>
-  );
-
-  const showGameTypeIcon =
-    isPhoneDevice || props.small
-      ? props.game.ranked || props.game.competitive
-      : true;
-  const GameTypeIcon = (
-    <Box
-      sx={{
-        textAlign: "center",
-        mx: 0.5,
-        ...(props.small ? { ml: 0 } : {}),
-        minWidth: "28px" /* 20pxheart + 0.5x8x2 margin-x */,
-      }}
-    >
-      {props.game.ranked && (
-        <i
-          className="fas fa-heart"
-          title="Ranked game"
-          style={{ color: "#e23b3b" }}
-        />
-      )}
-      {props.game.competitive && (
-        <i
-          className="fas fa-heart"
-          title="Competitive game"
-          style={{ color: "#edb334" }}
-        />
-      )}
-    </Box>
-  );
-  const showRedoButton = isPhoneDevice
-    ? !props.small && props.game.status === "Finished" && user.loggedIn
-    : !props.small;
-  const RightSideComponents = (
-    <Box
-      sx={{
-        display: "flex",
-        marginLeft: "auto",
-        alignItems: "center",
-        ...(!isPhoneDevice ? { whiteSpace: "nowrap" } : {}),
-        mr: 0.5,
-      }}
-    >
-      <Typography variant="body2">
-        {filterProfanity(props.game.setup.name, user.settings)}
-      </Typography>
-
-      {showRedoButton && (
-        <Box style={{ mx: 1, width: "32px", textAlign: "center" }}>
-          {props.game.status === "Finished" && user.loggedIn && (
-            <IconButton color="primary" onClick={onRehostClick}>
-              <i className="rehost fas fa-redo" title="Rehost" />
-            </IconButton>
-          )}
-        </Box>
-      )}
-    </Box>
-  );
   const SetupWrapped = (
     <Setup
       setup={props.game.setup}
-      maxRolesCount={props.small ? 3 : undefined}
-      anonymousGame={props.game.anonymousGame}
+      maxRolesCount={props.small ? 3 : maxRolesCount}
+      fixedWidth
     />
   );
-  const setupOnNewRow = isPhoneDevice || props.small;
+
+  const redoButton = (
+    <Box style={{ mx: 1, width: "32px", textAlign: "center" }}>
+      {props.game.status === "Finished" && user.loggedIn && (
+        <IconButton color="primary" onClick={onRehostClick}>
+          <i className="rehost fas fa-redo" title="Rehost" />
+        </IconButton>
+      )}
+    </Box>
+  );
 
   if (redirect) return <Redirect to={redirect} />;
   if (!props.game.setup) return <></>;
@@ -213,40 +256,48 @@ export const GameRow = (props) => {
       <Box
         sx={{
           display: "flex",
+          flexWrap: "wrap",
           alignItems: "center",
           width: "100%",
         }}
       >
-        {showGameTypeIcon && GameTypeIcon}
-        <Box sx={{ minWidth: props.small ? "88px" : "100px", ml: 0.5 }}>
-          {canShowGameButton && GameButton}
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "center",
+        <GameStatus 
+          small={props?.small}
+          game={props.game}
+          status={props.status}
+          showGameTypeIcon={showGameTypeIcon}
+          stackedVertically={stackedVertically}
+        />
+        {showLobbyName && !stackedVertically && (<Typography variant="body2">
+          {filterProfanity(lobbyName, user.settings)}
+        </Typography>)}
+        <Stack direction={stackedVertically ? "column" : "row"} sx={{
+          marginLeft: "auto"
+        }}>
+          <Stack direction="row" sx={{
+              alignItems: "center",
             }}
           >
-            {props.game.broken && (
-              <i
-                className="fas fa-car-crash"
-                style={{ fontSize: "24px" }}
-                title="Broken"
-              />
-            )}
-            {props.game.private && (
-              <i
-                className="fas fa-lock"
-                style={{ fontSize: "24px" }}
-                title="Private"
-              />
-            )}
-          </div>
-        </Box>
-        <PlayerCount game={props.game} small={props?.small} />
-        {!setupOnNewRow && SetupWrapped}
-        {RightSideComponents}
+            {showLobbyName && stackedVertically && (<Typography variant="body2">
+              {filterProfanity(lobbyName, user.settings)}
+            </Typography>)}
+            {showRedoButton && isPhoneDevice && (<Box sx={{ marginLeft: "auto" }}>{redoButton}</Box>)}
+          </Stack>
+          <Box
+            sx={{
+              display: "flex",
+              marginLeft: "auto",
+              alignItems: "center",
+              //...(!isPhoneDevice ? { whiteSpace: "nowrap" } : {}),
+              mr: 0.5,
+            }}
+          >
+            {!setupOnNewRow && SetupWrapped}
+            {showRedoButton && !isPhoneDevice && redoButton}
+            <Box sx={{ marginX: "auto" }}>{setupOnNewRow && SetupWrapped}</Box>
+          </Box>
+        </Stack>
       </Box>
-      <Box sx={{ marginX: "auto" }}>{setupOnNewRow && SetupWrapped}</Box>
     </ListItemButton>
   );
 };

--- a/react_main/src/pages/Play/LobbyBrowser/LobbyBrowser.jsx
+++ b/react_main/src/pages/Play/LobbyBrowser/LobbyBrowser.jsx
@@ -197,6 +197,7 @@ export const LobbyBrowser = () => {
       </div>
     </Box>
   );
+  const maxRolesCount = isPhoneDevice ? 4 : 10;
   const gameList = loading ? (
     <NewLoading small />
   ) : games.length ? (
@@ -208,6 +209,9 @@ export const LobbyBrowser = () => {
           refresh={() => getGameList(listType, page)}
           odd={games.indexOf(game) % 2 === 1}
           key={game.id}
+          showLobbyName
+          showGameTypeIcon
+          maxRolesCount={maxRolesCount}
         />
       ))}
     </List>

--- a/react_main/src/pages/Play/LobbyBrowser/RecentlyPlayedSetups.jsx
+++ b/react_main/src/pages/Play/LobbyBrowser/RecentlyPlayedSetups.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, useContext } from "react";
 import axios from "axios";
 import { Redirect } from "react-router-dom";
-import { Box, Card, IconButton, Typography } from "@mui/material";
+import { Box, IconButton, Paper, Stack, Typography } from "@mui/material";
 import { UserContext } from "../../../Contexts";
 import { useErrorAlert } from "../../../components/Alerts";
 import { getRecentlyPlayedSetups } from "../../../services/gameService";
@@ -69,6 +69,7 @@ export const RecentlyPlayedSetups = ({ daysInterval = 7 }) => {
     if (redirect) return <Redirect to={redirect} />;
 
     const showRedoButton = isPhoneDevice ? user.loggedIn : true;
+    const maxRolesCount = isPhoneDevice ? 5 : 7;
 
     return (
       <Box
@@ -79,8 +80,7 @@ export const RecentlyPlayedSetups = ({ daysInterval = 7 }) => {
           alignItems: "center",
         }}
       >
-        <Setup setup={setup.setupDetails} />
-        <Typography variant="body2">{setup.setupDetails.name}</Typography>
+        <Setup setup={setup.setupDetails} maxRolesCount={maxRolesCount} fixedWidth />
         {showRedoButton && (
           <Box style={{ mx: 1, width: "32px", textAlign: "center" }}>
             {user.loggedIn && (
@@ -95,16 +95,18 @@ export const RecentlyPlayedSetups = ({ daysInterval = 7 }) => {
   });
 
   return (
-    <Card variant="outlined">
+    <Paper>
       <Box sx={{ p: 2 }}>
         <Typography color="primary" gutterBottom>
           Most popular setups
         </Typography>
-        {setupRows}
+        <Stack spacing={1}>
+          {setupRows}
+        </Stack>
         <Box sx={{ mt: 2 }}>
           <svg ref={svgRef} />
         </Box>
       </Box>
-    </Card>
+    </Paper>
   );
 };

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -31,6 +31,7 @@ import { NewLoading } from "../Welcome/NewLoading";
 import { GameRow } from "../Play/LobbyBrowser/GameRow";
 import { Box, IconButton, Typography } from "@mui/material";
 import { useTheme } from "@mui/styles";
+import { useIsPhoneDevice } from "../../hooks/useIsPhoneDevice";
 
 export const KUDOS_ICON = `/images/kudos.png`;
 export const KARMA_ICON = `/images/karma.png`;
@@ -80,6 +81,7 @@ export default function Profile() {
   const history = useHistory();
   const errorAlert = useErrorAlert();
   const { userId } = useParams();
+  const isPhoneDevice = useIsPhoneDevice();
 
   const isSelf = userId === user.id;
   const isBlocked = !isSelf && user.blockedUsers.indexOf(userId) !== -1;
@@ -495,6 +497,7 @@ export default function Profile() {
         game={game}
         type={game.status || "Finished"}
         key={game.id}
+        odd={recentGames.indexOf(game) % 2 === 1}
         small
       />
     );
@@ -535,8 +538,9 @@ export default function Profile() {
       </div>
     ));
 
+  const maxRolesCount = isPhoneDevice ? 6 : 8;
   const createdSetupRows = createdSetups.map((setup) => (
-    <Setup setup={setup} key={setup.id} maxRolesCount={5} />
+    <Setup setup={setup} key={setup.id} maxRolesCount={maxRolesCount} fixedWidth  />
   ));
 
   const friendRequestRows = friendRequests.map((user) => (

--- a/react_main/src/pages/User/User.jsx
+++ b/react_main/src/pages/User/User.jsx
@@ -17,6 +17,7 @@ import { Link as MuiLink, Popover } from "@mui/material";
 import { Box, Card, AppBar, Toolbar } from "@mui/material";
 import { PieChart } from "./PieChart";
 import { usePopoverOpen } from "../../hooks/usePopoverOpen";
+import { useIsPhoneDevice } from "../../hooks/useIsPhoneDevice";
 
 export function YouTubeEmbed(props) {
   const embedId = props.embedId;
@@ -128,6 +129,8 @@ export function MediaEmbed(props) {
 export default function User(props) {
   const theme = useTheme();
   const user = useContext(UserContext);
+  const isPhoneDevice = useIsPhoneDevice();
+
   const links = [
     {
       text: "Profile",
@@ -148,6 +151,13 @@ export default function User(props) {
   ];
   if (user.loaded && !user.loggedIn) return <Redirect to="/" />;
 
+  const outerStyle = isPhoneDevice
+    ? { padding: theme.spacing(1) }
+    : { padding: theme.spacing(3) };
+  const cardStyle = isPhoneDevice
+      ? { padding: theme.spacing(1), textAlign: "justify" }
+      : { padding: theme.spacing(3), textAlign: "justify" };
+
   return (
     <>
       <AppBar position="static">
@@ -166,10 +176,10 @@ export default function User(props) {
           ))}
         </Toolbar>
       </AppBar>
-      <Box maxWidth="1080px" sx={{ padding: theme.spacing(3) }}>
+      <Box maxWidth="1080px" sx={outerStyle}>
         <Card
           variant="outlined"
-          sx={{ padding: theme.spacing(3), textAlign: "justify" }}
+          sx={cardStyle}
         >
           <Switch>
             <Route exact path="/user" render={() => <Profile />} />


### PR DESCRIPTION
Note: The "lobby name goes here" thing is not included in this pull request I was just using that to test how well it fit into the space. At some point I would add lobby names that default to "nearbear's lobby" and such. At some point I would like to add color coded rows but for the moment I'm quite exhausted on front end stuff.

Summary of changes:
- Made the Setup component fixed width based on the maxRolesCount that you give it
- Combined the game type button, setup name, and roles list all into one
- Tweaked recently played games widget
- Fixed the in-love text overflowing the profile
- Fixed alternating colors in recent games section of profile
- Compacted profile greatly for mobile - lots of excess padding
- Compacted GameRow greatly for mobile - now things will stack vertically to make more room as seen below
- Made host page usable on mobile
- anon game icon now appears in a column alongside the red heart instead of in the setup where it doesn't belong

Mobile still has a long way to go but hopefully this is a meaningful improvement.

### Mobile (375px width)

![image](https://github.com/user-attachments/assets/e6493e53-7405-4ce2-ab46-0f1be0b5bfe5)

![image](https://github.com/user-attachments/assets/5cc35a2f-de16-4494-8855-1452a98c8de9)

![image](https://github.com/user-attachments/assets/726b2a64-e382-4fc0-8b94-5b6e585c3f8e)

![image](https://github.com/user-attachments/assets/ec0f5ad0-d78d-4d20-b687-2c68acebcf53)

![image](https://github.com/user-attachments/assets/c35c8277-25ef-433b-93c7-3a5d03a0a4e1)

### Desktop

![image](https://github.com/user-attachments/assets/c91b5007-065b-4cf3-8767-9e02ea9571b5)

![image](https://github.com/user-attachments/assets/e6cc0d2a-fe21-411b-86f8-64a44852fd9b)

![image](https://github.com/user-attachments/assets/ac554fdc-6083-41f9-9368-33e7a3715f96)

![image](https://github.com/user-attachments/assets/8fc946fa-54cb-499e-ab5e-aad6200ce557)

![image](https://github.com/user-attachments/assets/c8888108-44d6-4964-842a-0c8be0051b3c)
