### PR TITLE
style: fix the spelling of Account section

### DIFF
--- a/react_main/src/pages/User/Settings.jsx
+++ b/react_main/src/pages/User/Settings.jsx
@@ -369,7 +369,7 @@ export default function Settings() {
 
       <Accordion>
         <AccordionSummary>
-          <Typography variant="h6">Accounts</Typography>
+          <Typography variant="h6">Account</Typography>
         </AccordionSummary>
         <Box sx={{ width: "50%", mx: "auto" }}>
           <AccordionDetails>


### PR DESCRIPTION
since there's no thing as multiple accounts with the same login, i thought 'Account' would make more sense