### PR TITLE
fix: allow spectating ranked games without red heart requirement

### DIFF
--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -721,8 +721,12 @@ function GameWrapper(props) {
   }, [connected]);
 
   function getConnectionInfo() {
-    axios
-      .get(`/game/${gameId}/connect`)
+    const urlParams = new URLSearchParams(window.location.search);
+    const isSpectating = urlParams.get('spectate') === 'true';
+    
+    const url = `/game/${gameId}/connect${isSpectating ? '?spectate=true' : ''}`;
+    
+    axios.get(url)
       .then((res) => {
         setGameType(res.data.type);
         setPort(res.data.port);
@@ -730,7 +734,6 @@ function GameWrapper(props) {
       })
       .catch((e) => {
         var msg = e && e.response && e.response.data;
-
         if (msg === "Game not found.") setLeave("review");
         else {
           setLeave(true);

--- a/react_main/src/pages/Play/LobbyBrowser/GameRow.jsx
+++ b/react_main/src/pages/Play/LobbyBrowser/GameRow.jsx
@@ -38,7 +38,7 @@ const GameStatus = (props) => {
     buttonVariant = "contained";
   } else if (props.game.status === "In Progress") {
     if (props.game.spectating || user.perms.canSpectateAny) {
-      buttonUrl = `/game/${props.game.id}`;
+      buttonUrl = `/game/${props.game.id}?spectate=true`; 
       buttonText = "Spectate";
       buttonColor = "info";
       buttonVariant = "contained";

--- a/routes/game.js
+++ b/routes/game.js
@@ -214,6 +214,7 @@ router.get("/:id/connect", async function (req, res) {
     var gameId = String(req.params.id);
     var userId = await routeUtils.verifyLoggedIn(req, true);
     var game = await redis.getGameInfo(gameId, true);
+    const isSpectating = req.query.spectate === 'true';
 
     if (!game) {
       res.status(500);
@@ -227,7 +228,7 @@ router.get("/:id/connect", async function (req, res) {
       return;
     }
 
-    if (game.settings.ranked) {
+    if (game.settings.ranked && !isSpectating) {
       const user = await models.User.findOne({ id: userId }).select(
         "redHearts"
       );


### PR DESCRIPTION
Probably there is a better solution with either different routes for spectating/joining, a Custom Hook for different game modes etc. Open to ideas, but this is a quick fix and works