### PR TITLE
 Banished change+ Jack/Consigliere/Sidhe and Clairvoyant roles

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -1052,11 +1052,15 @@ module.exports = class Game {
     let toDelete = [];
     for (let roleName in roleset) {
       let role = roleName.split(":")[0];
+      let modifiers = roleName.split(":")[1];
       if (this.getRoleAlignment(role) == "Event") {
         toDelete.push(roleName);
         if (!this.BanishedEvents.includes(roleName)) {
           this.CurrentEvents.push(roleName);
         }
+      }
+      else if (modifiers && modifiers.toLowerCase().includes("banished"))) {
+        toDelete.push(roleName);
       }
       if (role != "Host") {
         continue;

--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -1059,7 +1059,7 @@ module.exports = class Game {
           this.CurrentEvents.push(roleName);
         }
       }
-      else if (modifiers && modifiers.toLowerCase().includes("banished"))) {
+      else if (modifiers && modifiers.toLowerCase().includes("banished")) {
         toDelete.push(roleName);
       }
       if (role != "Host") {

--- a/Games/types/Mafia/Information.js
+++ b/Games/types/Mafia/Information.js
@@ -410,6 +410,54 @@ module.exports = class MafiaInformation {
     }
   }
 
+  getNotRoles(player, count, investType, forceTrue, alignment){
+    let role = player.getRoleAppearance(investType);
+    if(forceTrue == true){
+      role = this.game.formatRole(this.game.formatRoleInternal(player.role.name,player.role.modifier));
+    }
+    let notRoles = [];
+    let rolesToUse = this.game.PossibleRoles.filter(
+      (r) =>
+        this.game.formatRole(r) != role &&
+        !this.game.getRoleTags(r).includes("Exposed")
+    );
+    if(alignment){
+          if (alignment == "Evil") {
+      rolesToUse = rolesToUse.filter(
+        (r) =>
+          this.game.getRoleAlignment(r) == "Cult" ||
+          this.game.getRoleAlignment(r) == "Mafia" ||
+          (this.game.getRoleAlignment(r) == "Independent" &&
+            this.game.getRoleTags(r).includes("Hostile"))
+      );
+    }
+    if (alignment == "Good") {
+      rolesToUse = rolesToUse.filter(
+        (r) =>
+          this.game.getRoleAlignment(r) != "Cult" &&
+          this.game.getRoleAlignment(r) != "Mafia" &&
+          !(
+            this.game.getRoleAlignment(r) == "Independent" &&
+            this.game.getRoleTags(r).includes("Hostile")
+          )
+      );
+    }
+    }
+    rolesToUse = Random.randomizeArray(rolesToUse);
+
+    for(let x = 0; x < count && x < rolesToUse.length; x++){
+      notRoles.push(rolesToUse[x]);
+    }
+    if(notRoles.length < count){
+      while(notRoles.length < count){
+        notRoles.push(notRoles[0]);
+      }
+    }
+    
+
+    return notRoles;
+  }
+
   getMostValuableEvilPlayer() {
     let score = 5;
     let highest = 0;

--- a/Games/types/Mafia/Information.js
+++ b/Games/types/Mafia/Information.js
@@ -257,7 +257,8 @@ module.exports = class MafiaInformation {
     excludeCreator,
     InvestType,
     alignment,
-    forceFalse
+    forceFalse,
+    UseAppear
   ) {
     if (count == null || count <= 0) {
       count = 1;
@@ -267,6 +268,9 @@ module.exports = class MafiaInformation {
     }
     if (forceFalse == null) {
       forceFalse = false;
+    }
+    if (UseAppear == null) {
+      UseAppear = false;
     }
     let fakeRoles = [];
     let returnRoles = [];
@@ -285,17 +289,11 @@ module.exports = class MafiaInformation {
                 .includes("Exposed")
           )
       );
+      if (UseAppear) {
+        randomPlayers = randomPlayers.filter((p) => p.getRoleAppearance() != player.getRoleAppearance());
+      }
       if (forceFalse) {
-        randomPlayers = randomPlayers.filter(
-          (p) =>
-            p.getRoleAppearance() ==
-            this.game.formatRole(
-              this.game.formatRoleInternal(
-                player.role.name,
-                player.role.modifier
-              )
-            )
-        );
+        randomPlayers = randomPlayers.filter((p) => p.getRoleAppearance() != this.game.formatRole(this.game.formatRoleInternal(player.role.name,player.role.modifier)));
       }
       if (
         alignment &&

--- a/Games/types/Mafia/information/TwoNotRolesInfo.js
+++ b/Games/types/Mafia/information/TwoNotRolesInfo.js
@@ -1,0 +1,133 @@
+const Information = require("../Information");
+const Random = require("../../../../lib/Random");
+const {
+  EVIL_FACTIONS,
+  NOT_EVIL_FACTIONS,
+  CULT_FACTIONS,
+  MAFIA_FACTIONS,
+  FACTION_LEARN_TEAM,
+  FACTION_WIN_WITH_MAJORITY,
+  FACTION_WITH_MEETING,
+  FACTION_KILL,
+} = require("../const/FactionList");
+
+module.exports = class TwoNotRolesInfo extends Information {
+  constructor(creator, game, target, investType, learner) {
+    super("Two Not Roles Info", creator, game);
+    if (investType == null) {
+      investType = "investigate";
+    }
+    this.investType = investType;
+    if (target == null) {
+      this.randomTarget = true;
+      target = Random.randArrayVal(
+        this.game.alivePlayers().filter((p) => p != learner)
+      );
+    }
+    if (learner == null) {
+      learner = this.creator;
+    }
+    this.target = target;
+    this.learner = learner;
+
+    this.targetRole = this.target
+      .getRoleAppearance(this.investType)
+      .split(" (")[0];
+    let info = this.getFakeRole(this.target, 2, false, this.investType, null, null, true);
+    let trueRole = this.game.formatRoleInternal(
+      target.role.name,
+      target.role.modifier
+    );
+    this.trueRole = this.game.formatRole(trueRole);
+    this.mainInfo = info;
+
+    //this.game.queueAlert(`:invest: Main ${this.mainInfo} Invest ${target.getRoleAppearance("investigate")} Real ${this.trueRole}.`);
+  }
+
+  getInfoRaw() {
+    super.getInfoRaw();
+    return Random.randomizeArray(this.mainInfo);
+  }
+
+  getInfoFormated() {
+    super.getInfoRaw();
+    let info = Random.randomizeArray(this.mainInfo);
+    return `You Learn that ${this.target.name}'s Role is not ${info[0]}, or ${info[1]}.`;
+    //return `You Learn that your Target's Role is ${this.mainInfo}`
+  }
+
+  isTrue() {
+    if (!this.mainInfo.includes(this.trueRole)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+  isFalse() {
+    if (this.isTrue()) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+  isFavorable() {
+    for (let role of this.mainInfo) {
+      if (this.game.getRoleAlignment(role.split(" (")[0]) == "Village") {
+        return false;
+      }
+    }
+    return true;
+  }
+  isUnfavorable() {
+    for (let role of this.mainInfo) {
+      if (this.game.getRoleAlignment(role.split(" (")[0]) != "Village") {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  makeTrue() {
+    let roles = this.getFakeRole(
+      this.target,
+      2,
+      false,
+      this.investType,
+      null,
+      true
+    );
+
+    this.mainInfo = roles;
+    this.targetRole = roles[0].split(":")[0];
+  }
+  makeFalse() {
+    let info = this.getFakeRole(this.target, 1, false, this.investType);
+    info.push(this.trueRole);
+    this.mainInfo = info;
+    this.targetRole = this.target.role.name;
+  }
+  makeFavorable() {
+    let roles = this.getFakeRole(
+      this.target,
+      2,
+      false,
+      this.investType,
+      "Evil"
+    );
+
+    this.mainInfo = roles;
+    this.targetRole = roles[0].split(":")[0];
+  }
+  makeUnfavorable() {
+    let roles = this.getFakeRole(
+      this.target,
+      2,
+      false,
+      this.investType,
+      "Village"
+    );
+
+    this.mainInfo = roles;
+    this.targetRole = roles[0].split(":")[0];
+  }
+};

--- a/Games/types/Mafia/information/TwoNotRolesInfo.js
+++ b/Games/types/Mafia/information/TwoNotRolesInfo.js
@@ -33,7 +33,7 @@ module.exports = class TwoNotRolesInfo extends Information {
     this.targetRole = this.target
       .getRoleAppearance(this.investType)
       .split(" (")[0];
-    let info = this.getFakeRole(this.target, 2, false, this.investType, null, null, true);
+    let info = this.getNotRoles(this.target, 2, this.investType);
     let trueRole = this.game.formatRoleInternal(
       target.role.name,
       target.role.modifier
@@ -52,7 +52,7 @@ module.exports = class TwoNotRolesInfo extends Information {
   getInfoFormated() {
     super.getInfoRaw();
     let info = Random.randomizeArray(this.mainInfo);
-    return `You Learn that ${this.target.name}'s Role is not ${info[0]}, or ${info[1]}.`;
+    return `You Learn that ${this.target.name}'s Role is not ${this.game.formatRole(info[0])}, or ${this.game.formatRole(info[1])}.`;
     //return `You Learn that your Target's Role is ${this.mainInfo}`
   }
 
@@ -88,30 +88,28 @@ module.exports = class TwoNotRolesInfo extends Information {
   }
 
   makeTrue() {
-    let roles = this.getFakeRole(
+    let roles = this.getNotRoles(
       this.target,
       2,
-      false,
       this.investType,
-      null,
-      true
+      true,
     );
 
     this.mainInfo = roles;
     this.targetRole = roles[0].split(":")[0];
   }
   makeFalse() {
-    let info = this.getFakeRole(this.target, 1, false, this.investType);
+    let info = this.getNotRoles(this.target, 1, this.investType);
     info.push(this.trueRole);
     this.mainInfo = info;
     this.targetRole = this.target.role.name;
   }
   makeFavorable() {
-    let roles = this.getFakeRole(
+    let roles = this.getNotRoles(
       this.target,
       2,
-      false,
       this.investType,
+      null,
       "Evil"
     );
 
@@ -119,12 +117,12 @@ module.exports = class TwoNotRolesInfo extends Information {
     this.targetRole = roles[0].split(":")[0];
   }
   makeUnfavorable() {
-    let roles = this.getFakeRole(
+    let roles = this.getNotRoles(
       this.target,
       2,
-      false,
       this.investType,
-      "Village"
+      null,
+      "Good"
     );
 
     this.mainInfo = roles;

--- a/Games/types/Mafia/items/ReturnToRole.js
+++ b/Games/types/Mafia/items/ReturnToRole.js
@@ -1,4 +1,5 @@
 const Item = require("../Item");
+const Action = require("../Action");
 
 module.exports = class ReturnToRole extends Item {
   constructor(currRole, currModifier, currData, newRole) {
@@ -12,12 +13,32 @@ module.exports = class ReturnToRole extends Item {
     this.newRole = newRole;
 
     this.listeners = {
-      state: function (stateInfo) {
-        if (this.game.getStateName() != "Day") return;
+      afterActions: function () {
+        if (this.hasBeenDay != true) return;
         if (this.holder.role.name != this.currRole) {
           this.drop();
           return;
         }
+          this.holder.setRole(
+          `${currRole}:${currModifier}`,
+          this.currData,
+          true,
+          true,
+          true,
+          "No Change"
+        );
+        this.drop();
+      },
+      state: function (stateInfo) {
+        if (this.game.getStateName() == "Day"){
+          this.hasBeenDay = true;
+        };
+        if (this.holder.role.name != this.currRole) {
+          this.drop();
+          return;
+        }
+
+        /*
         this.holder.setRole(
           `${currRole}:${currModifier}`,
           this.currData,
@@ -27,6 +48,7 @@ module.exports = class ReturnToRole extends Item {
           "No Change"
         );
         this.drop();
+        */
       },
     };
 

--- a/Games/types/Mafia/roles/Cult/Sidhe.js
+++ b/Games/types/Mafia/roles/Cult/Sidhe.js
@@ -1,0 +1,15 @@
+const Role = require("../../Role");
+
+module.exports = class Sidhe extends Role {
+  constructor(player, data) {
+    super("Sidhe", player, data);
+
+    this.alignment = "Cult";
+    this.cards = [
+      "VillageCore",
+      "WinWithFaction",
+      "MeetingFaction",
+      "BecomeBanishedRoleFor1Phase",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/Mafia/Consigliere.js
+++ b/Games/types/Mafia/roles/Mafia/Consigliere.js
@@ -1,0 +1,15 @@
+const Role = require("../../Role");
+
+module.exports = class Consigliere extends Role {
+  constructor(player, data) {
+    super("Consigliere", player, data);
+
+    this.alignment = "Mafia";
+    this.cards = [
+      "VillageCore",
+      "WinWithFaction",
+      "MeetingFaction",
+      "BecomeBanishedRoleFor1Phase",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/Village/Clairvoyant.js
+++ b/Games/types/Mafia/roles/Village/Clairvoyant.js
@@ -1,0 +1,15 @@
+const Role = require("../../Role");
+
+module.exports = class Clairvoyant extends Role {
+  constructor(player, data) {
+    super("Clairvoyant", player, data);
+
+    this.alignment = "Village";
+    this.cards = [
+      "VillageCore",
+      "WinWithFaction",
+      "MeetingFaction",
+      "Learn2NotRoles",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/Village/Jack
+++ b/Games/types/Mafia/roles/Village/Jack
@@ -1,0 +1,15 @@
+const Role = require("../../Role");
+
+module.exports = class Jack extends Role {
+  constructor(player, data) {
+    super("Jack", player, data);
+
+    this.alignment = "Village";
+    this.cards = [
+      "VillageCore",
+      "WinWithFaction",
+      "MeetingFaction",
+      "BecomeBanishedRoleFor1Phase",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/cards/BecomeBanishedRoleFor1Phase.js
+++ b/Games/types/Mafia/roles/cards/BecomeBanishedRoleFor1Phase.js
@@ -1,0 +1,92 @@
+const Card = require("../../Card");
+const roleBlacklist = ["Monkey", "Ape", "Jack", "Consigliere", "Sidhe"];
+
+module.exports = class BecomeBanishedRoleFor1Phase extends Card {
+  constructor(role) {
+    super(role);
+
+    this.meetings = {
+      "Use Power": {
+        states: ["Night"],
+        flags: ["voting", "instant"],
+        inputType: "custom",
+        action: {
+          run: function () {
+            if(this.target == "None"){
+            return;
+            }
+
+            this.actor.role.data.ConvertOptions.splice(this.actor.role.data.ConvertOptions.indexOf(this.target),1);
+
+            let currRole = this.actor.role.name;
+            let currModifiers = this.actor.role.modifier;
+            let currData = this.actor.role.data;
+
+            this.actor.holdItem(
+              "ReturnToRole",
+              currRole,
+              currModifiers,
+              currData,
+              this.target
+            );
+            this.actor.setRole(
+              `${this.target}`,
+              null,
+              true,
+              true,
+              false,
+              "No Change"
+            );
+
+            this.actor.joinMeetings(this.actor.role.meetings);
+            for (let meeting of this.game.meetings){
+               meeting.generateTargets();
+            }
+            this.actor.sendMeetings();
+
+            //this.actor.role.priorityOffset = -1;
+
+            if (this.actor.role.name != currRole) {
+              this.actor.role.name = currRole;
+              this.actor.role.appearance.death = currRole;
+              this.actor.role.appearance.reveal = currRole;
+              this.actor.role.appearance.investigate = currRole;
+              this.actor.role.appearance.condemn = currRole;
+              this.actor.role.alignment = this.game.getRoleAlignment(currRole);
+            }
+          },
+        },
+      },
+    };
+    
+
+    this.listeners = {
+      roleAssigned: function (player) {
+        if (player !== this.player) {
+          return;
+        }
+
+        this.data.ConvertOptions = this.game.PossibleRoles.filter(
+          (r) =>
+            this.game.getRoleAlignment(r) ==
+            this.game.getRoleAlignment(this.player.role.name) && (r.split(":")[1] && r.split(":")[1].toLowerCase().includes("banished"))
+        && !roleBlacklist.includes(r.split(":")[0])
+        
+        );
+      },
+      // refresh cooldown
+      state: function (stateInfo) {
+        if (!stateInfo.name.match(/Night/)) {
+          return;
+        }
+        var ConvertOptions = this.data.ConvertOptions.filter((r) => r);
+        if(!this.modifier.includes("Proactive")){
+        ConvertOptions.push("None");
+        }
+
+        this.meetings["Use Power"].targets = ConvertOptions;
+      },
+    };
+
+  }
+};

--- a/Games/types/Mafia/roles/cards/BecomeUndercoverEvil.js
+++ b/Games/types/Mafia/roles/cards/BecomeUndercoverEvil.js
@@ -97,7 +97,7 @@ module.exports = class BecomeUndercoverEvil extends Card {
           return;
         }
         this.player.holdItem("IsTheMole", this.player.faction);
-        this.player.setRole(this.player.role, undefined, false, true, false);
+        this.player.setRole(this.player.role.newRole, undefined, false, true, false);
         let tempApp = {
           self: "Mole",
         };

--- a/Games/types/Mafia/roles/cards/Learn2NotRoles.js
+++ b/Games/types/Mafia/roles/cards/Learn2NotRoles.js
@@ -1,0 +1,35 @@
+const Card = require("../../Card");
+const Random = require("../../../../../lib/Random");
+const { PRIORITY_INVESTIGATIVE_DEFAULT } = require("../../const/Priority");
+
+module.exports = class Learn2NotRoles extends Card {
+  constructor(role) {
+    super(role);
+
+    this.meetings = {
+      Sry: {
+        states: ["Night"],
+        flags: ["voting"],
+        targets: { include: ["alive"], exclude: ["self"] },
+        action: {
+          labels: ["investigate", "role"],
+          priority: PRIORITY_INVESTIGATIVE_DEFAULT,
+          run: function () {
+            
+
+            let info = this.game.createInformation(
+              "TwoNotRolesInfo",
+              this.actor,
+              this.game,
+              this.target
+            );
+            info.processInfo();
+            var alert = `:invest: ${info.getInfoFormated()}.`;
+            this.actor.queueAlert(alert);
+
+          },
+        },
+      },
+    };
+  }
+};

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -38,7 +38,7 @@ const modifierData = {
       internal: ["BanishedRole"],
       tags: ["Banished"],
       description:
-        "Banished roles have abnormal spawn conditions. Banished roles will only spawn if the Banished count is increased, or if another roles adds Banished roles to the game.",
+        "Banished roles will only spawn if the Banished count is increased, or if another roles adds Banished roles to the game.",
       eventDescription: "This Event will not occur normally.",
       incompatible: ["Inclusive", "Exclusive"],
     },

--- a/data/roles.js
+++ b/data/roles.js
@@ -1331,6 +1331,15 @@ const roleData = {
       ],
       nightOrder: [["Become Role and Make Delirious",(PRIORITY_NIGHT_ROLE_BLOCKER)]],
     },
+    Jack: {
+      alignment: "Village",
+      category: "Manipulative",
+      tags: ["Advanced", "Banished Interaction",],
+      description: [
+        "At night chooses a banished Village role, gains it's abilities until the next night",
+        "Cannot select a role they already selected.",
+      ],
+    },
     Student: {
       alignment: "Village",
       disabled: true,
@@ -2347,6 +2356,15 @@ const roleData = {
       ],
       nightOrder: [["Become Role and Make Delirious",(PRIORITY_NIGHT_ROLE_BLOCKER)]],
     },
+    Consigliere: {
+      alignment: "Mafia",
+      category: "Manipulative",
+      tags: ["Advanced", "Banished Interaction"],
+      description: [
+        "At night chooses a banished Mafia role, gains it's abilities until the next night",
+        "Cannot select a role they already selected.",
+      ],
+    },
     Apprentice: {
       alignment: "Mafia",
       tags: ["Conversion", "Dead", "Basic"],
@@ -3016,6 +3034,15 @@ const roleData = {
       ],
       nightOrder: [["Apply Effect",(PRIORITY_EFFECT_GIVER_DEFAULT)]],
       graveyardParticipation: "all",
+    },
+    Sidhe: {
+      alignment: "Cult",
+      category: "Manipulative",
+      tags: ["Advanced", "Banished Interaction"],
+      description: [
+        "At night chooses a banished Cult role, gains it's abilities until the next night",
+        "Cannot select a role they already selected.",
+      ],
     },
     "Queen Bee": {
       alignment: "Cult",

--- a/data/roles.js
+++ b/data/roles.js
@@ -735,9 +735,23 @@ const roleData = {
         "Basic",
       ],
       description: [
-        "At night, learns either one player's role or two excess roles.",
+        "Each night can choose to learn a player's role or two excess roles"
       ],
       nightOrder: [["Learn Role or Excess Roles",(PRIORITY_INVESTIGATIVE_DEFAULT)]],
+    },
+    Clairvoyant: {
+      alignment: "Village",
+      category: "Investigative",
+      tags: [
+        "Information",
+        "Roles",
+        "Basic",
+        "Visiting"
+      ],
+      description: [
+        "Visits one player each night and learns two roles that are not that player's role.",
+      ],
+      nightOrder: [["Learn Not Roles",(PRIORITY_INVESTIGATIVE_DEFAULT)]],
     },
     Auditor: {
       alignment: "Village",

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -885,8 +885,8 @@ function verifyRolesAndCount(setup) {
       //roleset = Object.keys(roleset).filter((role) => roleData[gameType][role.split(":")[0]].alignment != "Event");
       for (let role in roles[i]) {
         let roleName = role.split(":")[0];
-
-        if (roleData[gameType][roleName].alignment == "Event") eventCount++;
+        let modifiers = role.split(":")[1];
+        if (roleData[gameType][roleName].alignment == "Event" || (modifiers && modifiers.toLowerCase().includes("banished"))) eventCount++;
       }
 
       let roleSetSize = Object.keys(roleset).length - eventCount;
@@ -961,8 +961,8 @@ function verifyRolesAndCount(setup) {
       //roleset = Object.keys(roleset).filter((role) => roleData[gameType][role.split(":")[0]].alignment != "Event");
       for (let role in roles[i]) {
         let roleName = role.split(":")[0];
-
-        if (roleData[gameType][roleName].alignment == "Event") eventCount++;
+        let modifiers = role.split(":")[1];
+        if (roleData[gameType][roleName].alignment == "Event" || (modifiers && modifiers.toLowerCase().includes("banished"))) eventCount++;
       }
       //Check that all roles are valid roles
       for (let role in roleset)
@@ -977,7 +977,9 @@ function verifyRolesAndCount(setup) {
 
       for (let role in roleset) {
         let roleName = role.split(":")[0];
+        let modifiers = role.split(":")[1];
         if (roleData[gameType][roleName].alignment == "Event") continue;
+        if (modifiers && modifiers.toLowerCase().includes("banished"))) continue;
         roleset[role] = Math.abs(Math.floor(Number(roleset[role]) || 0));
         tempCount[roleData[gameType][roleName].alignment] += roleset[role];
         tempTotal += roleset[role];

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -979,7 +979,7 @@ function verifyRolesAndCount(setup) {
         let roleName = role.split(":")[0];
         let modifiers = role.split(":")[1];
         if (roleData[gameType][roleName].alignment == "Event") continue;
-        if (modifiers && modifiers.toLowerCase().includes("banished"))) continue;
+        if (modifiers && modifiers.toLowerCase().includes("banished")) continue;
         roleset[role] = Math.abs(Math.floor(Number(roleset[role]) || 0));
         tempCount[roleData[gameType][roleName].alignment] += roleset[role];
         tempTotal += roleset[role];


### PR DESCRIPTION
Banished roles no longer spawn in non-closed setups.

Clairvoyant, "Each night choose a player, learn 2 roles that aren't that player's role."

Jack, "At night choose a banished role from your alignment, gains it's abilities until the next night. Cannot choose a role they already used"

Consigliere, Jack but mafia

Sidhe, Jack but cult.