### PR TITLE
Daily Chellange  Changes + Laundress interactions + 2 modifers for BOTC things

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -2788,8 +2788,15 @@ module.exports = class Game {
           player.EarnedAchievements = [];
         }
 
-        if(this.hasIntegrity && !this.private){
+        if(this.hasIntegrity && !this.private && player.DailyTracker && player.DailyTracker.length >= 1){
          coinsEarned += player.DailyPayout;
+        if(player.user.dailyChallenges && player.user.dailyChallenges.length <= 0){
+          coinsEarned += 20;
+          player.DailyCompleted = 1;
+        }
+        else{
+          player.DailyCompleted = 0;
+        }
         }
         
         await models.User.updateOne(

--- a/Games/types/Mafia/Event.js
+++ b/Games/types/Mafia/Event.js
@@ -85,6 +85,11 @@ module.exports = class MafiaEvent extends Event {
       } else if (this.modifiers.includes("Unholy") && !player.isDemonic(true)) {
         return false;
       }
+      if (this.modifiers.includes("Refined") && player.role.data.banished == true) {
+        return false;
+      } else if (this.modifiers.includes("Unrefined") && player.role.data.banished != true) {
+        return false;
+      }
       if (this.modifiers.includes("Simple") && !this.isVanilla(p)) {
         return false;
       } else if (this.modifiers.includes("Complex") && this.isVanilla(p)) {

--- a/Games/types/Mafia/information/OneOfPlayersIsRoleInfo.js
+++ b/Games/types/Mafia/information/OneOfPlayersIsRoleInfo.js
@@ -23,16 +23,16 @@ module.exports = class OneOfPlayersIsRoleInfo extends Information {
     if (amount == null || amount <= 0) {
       amount = 2;
     }
-    
+    this.amount = amount;
 
     if(validRoles.length <= 0){
       this.mainInfo = "None";
       return;
     }
-  let formattedRoles = validRoles.map((r) => this.formatRole(r));
+  let formattedRoles = validRoles.map((r) => this.game.formatRole(r));
     let validPlayers = this.game.alivePlayers().filter((p) => formattedRoles.includes(p.getRoleAppearance(this.investType)) && p != this.creator);
     if(validPlayers.length <= 0){
-      validPlayers = this.game.player.filter((p) => formattedRoles.includes(p.getRoleAppearance(this.investType)) && p != this.creator);
+      validPlayers = this.game.players.filter((p) => formattedRoles.includes(p.getRoleAppearance(this.investType)) && p != this.creator);
     }
     if(validPlayers.length <= 0){
       this.mainInfo = "None";
@@ -41,17 +41,15 @@ module.exports = class OneOfPlayersIsRoleInfo extends Information {
 
       target = [];
       target.push(Random.randArrayVal(validPlayers.filter((p) => !target.includes(p) && p != this.creator)));
-      let role = temp.getRoleAppearance(this.investType);
+      let role = target[0].getRoleAppearance(this.investType);
+      this.targetRole = target[0].getRoleAppearance(this.investType).split((" ("))[0];
       for (let x = 0; x < amount-1; x++) {
         target.push(Random.randArrayVal(this.game.alivePlayers().filter((p) => !target.includes(p) && p != this.creator)));
       }
     
     this.target = target;
-    let temp = this.target[0];
-    this.targetRole = temp.getRoleAppearance(this.investType);
     
-    let role = temp.getRoleAppearance(this.investType);
-    let trueRole = this.game.formatRoleInternal(temp.role.name, temp.role.modifier);
+    let trueRole = this.game.formatRoleInternal(target[0].role.name, target[0].role.modifier);
     this.trueRole = this.game.formatRole(trueRole);
     this.mainInfo = role;
 
@@ -68,6 +66,7 @@ module.exports = class OneOfPlayersIsRoleInfo extends Information {
     if(this.mainInfo == "None"){
       return `You couldn't find anyone to do the laundry of!`;
     }
+    this.target = Random.randomizeArray(this.target);
     return `You did ${this.target[0].name} and ${this.target[1].name} laundry... one of them wears the clothes of a ${this.mainInfo}!`;
     //return `You Learn that your Target's Role is ${this.mainInfo}`
   }
@@ -119,7 +118,7 @@ module.exports = class OneOfPlayersIsRoleInfo extends Information {
     }
     if (
       this.game.getRoleAlignment(this.targetRole) == "Village" || (this.game.getRoleAlignment(this.targetRole) == "Independent" && !this.game.getRoleTags(this.targetRole).includes("Hostile")
-    ) {
+    )) {
       return false;
     } else {
       return true;
@@ -135,32 +134,26 @@ module.exports = class OneOfPlayersIsRoleInfo extends Information {
 
     let validPlayers = this.game.alivePlayers().filter((p) => validRoles.includes(this.game.formatRoleInternal(p.role.name, p.role.modifier)) && p != this.creator);
     if(validPlayers.length <= 0){
-      validPlayers = this.game.player.filter((p) => validRoles.includes(this.game.formatRoleInternal(p.role.name, p.role.modifier)) && p != this.creator);
+      validPlayers = this.game.players.filter((p) => validRoles.includes(this.game.formatRoleInternal(p.role.name, p.role.modifier)) && p != this.creator);
     }
     if(validPlayers.length <= 0){
       this.mainInfo = "None";
       return;
     }
 
-      target = [];
+      let target = [];
       target.push(Random.randArrayVal(validPlayers.filter((p) => !target.includes(p) && p != this.creator)));
-      this.targetRole = this.game.formatRoleInternal(target[0].role.name, target[0].role.modifier);
-      for (let x = 0; x < amount-1; x++) {
+      this.targetRole = target[0].role.name;
+      this.trueRole = this.game.formatRoleInternal(target[0].role.name, target[0].role.modifier);
+      for (let x = 0; x <  this.amount-1; x++) {
         target.push(Random.randArrayVal(this.game.alivePlayers().filter((p) => !target.includes(p) && p != this.creator)));
       }
 
     this.target = target;
-    this.targetRole = this.game.formatRole(this.game.formatRoleInternal(temp.role.name, temp.role.modifier));
     
-    let role = temp.getRoleAppearance(this.investType);
-    let trueRole = this.game.formatRoleInternal(temp.role.name, temp.role.modifier);
+
+    let trueRole = this.trueRole;
     this.trueRole = this.game.formatRole(trueRole);
-    this.mainInfo = role;
-  
-    
-    
-    let temp = Random.randArrayVal(this.target);
-    this.targetRole = temp.role.name;
     this.mainInfo = this.trueRole;
   }
   makeFalse() {
@@ -170,7 +163,7 @@ module.exports = class OneOfPlayersIsRoleInfo extends Information {
       this.mainInfo = "None";
       return;
     }
-    if(this.mainInfo == "None";){
+    if(this.mainInfo == "None"){
       this.mainInfo = this.game.formatRole(Random.randArrayVal(validRoles));
     }
     let fakePlayers = this.game
@@ -208,14 +201,14 @@ module.exports = class OneOfPlayersIsRoleInfo extends Information {
 
 getAllowedRoles(){
   let roles = this.game.PossibleRoles;
-  let isLoyal = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Loyal");
-  let isDisloyal = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Disloyal");
-  let isSimple = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Simple");
-  let isComplex = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Complex");
-  let isHoly = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Holy");
-  let isUnholy = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Unholy");
-  let isRefined = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Refined");
-  let isUnrefined = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Unrefined");
+  let isLoyal = this.game.getRoleTags(this.game.formatRoleInternal(this.creator.role.name, this.creator.role.modifier)).includes("Loyal");
+  let isDisloyal = this.game.getRoleTags(this.game.formatRoleInternal(this.creator.role.name, this.creator.role.modifier)).includes("Disloyal");
+  let isSimple = this.game.getRoleTags(this.game.formatRoleInternal(this.creator.role.name, this.creator.role.modifier)).includes("Simple");
+  let isComplex = this.game.getRoleTags(this.game.formatRoleInternal(this.creator.role.name, this.creator.role.modifier)).includes("Complex");
+  let isHoly = this.game.getRoleTags(this.game.formatRoleInternal(this.creator.role.name, this.creator.role.modifier)).includes("Holy");
+  let isUnholy = this.game.getRoleTags(this.game.formatRoleInternal(this.creator.role.name, this.creator.role.modifier)).includes("Unholy");
+  let isRefined = this.game.getRoleTags(this.game.formatRoleInternal(this.creator.role.name, this.creator.role.modifier)).includes("Refined");
+  let isUnrefined = this.game.getRoleTags(this.game.formatRoleInternal(this.creator.role.name, this.creator.role.modifier)).includes("Unrefined");
 
   if(isLoyal){
     roles = roles.filter((r) => this.game.getRoleAlignment(r) == "Village" || (this.game.getRoleAlignment(r) == "Independent" && !this.game.getRoleTags(r).includes("Hostile")));

--- a/Games/types/Mafia/information/OneOfPlayersIsRoleInfo.js
+++ b/Games/types/Mafia/information/OneOfPlayersIsRoleInfo.js
@@ -14,6 +14,8 @@ const {
 module.exports = class OneOfPlayersIsRoleInfo extends Information {
   constructor(creator, game, target, amount, investType) {
     super("One Of Players Is Role Info", creator, game);
+    let validRoles = this.getAllowedRoles();
+    
     if (investType == null) {
       investType = "investigate";
     }
@@ -21,28 +23,35 @@ module.exports = class OneOfPlayersIsRoleInfo extends Information {
     if (amount == null || amount <= 0) {
       amount = 2;
     }
-    if (target == null) {
-      this.randomTarget = true;
-      target = [];
-      for (let x = 0; x < amount; x++) {
-        target.push(
-          Random.randArrayVal(
-            this.game
-              .alivePlayers()
-              .filter((p) => !target.includes(p) && p != this.creator)
-          )
-        );
-      }
-    }
-    this.target = target;
-    let temp = Random.randArrayVal(this.target);
-    this.targetRole = temp.getRoleAppearance(this.investType).split(" (")[0];
+    
 
+    if(validRoles.length <= 0){
+      this.mainInfo = "None";
+      return;
+    }
+  let formattedRoles = validRoles.map((r) => this.formatRole(r));
+    let validPlayers = this.game.alivePlayers().filter((p) => formattedRoles.includes(p.getRoleAppearance(this.investType)) && p != this.creator);
+    if(validPlayers.length <= 0){
+      validPlayers = this.game.player.filter((p) => formattedRoles.includes(p.getRoleAppearance(this.investType)) && p != this.creator);
+    }
+    if(validPlayers.length <= 0){
+      this.mainInfo = "None";
+      return;
+    }
+
+      target = [];
+      target.push(Random.randArrayVal(validPlayers.filter((p) => !target.includes(p) && p != this.creator)));
+      let role = temp.getRoleAppearance(this.investType);
+      for (let x = 0; x < amount-1; x++) {
+        target.push(Random.randArrayVal(this.game.alivePlayers().filter((p) => !target.includes(p) && p != this.creator)));
+      }
+    
+    this.target = target;
+    let temp = this.target[0];
+    this.targetRole = temp.getRoleAppearance(this.investType);
+    
     let role = temp.getRoleAppearance(this.investType);
-    let trueRole = this.game.formatRoleInternal(
-      temp.role.name,
-      temp.role.modifier
-    );
+    let trueRole = this.game.formatRoleInternal(temp.role.name, temp.role.modifier);
     this.trueRole = this.game.formatRole(trueRole);
     this.mainInfo = role;
 
@@ -56,11 +65,22 @@ module.exports = class OneOfPlayersIsRoleInfo extends Information {
 
   getInfoFormated() {
     super.getInfoRaw();
+    if(this.mainInfo == "None"){
+      return `You couldn't find anyone to do the laundry of!`;
+    }
     return `You did ${this.target[0].name} and ${this.target[1].name} laundry... one of them wears the clothes of a ${this.mainInfo}!`;
     //return `You Learn that your Target's Role is ${this.mainInfo}`
   }
 
   isTrue() {
+    if(this.mainInfo == "None"){
+      for (let player of this.game.players){
+        if(this.getAllowedRoles().includes(this.game.formatRoleInternal(player.role.name, player.role.modifier))){
+          return false;
+        }
+      }
+      return true;
+    }
     for (let player of this.target) {
       if (
         this.game.formatRole(
@@ -80,8 +100,12 @@ module.exports = class OneOfPlayersIsRoleInfo extends Information {
     }
   }
   isFavorable() {
+    let villageRoles = this.getAllowedRoles().filter((r) => this.game.getRoleAlignment(r) == "Village" || (this.game.getRoleAlignment(r) == "Independent" && !this.game.getRoleTags(r).includes("Hostile")));
+    if(villageRoles.length <= 0){
+      return true;
+    }
     if (
-      this.game.getRoleAlignment(this.targetRole) == this.creator.role.alignment
+      this.game.getRoleAlignment(this.targetRole) == "Village" || (this.game.getRoleAlignment(this.targetRole) == "Independent" && !this.game.getRoleTags(this.targetRole).includes("Hostile"))
     ) {
       return true;
     } else {
@@ -89,8 +113,12 @@ module.exports = class OneOfPlayersIsRoleInfo extends Information {
     }
   }
   isUnfavorable() {
+    let evilRoles = this.getAllowedRoles().filter((r) => this.game.getRoleAlignment(r) != "Village" && !(this.game.getRoleAlignment(r) == "Independent" && this.game.getRoleTags(r).includes("Hostile")));
+    if(evilRoles.length <= 0){
+      return true;
+    }
     if (
-      this.game.getRoleAlignment(this.targetRole) == this.creator.role.alignment
+      this.game.getRoleAlignment(this.targetRole) == "Village" || (this.game.getRoleAlignment(this.targetRole) == "Independent" && !this.game.getRoleTags(this.targetRole).includes("Hostile")
     ) {
       return false;
     } else {
@@ -99,21 +127,52 @@ module.exports = class OneOfPlayersIsRoleInfo extends Information {
   }
 
   makeTrue() {
+    let validRoles = this.getAllowedRoles();
+    if(validRoles.length <= 0){
+      this.mainInfo = "None";
+      return;
+    }
+
+    let validPlayers = this.game.alivePlayers().filter((p) => validRoles.includes(this.game.formatRoleInternal(p.role.name, p.role.modifier)) && p != this.creator);
+    if(validPlayers.length <= 0){
+      validPlayers = this.game.player.filter((p) => validRoles.includes(this.game.formatRoleInternal(p.role.name, p.role.modifier)) && p != this.creator);
+    }
+    if(validPlayers.length <= 0){
+      this.mainInfo = "None";
+      return;
+    }
+
+      target = [];
+      target.push(Random.randArrayVal(validPlayers.filter((p) => !target.includes(p) && p != this.creator)));
+      this.targetRole = this.game.formatRoleInternal(target[0].role.name, target[0].role.modifier);
+      for (let x = 0; x < amount-1; x++) {
+        target.push(Random.randArrayVal(this.game.alivePlayers().filter((p) => !target.includes(p) && p != this.creator)));
+      }
+
+    this.target = target;
+    this.targetRole = this.game.formatRole(this.game.formatRoleInternal(temp.role.name, temp.role.modifier));
+    
+    let role = temp.getRoleAppearance(this.investType);
+    let trueRole = this.game.formatRoleInternal(temp.role.name, temp.role.modifier);
+    this.trueRole = this.game.formatRole(trueRole);
+    this.mainInfo = role;
+  
+    
+    
     let temp = Random.randArrayVal(this.target);
     this.targetRole = temp.role.name;
-
-    let role = temp.getRoleAppearance(this.investType);
-    let trueRole = this.game.formatRoleInternal(
-      temp.role.name,
-      temp.role.modifier
-    );
-    this.trueRole = this.game.formatRole(trueRole);
     this.mainInfo = this.trueRole;
-
-    this.mainInfo = this.trueRole;
-    this.targetRole = this.target.role.name;
   }
   makeFalse() {
+    this.makeTrue();
+    let validRoles = this.getAllowedRoles();
+    if(validRoles.length <= 0){
+      this.mainInfo = "None";
+      return;
+    }
+    if(this.mainInfo == "None";){
+      this.mainInfo = this.game.formatRole(Random.randArrayVal(validRoles));
+    }
     let fakePlayers = this.game
       .alivePlayers()
       .filter(
@@ -127,21 +186,66 @@ module.exports = class OneOfPlayersIsRoleInfo extends Information {
     this.target = [fakePlayers[0], fakePlayers[1]];
   }
   makeFavorable() {
-    let roles = this.getFakeRole(
-      this.target,
-      1,
-      true,
-      this.investType,
-      this.creator.role.alignment
-    );
+    let validRoles = this.getAllowedRoles();
+   let villageRoles = validRoles.filter((r) => this.game.getRoleAlignment(r) == "Village" || (this.game.getRoleAlignment(r) == "Independent" && !this.game.getRoleTags(r).includes("Hostile")));
+    if(villageRoles.length <= 0){
+      return;
+    }
 
-    this.mainInfo = roles[0];
-    this.targetRole = roles[0].split(":")[0];
+    this.mainInfo =  this.game.formatRole(Random.randArrayVal(villageRoles));;
+    this.targetRole = this.mainInfo.split(" (")[0];
   }
   makeUnfavorable() {
-    let roles = this.getFakeRole(this.target, 1, true, this.investType, "Evil");
+    let validRoles = this.getAllowedRoles();
+   let villageRoles = validRoles.filter((r) => this.game.getRoleAlignment(r) != "Village" && !(this.game.getRoleAlignment(r) == "Independent" && !this.game.getRoleTags(r).includes("Hostile")));
+    if(villageRoles.length <= 0){
+      return;
+    }
 
-    this.mainInfo = roles[0];
-    this.targetRole = roles[0].split(":")[0];
+    this.mainInfo =  this.game.formatRole(Random.randArrayVal(villageRoles));;
+    this.targetRole = this.mainInfo.split(" (")[0];
   }
+
+getAllowedRoles(){
+  let roles = this.game.PossibleRoles;
+  let isLoyal = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Loyal");
+  let isDisloyal = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Disloyal");
+  let isSimple = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Simple");
+  let isComplex = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Complex");
+  let isHoly = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Holy");
+  let isUnholy = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Unholy");
+  let isRefined = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Refined");
+  let isUnrefined = this.game.getRoleTags(this.game.formatRoleInternal(this.role.name, this.role.modifier)).includes("Unrefined");
+
+  if(isLoyal){
+    roles = roles.filter((r) => this.game.getRoleAlignment(r) == "Village" || (this.game.getRoleAlignment(r) == "Independent" && !this.game.getRoleTags(r).includes("Hostile")));
+  }
+  if(isDisloyal){
+    roles = roles.filter((r) => this.game.getRoleAlignment(r) != "Village" && !(this.game.getRoleAlignment(r) == "Independent" && !this.game.getRoleTags(r).includes("Hostile")));
+  }
+  if(isSimple){
+    roles = roles.filter((r) => r.split(":")[0] == "Villager" || r.split(":")[0] == "Mafioso" || r.split(":")[0] == "Cultist" || r.split(":")[0] == "Grouch");
+  }
+  if(isComplex){
+    roles = roles.filter((r) => r.split(":")[0] != "Villager" && r.split(":")[0] != "Mafioso" && r.split(":")[0] != "Cultist" && r.split(":")[0] != "Grouch");
+  }
+  if(isHoly){
+    roles = roles.filter((r) => !this.game.getRoleTags(r).includes("Demonic"));
+  }
+  if(isUnholy){
+    roles = roles.filter((r) => this.game.getRoleTags(r).includes("Demonic"));
+  }
+  if(isRefined){
+    roles = roles.filter((r) => !this.game.getRoleTags(r).includes("Banished"));
+  }
+  if(isUnrefined){
+    roles = roles.filter((r) => this.game.getRoleTags(r).includes("Banished"));
+  }
+
+  return roles;
+  
+}
+
+
+  
 };

--- a/Games/types/Mafia/roles/cards/MakeAllVillageInfoFalse.js
+++ b/Games/types/Mafia/roles/cards/MakeAllVillageInfoFalse.js
@@ -33,7 +33,7 @@ module.exports = class MakeAllVillageInfoFalse extends Card {
         }
         for (let x = 0; x < this.FalseModeVillageEffects.length; x++) {
           if (this.FalseModeVillageEffects[x].player) {
-            var index = this.FalseModeVillageEffects[x].player.passiveEffects.indexOf(
+            var index = this.player.passiveEffects.indexOf(
               this.FalseModeVillageEffects[x]
             );
             if (index != -1) {
@@ -44,10 +44,6 @@ module.exports = class MakeAllVillageInfoFalse extends Card {
         }
         this.FalseModeVillageEffects = [];
         if (this.player.hasAbility(["Deception"])) {
-          let neighbors = this.player.getNeighbors();
-          if (neighbors[0].isEvil() == true || neighbors[1].isEvil() == true) {
-            return;
-          }
           for (let player of this.game.players.filter((p) => p.role.alignment == "Village")) {
             let effect = player.giveEffect("FalseMode", Infinity);
             this.player.passiveEffects.push(effect);

--- a/Games/types/Mafia/roles/cards/Refined.js
+++ b/Games/types/Mafia/roles/cards/Refined.js
@@ -1,0 +1,67 @@
+const Card = require("../../Card");
+const Action = require("../../Action");
+const Player = require("../../../../core/Player");
+const { PRIORITY_NIGHT_ROLE_BLOCKER } = require("../../const/Priority");
+
+module.exports = class Refined extends Card {
+  constructor(role) {
+    super(role);
+
+    this.listeners = {
+      state: function (stateInfo) {
+        if (!this.player.hasAbility(["Blocking", "Modifier"])) {
+          return;
+        }
+        if (!stateInfo.name.match(/Night/)) {
+          return;
+        }
+
+        var action = new Action({
+          actor: this.player,
+          game: this.player.game,
+          priority: PRIORITY_NIGHT_ROLE_BLOCKER - 1,
+          labels: ["block", "hidden", "absolute"],
+          run: function () {
+            for (let action of this.game.actions[0]) {
+              if (action.hasLabel("absolute")) {
+                continue;
+              }
+              if (action.hasLabel("mafia")) {
+                continue;
+              }
+              if (action.hasLabel("hidden")) {
+                continue;
+              }
+
+              let toCheck = action.target;
+              if (!Array.isArray(action.target)) {
+                toCheck = [action.target];
+              }
+
+              if (
+                action.actors.indexOf(this.actor) != -1 &&
+                !action.hasLabel("hidden") &&
+                action.target &&
+                toCheck[0] instanceof Player
+              ) {
+                for (let y = 0; y < toCheck.length; y++) {
+                  if (toCheck[y].role.data.banished == true) {
+                    if (
+                      action.priority > this.priority &&
+                      !action.hasLabel("absolute")
+                    ) {
+                      action.cancelActor(this.actor);
+                      break;
+                    }
+                  }
+                }
+              }
+            }
+          },
+        });
+
+        this.game.queueAction(action);
+      },
+    };
+  }
+};

--- a/Games/types/Mafia/roles/cards/Unrefined.js
+++ b/Games/types/Mafia/roles/cards/Unrefined.js
@@ -1,0 +1,67 @@
+const Card = require("../../Card");
+const Action = require("../../Action");
+const Player = require("../../../../core/Player");
+const { PRIORITY_NIGHT_ROLE_BLOCKER } = require("../../const/Priority");
+
+module.exports = class Unrefined extends Card {
+  constructor(role) {
+    super(role);
+
+    this.listeners = {
+      state: function (stateInfo) {
+        if (!this.player.hasAbility(["Blocking", "Modifier"])) {
+          return;
+        }
+        if (!stateInfo.name.match(/Night/)) {
+          return;
+        }
+
+        var action = new Action({
+          actor: this.player,
+          game: this.player.game,
+          priority: PRIORITY_NIGHT_ROLE_BLOCKER - 1,
+          labels: ["block", "hidden", "absolute"],
+          run: function () {
+            for (let action of this.game.actions[0]) {
+              if (action.hasLabel("absolute")) {
+                continue;
+              }
+              if (action.hasLabel("mafia")) {
+                continue;
+              }
+              if (action.hasLabel("hidden")) {
+                continue;
+              }
+
+              let toCheck = action.target;
+              if (!Array.isArray(action.target)) {
+                toCheck = [action.target];
+              }
+
+              if (
+                action.actors.indexOf(this.actor) != -1 &&
+                !action.hasLabel("hidden") &&
+                action.target &&
+                toCheck[0] instanceof Player
+              ) {
+                for (let y = 0; y < toCheck.length; y++) {
+                  if (toCheck[y].role.data.banished != true) {
+                    if (
+                      action.priority > this.priority &&
+                      !action.hasLabel("absolute")
+                    ) {
+                      action.cancelActor(this.actor);
+                      break;
+                    }
+                  }
+                }
+              }
+            }
+          },
+        });
+
+        this.game.queueAction(action);
+      },
+    };
+  }
+};

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -156,7 +156,7 @@ const modifierData = {
     },
     Complex: {
       internal: ["Complex"],
-      tags: ["Visits", "Block Self", "Vanilla"],
+      tags: ["Visits", "Block Self", "Vanilla", "Complex"],
       description:
         "If this player visits a player with a vanilla role, all their actions will be blocked.",
       eventDescription:
@@ -221,7 +221,7 @@ const modifierData = {
     },
     Disloyal: {
       internal: ["Disloyal"],
-      tags: ["Visits", "Block Self", "Alignments"],
+      tags: ["Visits", "Block Self", "Alignments", "Disloyal"],
       description:
         "If this player visits a player of the same alignment, their secondary actions will be blocked.",
       eventDescription: "This Event will not apply to Non-Evil players.",
@@ -316,7 +316,7 @@ const modifierData = {
     },
     Holy: {
       internal: ["Holy"],
-      tags: ["Visits", "Block Self", "Modifiers"],
+      tags: ["Visits", "Block Self", "Modifiers", "Holy"],
       description:
         "If this player visits a player with a Demonic role, their secondary actions will be blocked.",
       eventDescription: "This Event will not apply to Demonic players.",
@@ -407,7 +407,7 @@ const modifierData = {
     },
     Loyal: {
       internal: ["Loyal"],
-      tags: ["Visits", "Block Self", "Alignments"],
+      tags: ["Visits", "Block Self", "Alignments", "Loyal"],
       description:
         "If this player visits a player of the opposite alignment, their secondary actions will be blocked.",
       eventDescription: "This Event will not apply to Evil players.",
@@ -571,6 +571,14 @@ const modifierData = {
       description: "Will be killed if their target was killed.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
+    Refined: {
+      internal: ["Refined"],
+      tags: ["Visits", "Block Self", "Modifiers", "Refined"],
+      description:
+        "If this player visits a player with a Banished role, their secondary actions will be blocked.",
+      eventDescription: "This Event will not apply to Banished players.",
+      incompatible: ["Unrefined"],
+    },
     Resolute: {
       internal: ["Resolute"],
       tags: ["Unblockable"],
@@ -664,7 +672,7 @@ const modifierData = {
     },
     Simple: {
       internal: ["Simple"],
-      tags: ["Visits", "Block Self", "Vanilla"],
+      tags: ["Visits", "Block Self", "Vanilla", "Simple"],
       description:
         "If this player visits a player with a power role, all their actions will be blocked.",
       eventDescription: "This Event will not apply to non-Vanilla players.",
@@ -746,7 +754,7 @@ const modifierData = {
     },
     Unholy: {
       internal: ["Unholy"],
-      tags: ["Visits", "Block Self", "Modifiers"],
+      tags: ["Visits", "Block Self", "Modifiers", "Unholy"],
       description:
         "If this player visits a player with a non-Demonic role, their secondary actions will be blocked.",
       eventDescription: "This Event will not apply to non-Demonic players.",
@@ -763,6 +771,14 @@ const modifierData = {
       tags: ["Killing"],
       description: "After Night 1, You can die at any time.",
       eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Unrefined: {
+      internal: ["Unrefined"],
+      tags: ["Visits", "Block Self", "Modifiers", "Unrefined"],
+      description:
+        "If this player visits a player with a non-Banished role, their secondary actions will be blocked.",
+      eventDescription: "This Event will not apply to non-Banished players.",
+      incompatible: ["Refined"],
     },
     Unwavering: {
       internal: ["ConvertImmune"],

--- a/data/roles.js
+++ b/data/roles.js
@@ -710,6 +710,32 @@ const roleData = {
         "On Night 1, learns that 1 of 2 players is a particular role.",
       ],
       nightOrder: [["Learn Info",(PRIORITY_INVESTIGATIVE_DEFAULT)]],
+      SpecialInteractionsModifiers: {
+      Loyal: [
+          "Will only learn about Good Roles.",
+        ],
+      Disloyal: [
+          "Will only learn about Evil Roles.",
+        ],
+      Holy: [
+          "Will only learn about non-Demonic Roles.",
+        ],
+      Unholy: [
+          "Will only learn about Demonic Roles.",
+      ],
+      Simple: [
+          "Will only learn about Vanilla Roles.",
+      ],
+      Complex: [
+          "Will only learn about PR Roles.",
+      ],
+      Refined: [
+          "Will only learn about non-Banished Roles.",
+      ],
+      Unrefined: [
+          "Will only learn about Banished Roles.",
+      ],
+      },
     },
     "Fortune Teller": {
       alignment: "Village",

--- a/react_main/src/components/Roles.jsx
+++ b/react_main/src/components/Roles.jsx
@@ -211,10 +211,10 @@ userRoleSkins1 = user.settings.roleSkins.split(",");
             primary={
               <div>
                 <span style={{ fontWeight: "bold" }}>{modifier.name}</span>:{" "}
-                {roleData?.alignment == "Event" &&
+                {(roleData?.SpecialInteractionsModifiers && roleData?.SpecialInteractionsModifiers[modifier.name]) ? roleData?.SpecialInteractionsModifiers[modifier.name] : (roleData?.alignment == "Event" &&
                 modifier.eventDescription != null
                   ? modifier.eventDescription
-                  : modifier.description}
+                  : modifier.description)}
               </div>
             }
           />


### PR DESCRIPTION
Daily Challenges now only show on leader-board if all 3 are completed.
Daily Challenges now give 20 coins for completing all 3, (Might want to adjust coin payout for individual challenges).

Refined- Blocked if targeting banished.
Unrefined- Blocked if targeting not banished.

Laundress- Can use Loyal, Disloyal, Simple, Complex, Holy, Unholy, Refined, and Unrefined.