### PR TITLE
Modifier categories and resort

### DIFF
--- a/Games/types/Mafia/roles/cards/ModifierConfused.js
+++ b/Games/types/Mafia/roles/cards/ModifierConfused.js
@@ -39,7 +39,7 @@ module.exports = class ModifierConfused extends Card {
           labels: ["block", "hidden", "absolute"],
           run: function () {
             if (Random.randInt(0, 1) == 0) {
-              this.blockWithDelirium(this.actor);
+              this.player.giveEffect("FalseMode", 1);
             }
           },
         });

--- a/Games/types/Mafia/roles/cards/PublicReveal.js
+++ b/Games/types/Mafia/roles/cards/PublicReveal.js
@@ -11,7 +11,13 @@ module.exports = class PublicReveal extends Card {
         }
 
         this.data.revealed = true;
-        this.revealToAll();
+      for (let player of this.game.players) {
+        if(player == this.player){
+        continue;
+        }
+          this.player.role.revealToPlayer(player);  
+      }
+      //this.revealToAll();
       },
     };
   }

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -1,6 +1,7 @@
 const modifierData = {
   Mafia: {
     Armed: {
+      category: "Items",
       internal: ["StartWithGun"],
       tags: ["Items", "Killing", "Gun", "Day Killer"],
       description: "Starts with a gun.",
@@ -8,6 +9,7 @@ const modifierData = {
       allowDuplicate: true,
     },
     Apprehensive: {
+      category: "Items",
       internal: ["LearnVisitorsAndArm"],
       tags: ["Items", "Gun", "Killing", "Reflexive", "Information"],
       description:
@@ -15,18 +17,21 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Ascetic: {
+      category: "Visits",
       internal: ["Ascetic"],
       tags: ["Role Blocker", "Kill Interaction", "Reflexive"],
       description: "Is untargetable from all non-killing actions.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Astral: {
+      category: "Visits",
       internal: ["Astral"],
       tags: ["Visits", "Astral"],
       description: "All actions done by this player are not visits.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Austere: {
+      category: "Other",
       internal: ["OnlyUseInPlayRoles"],
       tags: ["Austere"],
       description:
@@ -35,6 +40,7 @@ const modifierData = {
       incompatible: ["Excessive"],
     },
     Backup: {
+      category: "Other",
       internal: ["BackUpModifier"],
       tags: ["Conversion"],
       description:
@@ -43,6 +49,7 @@ const modifierData = {
       incompatible: ["Retired"],
     },
     Banished: {
+      category: "Other",
       internal: ["BanishedRole"],
       tags: ["Banished"],
       description:
@@ -51,6 +58,7 @@ const modifierData = {
       incompatible: ["Inclusive", "Exclusive"],
     },
     Birdbrained: {
+      category: "Items",
       internal: ["StartWithFalcon"],
       tags: ["Information", "Items", "Falcon", "Visits"],
       description: "Starts with a falcon.",
@@ -58,30 +66,35 @@ const modifierData = {
       allowDuplicate: true,
     },
     Biased: {
+      category: "Appearance",
       internal: ["OnePlayerShowsAsEvil"],
       tags: ["Information"],
       description: "One Village-aligned player will have unfavorable results to this role's information abilities.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Blessed: {
+      category: "Other",
       internal: ["StartWithExtraLife"],
       tags: ["Extra Lives"],
       description: "Starts with an Extra Life",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Blind: {
+      category: "Appearance",
       internal: ["Blind"],
       tags: ["Speech", "Blind"],
       description: "Sees all speech as anonymous.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Bloodthirsty: {
+      category: "Other",
       internal: ["ModifierBloodthirsty"],
       tags: ["Visits", "Killing"],
       description: "When visiting, their target will be killed.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Boastful: {
+      category: "Other",
       internal: ["ModifierBoastful"],
       tags: ["Information", "Reports"],
       description:
@@ -89,6 +102,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Bouncy: {
+      category: "Visits",
       internal: ["Bouncy"],
       tags: ["Redirection"],
       description:
@@ -96,6 +110,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Braggadocious: {
+      category: "Other",
       internal: ["PreventFactionJoints"],
       tags: [],
       description:
@@ -103,13 +118,15 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Brutish: {
+      category: "Other",
       internal: ["MakeSkittishOnRoleShare"],
-      tags: [],
+      tags: ["Role Share"],
       description:
         "Players who role-share with a Brutish player become skittish. Skittish players must accept all incoming role-shares.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Bulletproof: {
+      category: "Items",
       internal: ["StartWithArmor"],
       tags: ["Items", "Armor"],
       description: "Starts with armor.",
@@ -117,6 +134,7 @@ const modifierData = {
       allowDuplicate: true,
     },
     Caffeinated: {
+      category: "Items",
       internal: ["StartWithCoffee"],
       tags: ["Items", "Coffee"],
       description: "Starts with a Coffee.",
@@ -124,6 +142,7 @@ const modifierData = {
       allowDuplicate: true,
     },
     Camouflaged: {
+      category: "Appearance",
       internal: ["AppearAsRandomRole"],
       tags: ["Roles", "Deception"],
       description:
@@ -131,6 +150,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Chaotic: {
+      category: "Other",
       internal: ["BecomeExcessRole"],
       tags: ["Conversion", "Excess Roles"],
       description:
@@ -138,12 +158,14 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Checking: {
+      category: "Visits",
       internal: ["CheckSuccessfulVisit"],
       tags: ["Information", "Visits"],
       description: "Learns if their visit was successful or if it was blocked.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Churchgoing: {
+      category: "Items",
       internal: ["StartWithTract"],
       tags: ["Items", "Convert Saver", "Tract"],
       description: "Starts with a tract.",
@@ -151,6 +173,7 @@ const modifierData = {
       allowDuplicate: true,
     },
     Clannish: {
+      category: "Other",
       internal: ["AddRottenCopy"],
       tags: ["Delirium", "Setup Changes"],
       description:
@@ -158,12 +181,14 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Clueless: {
+      category: "Appearance",
       internal: ["Clueless"],
       tags: ["Speech", "Clueless", "Random Messages"],
       description: "Sees all speech as coming from random people.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Clumsy: {
+      category: "Visits",
       internal: ["RevealRoleToTarget"],
       tags: ["Information", "Visits", "Roles"],
       description:
@@ -171,12 +196,14 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Choosy: {
+      category: "Visits",
       internal: ["GuessRoleToGetBlocked"],
       tags: ["Self Block"],
       description: "Each night chooses a role. Actions will be blocked if visiting a player with that role.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Complex: {
+      category: "Visits",
       internal: ["Complex"],
       tags: ["Visits", "Block Self", "Vanilla", "Complex"],
       description:
@@ -186,12 +213,14 @@ const modifierData = {
       incompatible: ["Simple"],
     },
     Commuting: {
+      category: "Visits",
       internal: ["Commuting"],
       tags: ["Role Blocker", "Reflexive"],
       description: "Is untargetable from all actions.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Confused: {
+      category: "Appearance",
       internal: ["ModifierConfused"],
       tags: ["Manipulative", "Delirium", "Block Self"],
       description: "Investigative reports appear incorrect 50% of the time.",
@@ -199,20 +228,23 @@ const modifierData = {
       incompatible: ["Sane", "Insane", "Naive", "Paranoid"],
     },
     Consecutive: {
+      category: "Visits",
       internal: ["Consecutive"],
-      tags: ["Visits", "Block Self", "Consecutive"],
+      tags: ["Visits", "Consecutive"],
       description:
       "Can only target players they targeted previously.",
       eventDescription: "This modifier does nothing when on an Event.",
       incompatible: ["Fair", "Nonconsecutive"],
     },
     Creamed: {
+      category: "Items",
       internal: ["StartWithIceCream"],
       tags: ["Items", "Ice Cream"],
       description: "Starts with a Ice Cream. Ice Cream can be used to become a Vanilla role",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Crystalline: {
+      category: "Items",
       internal: ["StartWithCrystal"],
       tags: ["Revealing", "Items", "Crystal"],
       description: "Starts with a crystal ball.",
@@ -220,12 +252,14 @@ const modifierData = {
       allowDuplicate: true,
     },
     Dead: {
+      category: "Other",
       internal: ["Dead"],
       tags: ["Dead"],
       description: "Starts game dead",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Demonic: {
+      category: "Other",
       internal: ["Demonic"],
       tags: ["Demonic", "Essential"],
       description:
@@ -233,6 +267,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Delayed: {
+      category: "Visits",
       internal: ["Delayed"],
       tags: ["Delayed", "Meetings"],
       description:
@@ -242,6 +277,7 @@ const modifierData = {
       allowDuplicate: true,
     },
     Diplomatic: {
+      category: "Other",
       internal: ["CondemnImmune"],
       tags: ["Condemn", "Condemn Immune"],
       description: "Cannot be condemned.",
@@ -249,6 +285,7 @@ const modifierData = {
       incompatible: ["Frustrated"],
     },
     Disloyal: {
+      category: "Visits",
       internal: ["Disloyal"],
       tags: ["Visits", "Block Self", "Alignments", "Disloyal"],
       description:
@@ -257,6 +294,7 @@ const modifierData = {
       incompatible: ["Loyal"],
     },
     Dovish: {
+      category: "Other",
       internal: ["VillageMightSurviveCondemn"],
       tags: ["Condemn", "Condemn Immune", "Alignments", "Protective"],
       description:
@@ -264,6 +302,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Sorrowful: {
+      category: "Visits",
       internal: ["BlockedUnlessKilled"],
       tags: ["Block Self", "Death"],
       description:
@@ -272,6 +311,7 @@ const modifierData = {
       incompatible: ["Fatal"],
     },
     Even: {
+      category: "Visits",
       internal: ["Even"],
       tags: ["Even", "Meetings"],
       description:
@@ -280,6 +320,7 @@ const modifierData = {
       incompatible: ["Odd", "Delayed"],
     },
     Excessive: {
+      category: "Other",
       internal: ["ExcessiveRole"],
       tags: ["Excessive"],
       description:
@@ -288,6 +329,7 @@ const modifierData = {
       incompatible: ["Austere"],
     },
     Exclusive: {
+      category: "Other",
       internal: ["Remove1Banished"],
       tags: ["Banished", "Setup Changes"],
       description: "Removes 1 Banished Role in Closed Setups.",
@@ -296,6 +338,7 @@ const modifierData = {
       incompatible: ["Banished", "Inclusive"],
     },
     Exposed: {
+      category: "Other",
       internal: ["PublicReveal"],
       tags: ["Reveal Self"],
       description: "Starts revealed to everyone.",
@@ -303,6 +346,7 @@ const modifierData = {
       incompatible: ["Humble", "Scatterbrained", "Respected", "Modest"],
     },
     Explosive: {
+      category: "Items",
       internal: ["StartWithBomb"],
       tags: ["Items", "Killing"],
       description: "Starts with a bomb.",
@@ -310,6 +354,7 @@ const modifierData = {
       allowDuplicate: true,
     },
     Faceless: {
+      category: "Appearance",
       internal: ["AppearAsFliplessOnDeath"],
       tags: ["Clean Night Kill"],
       description:
@@ -318,6 +363,7 @@ const modifierData = {
       incompatible: ["Shady", "Unassuming", "Phony", "Suspect"],
     },
     Fair: {
+      category: "Visits",
       internal: ["FairModifier"],
       tags: ["Fair"],
       description:
@@ -326,6 +372,7 @@ const modifierData = {
       incompatible: ["Nonconsecutive", "Consecutive"],
     },
     Fatal: {
+      category: "Visits",
       internal: ["BlockedIfKilled"],
       tags: ["Block Self", "Death"],
       description:
@@ -334,6 +381,7 @@ const modifierData = {
       incompatible: ["Sorrowful"],
     },
     Felonious: {
+      category: "Other",
       internal: ["VotingPowerZero"],
       tags: ["Voting"],
       description: "Player's vote is worth 0.",
@@ -341,18 +389,21 @@ const modifierData = {
       incompatible: ["Trustworthy", "Untrustworthy"],
     },
     Fearful: {
+      category: "Visits",
       internal: ["BlockedIfScary"],
       tags: ["Self Block"],
       description: "Actions will be Blocked if a Scary role is alive.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Fragile: {
+      category: "Visits",
       internal: ["DieIfVisited"],
       tags: ["Killing", "Visits", "Self Kill"],
       description: "Will be killed if visited.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Frustrated: {
+      category: "Other",
       internal: ["FrustratedCondemnation"],
       tags: ["Voting", "Condemn"],
       description:
@@ -361,18 +412,21 @@ const modifierData = {
       incompatible: ["Diplomatic"],
     },
     Global: {
+      category: "Visits",
       internal: ["GlobalModifier"],
       tags: ["Visits", "Dawn"],
       description: "Will target All players at Night",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Gunslinging: {
+      category: "Items",
       internal: ["DefendAndSnatchGun"],
       tags: ["Items", "Gun"],
       description: "80% chance of snatching a gun when shot at.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Hemophilic: {
+      category: "Other",
       internal: ["ConvertKillToBleed"],
       tags: ["Bleeding"],
       description:
@@ -380,6 +434,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Holy: {
+      category: "Visits",
       internal: ["Holy"],
       tags: ["Visits", "Block Self", "Modifiers", "Holy"],
       description:
@@ -388,6 +443,7 @@ const modifierData = {
       incompatible: ["Unholy"],
     },
     Humble: {
+      category: "Appearance",
       internal: ["Humble"],
       tags: ["Vanilla"],
       description:
@@ -396,6 +452,7 @@ const modifierData = {
       incompatible: ["Respected", "Scatterbrained", "Exposed"],
     },
     Inclusive: {
+      category: "Other",
       internal: ["Add1Banished"],
       tags: ["Banished", "Setup Changes"],
       description: "Adds 1 Banished Role in Closed Setups.",
@@ -404,6 +461,7 @@ const modifierData = {
       incompatible: ["Banished", "Exclusive"],
     },
     Infamous: {
+      category: "Other",
       internal: ["RevealToEvils"],
       tags: ["Reveal Self"],
       description: "Starts revealed to all Evil players.",
@@ -411,12 +469,14 @@ const modifierData = {
       incompatible: ["Exposed"],
     },
     Insane: {
+      category: "Appearance",
       internal: ["FalseModifier"],
       tags: ["FalseMode"],
       description: "All Information received by this role is false.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Insightful: {
+      category: "Other",
       internal: ["Learn3ExcessRoles"],
       tags: ["Investigative", "Roles", "Excess Roles"],
       description:
@@ -424,6 +484,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Inverse: {
+      category: "Other",
       internal: ["VotingNegative"],
       tags: ["Voting"],
       description: "Player's vote is Negative.",
@@ -431,6 +492,7 @@ const modifierData = {
       incompatible: ["Felonious"],
     },
     Kleptomaniac: {
+      category: "Items",
       internal: ["StealFromTargets"],
       tags: ["Items", "Visits"],
       description:
@@ -438,12 +500,14 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Klutzy: {
+      category: "Items",
       internal: ["DropOwnItems"],
       tags: ["Items"],
       description: "Will passively drop any items held or received.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Lazy: {
+      category: "Visits",
       internal: ["ModifierLazy"],
       tags: ["Manipulative", "Delayed"],
       description:
@@ -451,6 +515,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Leaky: {
+      category: "Other",
       internal: ["ModifierLeaky"],
       tags: ["Whispers"],
       description:
@@ -458,18 +523,21 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Liminal: {
+      category: "Visits",
       internal: ["VisitDeadOrAlive"],
       tags: ["Visits", "Dead", "Liminal"],
       description: "Secondary actions can be used on dead or living players.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Linchpin: {
+      category: "Other",
       internal: ["KillAlignedOnDeath"],
       tags: ["Essential", "Selective Revealing", "Linchpin"],
       description: "If dead, all aligned players will die too.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Lone: {
+      category: "Other",
       internal: ["ModifierLone"],
       tags: ["Lone"],
       description:
@@ -477,6 +545,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Loud: {
+      category: "Visits",
       internal: ["ModifierLoud"],
       tags: ["Reflexive", "Information"],
       description:
@@ -484,6 +553,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Loyal: {
+      category: "Visits",
       internal: ["Loyal"],
       tags: ["Visits", "Block Self", "Alignments", "Loyal"],
       description:
@@ -492,6 +562,7 @@ const modifierData = {
       incompatible: ["Disloyal"],
     },
     Luminous: {
+      category: "Items",
       internal: ["StartWithCandle"],
       tags: ["Information", "Items", "Candle", "Visits"],
       description: "Starts with a candle.",
@@ -499,12 +570,14 @@ const modifierData = {
       allowDuplicate: true,
     },
     Macho: {
+      category: "Visits",
       internal: ["SaveImmune"],
       tags: ["Macho", "Save Immune"],
       description: "Can not be saved or protected from kills by any means.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Macabre: {
+      category: "Items",
       internal: ["StartWithSyringe"],
       tags: ["Revive", "Items", "Syringe", "Graveyard"],
       description: "Starts with a syringe.",
@@ -512,6 +585,7 @@ const modifierData = {
       allowDuplicate: true,
     },
     Magnetic: {
+      category: "Visits",
       internal: ["Magnetic"],
       tags: ["Redirection"],
       description:
@@ -519,6 +593,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Married: {
+      category: "Other",
       internal: ["LearnAndLifeLinkToPlayer"],
       tags: ["Information", "Linked"],
       description:
@@ -526,12 +601,14 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Masked: {
+      category: "Appearance",
       internal: ["DisguiseAsTarget"],
       tags: ["Roles", "Deception", "Suits"],
       description: "Gains a suit of each target's role.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Modest: {
+      category: "Appearance",
       internal: ["Modest"],
       tags: ["Modifiers"],
       description: "Appears to self with no modifiers.",
@@ -539,12 +616,14 @@ const modifierData = {
       incompatible: ["Exposed"],
     },
     Morbid: {
+      category: "Visits",
       internal: ["VisitOnlyDead"],
       tags: ["Visits", "Dead", "Morbid"],
       description: "Secondary actions can only be used on dead players.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Narcissistic: {
+      category: "Visits",
       internal: ["TargetSelf50Percent"],
       tags: ["Redirection"],
       description:
@@ -552,12 +631,14 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Neighborly: {
+      category: "Other",
       internal: ["MeetWithNeighbors"],
       tags: ["Meeting"],
       description: "Attends a Night Meeting with their Neighbors.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Noisy: {
+      category: "Visits",
       internal: ["RevealNameToTarget"],
       tags: ["Information", "Visits"],
       description:
@@ -565,6 +646,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Notable: {
+      category: "Other",
       internal: ["RevealToVillage"],
       tags: ["Reveal Self"],
       description: "Starts revealed to all Village-aligned players.",
@@ -572,6 +654,7 @@ const modifierData = {
       incompatible: ["Exposed"],
     },
     Nonconsecutive: {
+      category: "Visits",
       internal: ["Nonconsecutive"],
       tags: ["Visits", "Block Self", "Nonconsecutive"],
       description:
@@ -580,6 +663,7 @@ const modifierData = {
       incompatible: ["Fair", "Consecutive"],
     },
     Odd: {
+      category: "Visits",
       internal: ["Odd"],
       tags: ["Odd", "Meetings"],
       description: "Can only attend secondary meetings on odd days and nights.",
@@ -587,12 +671,14 @@ const modifierData = {
       incompatible: ["Even"],
     },
     Omniscient: {
+      category: "Other",
       internal: ["Omniscient"],
       tags: ["Roles", "Visits", "Information"],
       description: "Each night see all visits and learn all players roles.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     "X-Shot": {
+      category: "Visits",
       internal: ["OneShot"],
       tags: ["X-Shot"],
       description: "Can only perform actions X times. X is equal the number of times this modifier is added.",
@@ -600,6 +686,7 @@ const modifierData = {
       allowDuplicate: true,
     },
     Phony: {
+      category: "Appearance",
       internal: ["AppearAsVillagePROnDeath"],
       tags: ["Deception"],
       description: "Appears as Village Power Role when condemned or on death.",
@@ -607,18 +694,21 @@ const modifierData = {
       incompatible: ["Shady", "Faceless", "Suspect", "Unassuming"],
     },
     Picky: {
+      category: "Visits",
       internal: ["GuessRoleOrGetBlocked"],
       tags: ["Self Block"],
       description: "Each night chooses a role. Actions will be blocked unless visiting a player with that role.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Pious: {
+      category: "Other",
       internal: ["ConvertKillersOnDeath"],
       tags: ["Sacrificial", "Conversion"],
       description: "On death, has a chance to redeem their killer.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Preoccupied: {
+      category: "Visits",
       internal: ["BlockIfVisited"],
       tags: ["Visits", "Block Self"],
       description:
@@ -626,12 +716,14 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Proactive: {
+      category: "Visits",
       internal: ["MustAct"],
       tags: ["Action"],
       description: "Must take actions.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Prosaic: {
+      category: "Items",
       internal: ["StartWithEnvelope"],
       tags: ["Messages", "Items", "Envelope"],
       description: "Starts with an envelope.",
@@ -639,18 +731,21 @@ const modifierData = {
       allowDuplicate: true,
     },
     Provocative: {
+      category: "Items",
       internal: ["Provocative"],
       tags: ["Messages", "Items", "Sockpuppet"],
       description: "Each day, receives a sockpuppet.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Random: {
+      category: "Visits",
       internal: ["TargetRandom"],
       tags: ["Redirection"],
       description: "Each night is redirected onto a random player.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Reactionary: {
+      category: "Other",
       internal: ["KillConverters"],
       tags: ["Convert Saver", "Killing", "Reflexive"],
       description:
@@ -658,19 +753,22 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Reclusive: {
+      category: "Other",
       internal: ["MakeShyOnRoleShare"],
-      tags: ["Killing", "Visits", "Self Kill"],
+      tags: ["Role Share"],
       description:
         "Players who role-share with a Reclusive player become shy. Shy players cannot accept incoming role-shares and cannot Private/Public Reveal.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Regretful: {
+      category: "Visits",
       internal: ["Regretful"],
       tags: ["Killing", "Visits", "Self Kill"],
       description: "Will be killed if their target was killed.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Refined: {
+      category: "Visits",
       internal: ["Refined"],
       tags: ["Visits", "Block Self", "Modifiers", "Refined"],
       description:
@@ -679,6 +777,7 @@ const modifierData = {
       incompatible: ["Unrefined"],
     },
     Resolute: {
+      category: "Visits",
       internal: ["Resolute"],
       tags: ["Unblockable"],
       description:
@@ -686,6 +785,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Respected: {
+      category: "Appearance",
       internal: ["VillagerToInvestigative"],
       tags: ["Villager", "Deception"],
       description: "Appears as a Villager to investigative roles.",
@@ -693,6 +793,7 @@ const modifierData = {
       incompatible: ["Humble", "Scatterbrained", "Exposed"],
     },
     Restless: {
+      category: "Visits",
       internal: ["ActWhileDead"],
       tags: ["Dead", "Graveyard", "Restless", "Graveyard Participation"],
       description: "Can only perform secondary actions while dead.",
@@ -700,6 +801,7 @@ const modifierData = {
       incompatible: ["Transcendent", "Vengeful"],
     },
     Retired: {
+      category: "Other",
       internal: ["Retired"],
       tags: ["Information", "Retired"],
       description:
@@ -708,6 +810,7 @@ const modifierData = {
       incompatible: ["Backup"],
     },
     Rifled: {
+      category: "Items",
       internal: ["StartWithRifle"],
       tags: ["Items", "Killing", "Gun", "Alignments", "Day Killer"],
       description: "Starts with a rifle.",
@@ -715,6 +818,7 @@ const modifierData = {
       allowDuplicate: true,
     },
     Sacrificial: {
+      category: "Visits",
       internal: ["Sacrificial"],
       tags: ["Sacrificial", "Killing", "Self Kill"],
       description:
@@ -722,6 +826,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Scatterbrained: {
+      category: "Appearance",
       internal: ["Scatterbrained"],
       tags: ["Visitor"],
       description:
@@ -730,30 +835,35 @@ const modifierData = {
       incompatible: ["Humble", "Respected", "Exposed"],
     },
     Scary: {
+      category: "Visits",
       internal: ["BlockedFearful"],
       tags: ["Self Block"],
       description: "Will Block any Fearful roles when alive.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Seductive: {
+      category: "Visits",
       internal: ["BlockTargets"],
       tags: ["Visits", "Role Blocker"],
       description: "While visiting a player, that player will be roleblocked.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Selfish: {
+      category: "Visits",
       internal: ["CanVisitSelf"],
       tags: ["Visits", "Role Blocker", "Selfish"],
       description: "Can target themselves.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Sensible: {
+      category: "Other",
       internal: ["LearnIfRoleChanged"],
       tags: ["Information"],
       description: "Each night learn what their role is.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Shady: {
+      category: "Appearance",
       internal: ["AppearAsRandomEvil"],
       tags: ["Deception"],
       description:
@@ -762,6 +872,7 @@ const modifierData = {
       incompatible: ["Faceless", "Unassuming", "Suspect", "Phony",],
     },
     Shielded: {
+      category: "Items",
       internal: ["StartWithShield"],
       tags: ["Items"],
       description: "Starts with a Shield.",
@@ -769,6 +880,7 @@ const modifierData = {
       allowDuplicate: true,
     },
     Suspect: {
+      category: "Appearance",
       internal: ["AppearAsVanillaEvil"],
       tags: ["Deception"],
       description:
@@ -777,6 +889,7 @@ const modifierData = {
       incompatible: ["Faceless", "Unassuming", "Shady", "Phony"],
     },
     Simple: {
+      category: "Visits",
       internal: ["Simple"],
       tags: ["Visits", "Block Self", "Vanilla", "Simple"],
       description:
@@ -785,12 +898,14 @@ const modifierData = {
       incompatible: ["Complex"],
     },
     Social: {
+      category: "Other",
       internal: ["MeetWithSocial"],
       tags: ["Meeting"],
       description: "Attends a meeting with all other Social players.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Steeled: {
+      category: "Items",
       internal: ["StartWithKnife"],
       tags: ["Bleeding", "Items", "Knife", "Killing", "Day Killer"],
       description: "Starts with a knife.",
@@ -798,12 +913,14 @@ const modifierData = {
       allowDuplicate: true,
     },
     Strong: {
+      category: "Other",
       internal: ["StrongModifier"],
       tags: ["Unblockable", "Strong"],
       description: "All kills performed by this player cannot be saved.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Suspended: {
+      category: "Visits",
       internal: ["Suspended"],
       tags: ["Suspended", "Meetings"],
       description:
@@ -813,18 +930,21 @@ const modifierData = {
       incompatible: ["Delayed"],
     },
     Telepathic: {
+      category: "Other",
       internal: ["ModifierTelepathic"],
       tags: ["Speaking"],
       description: "May anonymously contact any player.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Temporary: {
+      category: "Other",
       internal: ["LoseModifiers"],
       tags: ["Temporary", "Modifiers"],
       description: "Loses their Modifiers at the end of the Night.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Tinkering: {
+      category: "Items",
       internal: ["ForageItem"],
       tags: ["Items"],
       description:
@@ -832,12 +952,14 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Traitorous: {
+      category: "Other",
       internal: ["TurnIntoTraitorOnMafiaKill"],
       tags: ["Sacrificial", "Conversion", "Traitor"],
       description: "If killed by the Mafia, will turn into a Traitor instead.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Transcendent: {
+      category: "Visits",
       internal: ["ActAliveOrDead"],
       tags: ["Dead", "Graveyard", "Transcendent", "Graveyard Participation"],
       description: "Can perform secondary actions while either alive or dead.",
@@ -845,6 +967,7 @@ const modifierData = {
       incompatible: ["Restless", "Vengeful"],
     },
     Trustworthy: {
+      category: "Other",
       internal: ["VotingPowerIncrease"],
       tags: ["Voting"],
       description: "Player's vote is worth 1 more.",
@@ -853,6 +976,7 @@ const modifierData = {
       allowDuplicate: true,
     },
     Unassuming: {
+      category: "Appearance",
       internal: ["AppearAsVillagerOnDeath"],
       tags: ["Villager", "Deception"],
       description: "Appears as Villager when condemned or on death.",
@@ -860,6 +984,7 @@ const modifierData = {
       incompatible: ["Shady", "Faceless", "Suspect", "Phony"],
     },
     Unholy: {
+      category: "Visits",
       internal: ["Unholy"],
       tags: ["Visits", "Block Self", "Modifiers", "Unholy"],
       description:
@@ -868,18 +993,21 @@ const modifierData = {
       incompatible: ["Holy"],
     },
     Unkillable: {
+      category: "Other",
       internal: ["KillImmune"],
       tags: ["Unkillable"],
       description: "Can only be killed by condemn.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Unlucky: {
+      category: "Other",
       internal: ["UnluckyDeath"],
       tags: ["Killing"],
       description: "After Night 1, You can die at any time.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Unrefined: {
+      category: "Visits",
       internal: ["Unrefined"],
       tags: ["Visits", "Block Self", "Modifiers", "Unrefined"],
       description:
@@ -888,12 +1016,14 @@ const modifierData = {
       incompatible: ["Refined"],
     },
     Unwavering: {
+      category: "Other",
       internal: ["ConvertImmune"],
       tags: ["Convert Saver"],
       description: "Cannot be converted to another role.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Vain: {
+      category: "Visits",
       internal: ["Vain"],
       tags: ["Visits", "Killing", "Alignments", "Self Kill"],
       description:
@@ -902,6 +1032,7 @@ const modifierData = {
       incompatible: ["Weak"],
     },
     Vengeful: {
+      category: "Visits",
       internal: ["ActAfterNightKilled"],
       tags: ["Graveyard", "Vengeful", "Graveyard Participation"],
       description: "Can perform secondary actions after being killed at night",
@@ -909,6 +1040,7 @@ const modifierData = {
       incompatible: ["Transcendent", "Restless"],
     },
     Verrucose: {
+      category: "Other",
       internal: ["GivePermaDelirium"],
       tags: ["Sacrificial", "Manipulative", "Delirium"],
       description:
@@ -916,6 +1048,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Versatile: {
+      category: "Other",
       internal: ["InheritFirstDeadAligned"],
       tags: ["Dead", "Conversion"],
       description:
@@ -923,6 +1056,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Wannabe: {
+      category: "Appearance",
       internal: ["Wannabe"],
       tags: ["Deception"],
       description:
@@ -930,6 +1064,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Weak: {
+      category: "Visits",
       internal: ["Weak"],
       tags: ["Visits", "Killing", "Alignments", "Self Kill"],
       description:
@@ -938,6 +1073,7 @@ const modifierData = {
       incompatible: ["Vain"],
     },
     Wise: {
+      category: "Other",
       internal: ["MakePlayerLearnOneOfTwoPlayersOnDeath"],
       tags: ["Sacrificial", "Information", "Graveyard Participation"],
       description:
@@ -945,12 +1081,14 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Sane: {
+      category: "Appearance",
       internal: ["TrueModifier"],
       tags: ["FalseMode"],
       description: "All Information received by this role is true.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Paranoid: {
+      category: "Appearance",
       internal: ["UnfavorableModifier"],
       tags: ["FalseMode"],
       description:
@@ -958,6 +1096,7 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Naive: {
+      category: "Appearance",
       internal: ["FavorableModifier"],
       tags: ["FalseMode"],
       description:

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -8,28 +8,6 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
       allowDuplicate: true,
     },
-    Apprehensive: {
-      category: "Items",
-      internal: ["LearnVisitorsAndArm"],
-      tags: ["Items", "Gun", "Killing", "Reflexive", "Information"],
-      description:
-        "Will receive a Gun (that will not reveal shooter) with each visit and learn the name of the visitor.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Ascetic: {
-      category: "Visits",
-      internal: ["Ascetic"],
-      tags: ["Role Blocker", "Kill Interaction", "Reflexive"],
-      description: "Is untargetable from all non-killing actions.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Astral: {
-      category: "Visits",
-      internal: ["Astral"],
-      tags: ["Visits", "Astral"],
-      description: "All actions done by this player are not visits.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
     Austere: {
       category: "Other",
       internal: ["OnlyUseInPlayRoles"],
@@ -48,15 +26,6 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
       incompatible: ["Retired"],
     },
-    Banished: {
-      category: "Other",
-      internal: ["BanishedRole"],
-      tags: ["Banished"],
-      description:
-        "Banished roles will only spawn if the Banished count is increased, or if another roles adds Banished roles to the game.",
-      eventDescription: "This Event will not occur normally.",
-      incompatible: ["Inclusive", "Exclusive"],
-    },
     Birdbrained: {
       category: "Items",
       internal: ["StartWithFalcon"],
@@ -65,25 +34,11 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
       allowDuplicate: true,
     },
-    Biased: {
-      category: "Appearance",
-      internal: ["OnePlayerShowsAsEvil"],
-      tags: ["Information"],
-      description: "One Village-aligned player will have unfavorable results to this role's information abilities.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
     Blessed: {
       category: "Other",
       internal: ["StartWithExtraLife"],
       tags: ["Extra Lives"],
       description: "Starts with an Extra Life",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Blind: {
-      category: "Appearance",
-      internal: ["Blind"],
-      tags: ["Speech", "Blind"],
-      description: "Sees all speech as anonymous.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Bloodthirsty: {
@@ -99,30 +54,6 @@ const modifierData = {
       tags: ["Information", "Reports"],
       description:
         "All reports received are announced to everyone, with the player's role revealed.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Bouncy: {
-      category: "Visits",
-      internal: ["Bouncy"],
-      tags: ["Redirection"],
-      description:
-        "If possible, night kills will be redirected to another player of the same alignment.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Braggadocious: {
-      category: "Other",
-      internal: ["PreventFactionJoints"],
-      tags: [],
-      description:
-        "If a player with this modifier wins, then Village, Mafia, and Cult cannot also win alongside them.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Brutish: {
-      category: "Other",
-      internal: ["MakeSkittishOnRoleShare"],
-      tags: ["Role Share"],
-      description:
-        "Players who role-share with a Brutish player become skittish. Skittish players must accept all incoming role-shares.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Bulletproof: {
@@ -141,27 +72,12 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
       allowDuplicate: true,
     },
-    Camouflaged: {
-      category: "Appearance",
-      internal: ["AppearAsRandomRole"],
-      tags: ["Roles", "Deception"],
-      description:
-        "Appears on death and to information roles as a random role in the game that is not Villager, Impersonator or Impostor.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
     Chaotic: {
       category: "Other",
       internal: ["BecomeExcessRole"],
       tags: ["Conversion", "Excess Roles"],
       description:
         "On the first night, a player with this modifier will become a random excess role within their alignment. Independents will become excess roles from any alignment.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Checking: {
-      category: "Visits",
-      internal: ["CheckSuccessfulVisit"],
-      tags: ["Information", "Visits"],
-      description: "Learns if their visit was successful or if it was blocked.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Churchgoing: {
@@ -179,62 +95,6 @@ const modifierData = {
       description:
         "In closed Setups will add 0 to 2 Copies of This Role, 1 of the added roles is Permanently given Delirium.",
       eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Clueless: {
-      category: "Appearance",
-      internal: ["Clueless"],
-      tags: ["Speech", "Clueless", "Random Messages"],
-      description: "Sees all speech as coming from random people.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Clumsy: {
-      category: "Visits",
-      internal: ["RevealRoleToTarget"],
-      tags: ["Information", "Visits", "Roles"],
-      description:
-        "Announces the player's role to the targets of their night actions.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Choosy: {
-      category: "Visits",
-      internal: ["GuessRoleToGetBlocked"],
-      tags: ["Self Block"],
-      description: "Each night chooses a role. Actions will be blocked if visiting a player with that role.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Complex: {
-      category: "Visits",
-      internal: ["Complex"],
-      tags: ["Visits", "Block Self", "Vanilla", "Complex"],
-      description:
-        "If this player visits a player with a vanilla role, all their actions will be blocked.",
-      eventDescription:
-        "This Event will not apply to players with Vanilla roles.",
-      incompatible: ["Simple"],
-    },
-    Commuting: {
-      category: "Visits",
-      internal: ["Commuting"],
-      tags: ["Role Blocker", "Reflexive"],
-      description: "Is untargetable from all actions.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Confused: {
-      category: "Appearance",
-      internal: ["ModifierConfused"],
-      tags: ["Manipulative", "Delirium", "Block Self"],
-      description: "Investigative reports appear incorrect 50% of the time.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Sane", "Insane", "Naive", "Paranoid"],
-    },
-    Consecutive: {
-      category: "Visits",
-      internal: ["Consecutive"],
-      tags: ["Visits", "Consecutive"],
-      description:
-      "Can only target players they targeted previously.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Fair", "Nonconsecutive"],
     },
     Creamed: {
       category: "Items",
@@ -258,67 +118,6 @@ const modifierData = {
       description: "Starts game dead",
       eventDescription: "This modifier does nothing when on an Event.",
     },
-    Demonic: {
-      category: "Other",
-      internal: ["Demonic"],
-      tags: ["Demonic", "Essential"],
-      description:
-        "Cult will win if a Demonic player is alive in final 2 or only Demonic and Cult players are alive. If all Demonic players are dead, all Cult-aligned players will die.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Delayed: {
-      category: "Visits",
-      internal: ["Delayed"],
-      tags: ["Delayed", "Meetings"],
-      description:
-        "Cannot attend secondary meetings for the first day and night.",
-      eventDescription: "This Event will not occur on the first night.",
-      incompatible: ["Suspended"],
-      allowDuplicate: true,
-    },
-    Diplomatic: {
-      category: "Other",
-      internal: ["CondemnImmune"],
-      tags: ["Condemn", "Condemn Immune"],
-      description: "Cannot be condemned.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Frustrated"],
-    },
-    Disloyal: {
-      category: "Visits",
-      internal: ["Disloyal"],
-      tags: ["Visits", "Block Self", "Alignments", "Disloyal"],
-      description:
-        "If this player visits a player of the same alignment, their secondary actions will be blocked.",
-      eventDescription: "This Event will not apply to Non-Evil players.",
-      incompatible: ["Loyal"],
-    },
-    Dovish: {
-      category: "Other",
-      internal: ["VillageMightSurviveCondemn"],
-      tags: ["Condemn", "Condemn Immune", "Alignments", "Protective"],
-      description:
-        "While a role with this modifier is in play, Village-aligned players might survive being condemned",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Sorrowful: {
-      category: "Visits",
-      internal: ["BlockedUnlessKilled"],
-      tags: ["Block Self", "Death"],
-      description:
-        "Unless killed at night, their secondary actions will be blocked.",
-      eventDescription: "This Event will not apply to Non-Evil players.",
-      incompatible: ["Fatal"],
-    },
-    Even: {
-      category: "Visits",
-      internal: ["Even"],
-      tags: ["Even", "Meetings"],
-      description:
-        "Can only attend secondary meetings on even days and nights.",
-      eventDescription: "This Event will only occur on Even nights.",
-      incompatible: ["Odd", "Delayed"],
-    },
     Excessive: {
       category: "Other",
       internal: ["ExcessiveRole"],
@@ -328,23 +127,6 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
       incompatible: ["Austere"],
     },
-    Exclusive: {
-      category: "Other",
-      internal: ["Remove1Banished"],
-      tags: ["Banished", "Setup Changes"],
-      description: "Removes 1 Banished Role in Closed Setups.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      allowDuplicate: true,
-      incompatible: ["Banished", "Inclusive"],
-    },
-    Exposed: {
-      category: "Other",
-      internal: ["PublicReveal"],
-      tags: ["Reveal Self"],
-      description: "Starts revealed to everyone.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Humble", "Scatterbrained", "Respected", "Modest"],
-    },
     Explosive: {
       category: "Items",
       internal: ["StartWithBomb"],
@@ -352,71 +134,6 @@ const modifierData = {
       description: "Starts with a bomb.",
       eventDescription: "This modifier does nothing when on an Event.",
       allowDuplicate: true,
-    },
-    Faceless: {
-      category: "Appearance",
-      internal: ["AppearAsFliplessOnDeath"],
-      tags: ["Clean Night Kill"],
-      description:
-        "Player's role will be hidden from the town when condemned or on death.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Shady", "Unassuming", "Phony", "Suspect"],
-    },
-    Fair: {
-      category: "Visits",
-      internal: ["FairModifier"],
-      tags: ["Fair"],
-      description:
-        "Cannot target a previously targeted player.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Nonconsecutive", "Consecutive"],
-    },
-    Fatal: {
-      category: "Visits",
-      internal: ["BlockedIfKilled"],
-      tags: ["Block Self", "Death"],
-      description:
-        "If killed at night, their secondary actions will be blocked.",
-      eventDescription: "This Event will not apply to Non-Evil players.",
-      incompatible: ["Sorrowful"],
-    },
-    Felonious: {
-      category: "Other",
-      internal: ["VotingPowerZero"],
-      tags: ["Voting"],
-      description: "Player's vote is worth 0.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Trustworthy", "Untrustworthy"],
-    },
-    Fearful: {
-      category: "Visits",
-      internal: ["BlockedIfScary"],
-      tags: ["Self Block"],
-      description: "Actions will be Blocked if a Scary role is alive.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Fragile: {
-      category: "Visits",
-      internal: ["DieIfVisited"],
-      tags: ["Killing", "Visits", "Self Kill"],
-      description: "Will be killed if visited.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Frustrated: {
-      category: "Other",
-      internal: ["FrustratedCondemnation"],
-      tags: ["Voting", "Condemn"],
-      description:
-        "Cannot be condemned by majority vote. A non-zero minority vote will kill the target.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Diplomatic"],
-    },
-    Global: {
-      category: "Visits",
-      internal: ["GlobalModifier"],
-      tags: ["Visits", "Dawn"],
-      description: "Will target All players at Night",
-      eventDescription: "This modifier does nothing when on an Event.",
     },
     Gunslinging: {
       category: "Items",
@@ -433,48 +150,6 @@ const modifierData = {
         "If this player is shot or targeted for a kill, will bleed and then die in one day.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
-    Holy: {
-      category: "Visits",
-      internal: ["Holy"],
-      tags: ["Visits", "Block Self", "Modifiers", "Holy"],
-      description:
-        "If this player visits a player with a Demonic role, their secondary actions will be blocked.",
-      eventDescription: "This Event will not apply to Demonic players.",
-      incompatible: ["Unholy"],
-    },
-    Humble: {
-      category: "Appearance",
-      internal: ["Humble"],
-      tags: ["Vanilla"],
-      description:
-        "Appears as Villager (Village) / Mafioso (Mafia) / Cultist (Cult) / Grouch (Independent) to self with no modifier.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Respected", "Scatterbrained", "Exposed"],
-    },
-    Inclusive: {
-      category: "Other",
-      internal: ["Add1Banished"],
-      tags: ["Banished", "Setup Changes"],
-      description: "Adds 1 Banished Role in Closed Setups.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      allowDuplicate: true,
-      incompatible: ["Banished", "Exclusive"],
-    },
-    Infamous: {
-      category: "Other",
-      internal: ["RevealToEvils"],
-      tags: ["Reveal Self"],
-      description: "Starts revealed to all Evil players.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Exposed"],
-    },
-    Insane: {
-      category: "Appearance",
-      internal: ["FalseModifier"],
-      tags: ["FalseMode"],
-      description: "All Information received by this role is false.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
     Insightful: {
       category: "Other",
       internal: ["Learn3ExcessRoles"],
@@ -482,84 +157,6 @@ const modifierData = {
       description:
         "Learns 3 excess roles upon the game's start. Mafia/Cult roles always learn Village-aligned excess roles.",
       eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Inverse: {
-      category: "Other",
-      internal: ["VotingNegative"],
-      tags: ["Voting"],
-      description: "Player's vote is Negative.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Felonious"],
-    },
-    Kleptomaniac: {
-      category: "Items",
-      internal: ["StealFromTargets"],
-      tags: ["Items", "Visits"],
-      description:
-        "While visiting a player, that player's items will be stolen.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Klutzy: {
-      category: "Items",
-      internal: ["DropOwnItems"],
-      tags: ["Items"],
-      description: "Will passively drop any items held or received.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Lazy: {
-      category: "Visits",
-      internal: ["ModifierLazy"],
-      tags: ["Manipulative", "Delayed"],
-      description:
-        "Actions taken on night will only execute after a full day/night phase.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Leaky: {
-      category: "Other",
-      internal: ["ModifierLeaky"],
-      tags: ["Whispers"],
-      description:
-        "All whispers involving a player with this modifier are leaked.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Liminal: {
-      category: "Visits",
-      internal: ["VisitDeadOrAlive"],
-      tags: ["Visits", "Dead", "Liminal"],
-      description: "Secondary actions can be used on dead or living players.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Linchpin: {
-      category: "Other",
-      internal: ["KillAlignedOnDeath"],
-      tags: ["Essential", "Selective Revealing", "Linchpin"],
-      description: "If dead, all aligned players will die too.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Lone: {
-      category: "Other",
-      internal: ["ModifierLone"],
-      tags: ["Lone"],
-      description:
-        "If this role typically has a group meeting at night, they will not meet with or know the identity of their partner(s).",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Loud: {
-      category: "Visits",
-      internal: ["ModifierLoud"],
-      tags: ["Reflexive", "Information"],
-      description:
-        "If visited, cries out the identity of players who visited them during the night.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Loyal: {
-      category: "Visits",
-      internal: ["Loyal"],
-      tags: ["Visits", "Block Self", "Alignments", "Loyal"],
-      description:
-        "If this player visits a player of the opposite alignment, their secondary actions will be blocked.",
-      eventDescription: "This Event will not apply to Evil players.",
-      incompatible: ["Disloyal"],
     },
     Luminous: {
       category: "Items",
@@ -570,7 +167,7 @@ const modifierData = {
       allowDuplicate: true,
     },
     Macho: {
-      category: "Visits",
+      category: "Other",
       internal: ["SaveImmune"],
       tags: ["Macho", "Save Immune"],
       description: "Can not be saved or protected from kills by any means.",
@@ -584,14 +181,6 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
       allowDuplicate: true,
     },
-    Magnetic: {
-      category: "Visits",
-      internal: ["Magnetic"],
-      tags: ["Redirection"],
-      description:
-        "If possible, night kills will be redirected onto this player if someone with the same alignment as them is targeted.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
     Married: {
       category: "Other",
       internal: ["LearnAndLifeLinkToPlayer"],
@@ -600,76 +189,6 @@ const modifierData = {
         "On Night 1 will learn a Village-aligned player and their role. If that player is killed by the Mafia or a Demonic role, the Married player dies.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
-    Masked: {
-      category: "Appearance",
-      internal: ["DisguiseAsTarget"],
-      tags: ["Roles", "Deception", "Suits"],
-      description: "Gains a suit of each target's role.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Modest: {
-      category: "Appearance",
-      internal: ["Modest"],
-      tags: ["Modifiers"],
-      description: "Appears to self with no modifiers.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Exposed"],
-    },
-    Morbid: {
-      category: "Visits",
-      internal: ["VisitOnlyDead"],
-      tags: ["Visits", "Dead", "Morbid"],
-      description: "Secondary actions can only be used on dead players.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Narcissistic: {
-      category: "Visits",
-      internal: ["TargetSelf50Percent"],
-      tags: ["Redirection"],
-      description:
-        "Each night has 50% chance to be redirected onto themselves.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Neighborly: {
-      category: "Other",
-      internal: ["MeetWithNeighbors"],
-      tags: ["Meeting"],
-      description: "Attends a Night Meeting with their Neighbors.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Noisy: {
-      category: "Visits",
-      internal: ["RevealNameToTarget"],
-      tags: ["Information", "Visits"],
-      description:
-        "Announces the player's name to the targets of their night actions.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Notable: {
-      category: "Other",
-      internal: ["RevealToVillage"],
-      tags: ["Reveal Self"],
-      description: "Starts revealed to all Village-aligned players.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Exposed"],
-    },
-    Nonconsecutive: {
-      category: "Visits",
-      internal: ["Nonconsecutive"],
-      tags: ["Visits", "Block Self", "Nonconsecutive"],
-      description:
-        "Cannot target a player they targeted the previous night",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Fair", "Consecutive"],
-    },
-    Odd: {
-      category: "Visits",
-      internal: ["Odd"],
-      tags: ["Odd", "Meetings"],
-      description: "Can only attend secondary meetings on odd days and nights.",
-      eventDescription: "This Event will only occur on Odd nights.",
-      incompatible: ["Even"],
-    },
     Omniscient: {
       category: "Other",
       internal: ["Omniscient"],
@@ -677,49 +196,11 @@ const modifierData = {
       description: "Each night see all visits and learn all players roles.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
-    "X-Shot": {
-      category: "Visits",
-      internal: ["OneShot"],
-      tags: ["X-Shot"],
-      description: "Can only perform actions X times. X is equal the number of times this modifier is added.",
-      eventDescription: "This Event will only occur once.",
-      allowDuplicate: true,
-    },
-    Phony: {
-      category: "Appearance",
-      internal: ["AppearAsVillagePROnDeath"],
-      tags: ["Deception"],
-      description: "Appears as Village Power Role when condemned or on death.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Shady", "Faceless", "Suspect", "Unassuming"],
-    },
-    Picky: {
-      category: "Visits",
-      internal: ["GuessRoleOrGetBlocked"],
-      tags: ["Self Block"],
-      description: "Each night chooses a role. Actions will be blocked unless visiting a player with that role.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
     Pious: {
       category: "Other",
       internal: ["ConvertKillersOnDeath"],
       tags: ["Sacrificial", "Conversion"],
       description: "On death, has a chance to redeem their killer.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Preoccupied: {
-      category: "Visits",
-      internal: ["BlockIfVisited"],
-      tags: ["Visits", "Block Self"],
-      description:
-        "If visited during the night, blocks the player's night action.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Proactive: {
-      category: "Visits",
-      internal: ["MustAct"],
-      tags: ["Action"],
-      description: "Must take actions.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Prosaic: {
@@ -730,20 +211,6 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
       allowDuplicate: true,
     },
-    Provocative: {
-      category: "Items",
-      internal: ["Provocative"],
-      tags: ["Messages", "Items", "Sockpuppet"],
-      description: "Each day, receives a sockpuppet.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Random: {
-      category: "Visits",
-      internal: ["TargetRandom"],
-      tags: ["Redirection"],
-      description: "Each night is redirected onto a random player.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
     Reactionary: {
       category: "Other",
       internal: ["KillConverters"],
@@ -751,54 +218,6 @@ const modifierData = {
       description:
         "Kills anyone (up to two people) who tries to convert them at night.",
       eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Reclusive: {
-      category: "Other",
-      internal: ["MakeShyOnRoleShare"],
-      tags: ["Role Share"],
-      description:
-        "Players who role-share with a Reclusive player become shy. Shy players cannot accept incoming role-shares and cannot Private/Public Reveal.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Regretful: {
-      category: "Visits",
-      internal: ["Regretful"],
-      tags: ["Killing", "Visits", "Self Kill"],
-      description: "Will be killed if their target was killed.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Refined: {
-      category: "Visits",
-      internal: ["Refined"],
-      tags: ["Visits", "Block Self", "Modifiers", "Refined"],
-      description:
-        "If this player visits a player with a Banished role, their secondary actions will be blocked.",
-      eventDescription: "This Event will not apply to Banished players.",
-      incompatible: ["Unrefined"],
-    },
-    Resolute: {
-      category: "Visits",
-      internal: ["Resolute"],
-      tags: ["Unblockable"],
-      description:
-        "All actions done by this player cannot be roleblocked or controlled.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Respected: {
-      category: "Appearance",
-      internal: ["VillagerToInvestigative"],
-      tags: ["Villager", "Deception"],
-      description: "Appears as a Villager to investigative roles.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Humble", "Scatterbrained", "Exposed"],
-    },
-    Restless: {
-      category: "Visits",
-      internal: ["ActWhileDead"],
-      tags: ["Dead", "Graveyard", "Restless", "Graveyard Participation"],
-      description: "Can only perform secondary actions while dead.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Transcendent", "Vengeful"],
     },
     Retired: {
       category: "Other",
@@ -817,59 +236,12 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
       allowDuplicate: true,
     },
-    Sacrificial: {
-      category: "Visits",
-      internal: ["Sacrificial"],
-      tags: ["Sacrificial", "Killing", "Self Kill"],
-      description:
-        "Will sacrifice themselves and die, if they ever visit another player.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Scatterbrained: {
-      category: "Appearance",
-      internal: ["Scatterbrained"],
-      tags: ["Visitor"],
-      description:
-        "Appears as Visitor (Village) / Trespasser (Mafia) / Bogeyman (Cult) / Fool (Independent) to self with no modifier.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Humble", "Respected", "Exposed"],
-    },
-    Scary: {
-      category: "Visits",
-      internal: ["BlockedFearful"],
-      tags: ["Self Block"],
-      description: "Will Block any Fearful roles when alive.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Seductive: {
-      category: "Visits",
-      internal: ["BlockTargets"],
-      tags: ["Visits", "Role Blocker"],
-      description: "While visiting a player, that player will be roleblocked.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Selfish: {
-      category: "Visits",
-      internal: ["CanVisitSelf"],
-      tags: ["Visits", "Role Blocker", "Selfish"],
-      description: "Can target themselves.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
     Sensible: {
       category: "Other",
       internal: ["LearnIfRoleChanged"],
       tags: ["Information"],
       description: "Each night learn what their role is.",
       eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Shady: {
-      category: "Appearance",
-      internal: ["AppearAsRandomEvil"],
-      tags: ["Deception"],
-      description:
-        "Appears as a Random Evil Role from the setup when investigated or condemned. Appears as their real role on death.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Faceless", "Unassuming", "Suspect", "Phony",],
     },
     Shielded: {
       category: "Items",
@@ -878,31 +250,6 @@ const modifierData = {
       description: "Starts with a Shield.",
       eventDescription: "This modifier does nothing when on an Event.",
       allowDuplicate: true,
-    },
-    Suspect: {
-      category: "Appearance",
-      internal: ["AppearAsVanillaEvil"],
-      tags: ["Deception"],
-      description:
-        "Appears as a Vanilla Evil Role from the setup when investigated or condemned. Appears as their real role on death.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Faceless", "Unassuming", "Shady", "Phony"],
-    },
-    Simple: {
-      category: "Visits",
-      internal: ["Simple"],
-      tags: ["Visits", "Block Self", "Vanilla", "Simple"],
-      description:
-        "If this player visits a player with a power role, all their actions will be blocked.",
-      eventDescription: "This Event will not apply to non-Vanilla players.",
-      incompatible: ["Complex"],
-    },
-    Social: {
-      category: "Other",
-      internal: ["MeetWithSocial"],
-      tags: ["Meeting"],
-      description: "Attends a meeting with all other Social players.",
-      eventDescription: "This modifier does nothing when on an Event.",
     },
     Steeled: {
       category: "Items",
@@ -919,36 +266,11 @@ const modifierData = {
       description: "All kills performed by this player cannot be saved.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
-    Suspended: {
-      category: "Visits",
-      internal: ["Suspended"],
-      tags: ["Suspended", "Meetings"],
-      description:
-        "Can only attend secondary meetings for the first day and night.",
-      eventDescription: "This Event can only occur on the first night.",
-      allowDuplicate: true,
-      incompatible: ["Delayed"],
-    },
-    Telepathic: {
-      category: "Other",
-      internal: ["ModifierTelepathic"],
-      tags: ["Speaking"],
-      description: "May anonymously contact any player.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
     Temporary: {
       category: "Other",
       internal: ["LoseModifiers"],
       tags: ["Temporary", "Modifiers"],
       description: "Loses their Modifiers at the end of the Night.",
-      eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Tinkering: {
-      category: "Items",
-      internal: ["ForageItem"],
-      tags: ["Items"],
-      description:
-        "Crafts a random item if not visited during the night. If killed, the killer will find a gun that always reveals.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     Traitorous: {
@@ -957,40 +279,6 @@ const modifierData = {
       tags: ["Sacrificial", "Conversion", "Traitor"],
       description: "If killed by the Mafia, will turn into a Traitor instead.",
       eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Transcendent: {
-      category: "Visits",
-      internal: ["ActAliveOrDead"],
-      tags: ["Dead", "Graveyard", "Transcendent", "Graveyard Participation"],
-      description: "Can perform secondary actions while either alive or dead.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Restless", "Vengeful"],
-    },
-    Trustworthy: {
-      category: "Other",
-      internal: ["VotingPowerIncrease"],
-      tags: ["Voting"],
-      description: "Player's vote is worth 1 more.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Felonious"],
-      allowDuplicate: true,
-    },
-    Unassuming: {
-      category: "Appearance",
-      internal: ["AppearAsVillagerOnDeath"],
-      tags: ["Villager", "Deception"],
-      description: "Appears as Villager when condemned or on death.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Shady", "Faceless", "Suspect", "Phony"],
-    },
-    Unholy: {
-      category: "Visits",
-      internal: ["Unholy"],
-      tags: ["Visits", "Block Self", "Modifiers", "Unholy"],
-      description:
-        "If this player visits a player with a non-Demonic role, their secondary actions will be blocked.",
-      eventDescription: "This Event will not apply to non-Demonic players.",
-      incompatible: ["Holy"],
     },
     Unkillable: {
       category: "Other",
@@ -1006,38 +294,12 @@ const modifierData = {
       description: "After Night 1, You can die at any time.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
-    Unrefined: {
-      category: "Visits",
-      internal: ["Unrefined"],
-      tags: ["Visits", "Block Self", "Modifiers", "Unrefined"],
-      description:
-        "If this player visits a player with a non-Banished role, their secondary actions will be blocked.",
-      eventDescription: "This Event will not apply to non-Banished players.",
-      incompatible: ["Refined"],
-    },
     Unwavering: {
       category: "Other",
       internal: ["ConvertImmune"],
       tags: ["Convert Saver"],
       description: "Cannot be converted to another role.",
       eventDescription: "This modifier does nothing when on an Event.",
-    },
-    Vain: {
-      category: "Visits",
-      internal: ["Vain"],
-      tags: ["Visits", "Killing", "Alignments", "Self Kill"],
-      description:
-        "If this player visits a player of the same alignment, they die.",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Weak"],
-    },
-    Vengeful: {
-      category: "Visits",
-      internal: ["ActAfterNightKilled"],
-      tags: ["Graveyard", "Vengeful", "Graveyard Participation"],
-      description: "Can perform secondary actions after being killed at night",
-      eventDescription: "This modifier does nothing when on an Event.",
-      incompatible: ["Transcendent", "Restless"],
     },
     Verrucose: {
       category: "Other",
@@ -1055,13 +317,495 @@ const modifierData = {
         "Will passively convert to the role of the first aligned power role.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
-    Wannabe: {
-      category: "Appearance",
-      internal: ["Wannabe"],
-      tags: ["Deception"],
+    Wise: {
+      category: "Other",
+      internal: ["MakePlayerLearnOneOfTwoPlayersOnDeath"],
+      tags: ["Sacrificial", "Information", "Graveyard Participation"],
       description:
-        "Appears to visit a player who dies at night, prioritizing players who are killed by the mafia.",
+        "If killed at night, a player with this modifier learns that 1 of 2 players is evil.",
       eventDescription: "This modifier does nothing when on an Event.",
+    },
+    //Speaking Mods
+    Blind: {
+      category: "Other",
+      internal: ["Blind"],
+      tags: ["Speech", "Blind"],
+      description: "Sees all speech as anonymous.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Clueless: {
+      category: "Other",
+      internal: ["Clueless"],
+      tags: ["Speech", "Clueless", "Random Messages"],
+      description: "Sees all speech as coming from random people.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Leaky: {
+      category: "Other",
+      internal: ["ModifierLeaky"],
+      tags: ["Whispers"],
+      description:
+        "All whispers involving a player with this modifier are leaked.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Telepathic: {
+      category: "Other",
+      internal: ["ModifierTelepathic"],
+      tags: ["Speaking"],
+      description: "May anonymously contact any player.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Neighborly: {
+      category: "Other",
+      internal: ["MeetWithNeighbors"],
+      tags: ["Meeting"],
+      description: "Attends a Night Meeting with their Neighbors.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Social: {
+      category: "Other",
+      internal: ["MeetWithSocial"],
+      tags: ["Meeting"],
+      description: "Attends a meeting with all other Social players.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Lone: {
+      category: "Other",
+      internal: ["ModifierLone"],
+      tags: ["Lone"],
+      description:
+        "If this role typically has a group meeting at night, they will not meet with or know the identity of their partner(s).",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+
+    //Voting
+    Trustworthy: {
+      category: "Other",
+      internal: ["VotingPowerIncrease"],
+      tags: ["Voting"],
+      description: "Player's vote is worth 1 more.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Felonious"],
+      allowDuplicate: true,
+    },
+    Inverse: {
+      category: "Other",
+      internal: ["VotingNegative"],
+      tags: ["Voting"],
+      description: "Player's vote is Negative.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Felonious"],
+    },
+    Felonious: {
+      category: "Other",
+      internal: ["VotingPowerZero"],
+      tags: ["Voting"],
+      description: "Player's vote is worth 0.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Trustworthy", "Inverse"],
+    },
+    Frustrated: {
+      category: "Other",
+      internal: ["FrustratedCondemnation"],
+      tags: ["Voting", "Condemn"],
+      description:
+        "Cannot be condemned by majority vote. A non-zero minority vote will kill the target.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Diplomatic"],
+    },
+    Diplomatic: {
+      category: "Other",
+      internal: ["CondemnImmune"],
+      tags: ["Condemn", "Condemn Immune"],
+      description: "Cannot be condemned.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Frustrated"],
+    },
+    Dovish: {
+      category: "Other",
+      internal: ["VillageMightSurviveCondemn"],
+      tags: ["Condemn", "Condemn Immune", "Alignments", "Protective"],
+      description:
+        "While a role with this modifier is in play, Village-aligned players might survive being condemned",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    //Banished
+    Banished: {
+      category: "Other",
+      internal: ["BanishedRole"],
+      tags: ["Banished"],
+      description:
+        "Banished roles will only spawn if the Banished count is increased, or if another roles adds Banished roles to the game.",
+      eventDescription: "This Event will not occur normally.",
+      incompatible: ["Inclusive", "Exclusive"],
+    },
+      Inclusive: {
+      category: "Other",
+      internal: ["Add1Banished"],
+      tags: ["Setup Changes", "Banished Interaction"],
+      description: "Adds 1 Banished Role in Closed Setups.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      allowDuplicate: true,
+      incompatible: ["Banished", "Exclusive"],
+    },
+    Exclusive: {
+      category: "Other",
+      internal: ["Remove1Banished"],
+      tags: ["Setup Changes","Banished Interaction"],
+      description: "Removes 1 Banished Role in Closed Setups.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      allowDuplicate: true,
+      incompatible: ["Banished", "Inclusive"],
+    },
+
+    //Win-Con
+    Braggadocious: {
+      category: "Other",
+      internal: ["PreventFactionJoints"],
+      tags: [],
+      description:
+        "If a player with this modifier wins, then Village, Mafia, and Cult cannot also win alongside them.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Demonic: {
+      category: "Other",
+      internal: ["Demonic"],
+      tags: ["Demonic", "Essential"],
+      description:
+        "Cult will win if a Demonic player is alive in final 2 or only Demonic and Cult players are alive. If all Demonic players are dead, all Cult-aligned players will die.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Linchpin: {
+      category: "Other",
+      internal: ["KillAlignedOnDeath"],
+      tags: ["Essential", "Selective Revealing", "Linchpin"],
+      description: "If dead, all aligned players will die too.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    //Role Share
+    Brutish: {
+      category: "Other",
+      internal: ["MakeSkittishOnRoleShare"],
+      tags: ["Role Share"],
+      description:
+        "Players who role-share with a Brutish player become skittish. Skittish players must accept all incoming role-shares.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Reclusive: {
+      category: "Other",
+      internal: ["MakeShyOnRoleShare"],
+      tags: ["Role Share"],
+      description:
+        "Players who role-share with a Reclusive player become shy. Shy players cannot accept incoming role-shares and cannot Private/Public Reveal.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+
+
+
+    //Non-Starting Item
+    Apprehensive: {
+      category: "Items",
+      internal: ["LearnVisitorsAndArm"],
+      tags: ["Items", "Gun", "Killing", "Reflexive", "Information"],
+      description:
+        "Will receive a Gun (that will not reveal shooter) with each visit and learn the name of the visitor.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Provocative: {
+      category: "Items",
+      internal: ["Provocative"],
+      tags: ["Messages", "Items", "Sockpuppet"],
+      description: "Each day, receives a sockpuppet.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Tinkering: {
+      category: "Items",
+      internal: ["ForageItem"],
+      tags: ["Items"],
+      description:
+        "Crafts a random item if not visited during the night. If killed, the killer will find a gun that always reveals.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    //Item Interaction
+    Kleptomaniac: {
+      category: "Items",
+      internal: ["StealFromTargets"],
+      tags: ["Items", "Visits"],
+      description:
+        "While visiting a player, that player's items will be stolen.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Klutzy: {
+      category: "Items",
+      internal: ["DropOwnItems"],
+      tags: ["Items"],
+      description: "Will passively drop any items held or received.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+
+    //Visit Immunies
+    Ascetic: {
+      category: "Visits",
+      internal: ["Ascetic"],
+      tags: ["Role Blocker", "Kill Interaction", "Reflexive"],
+      description: "Is untargetable from all non-killing actions.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Commuting: {
+      category: "Visits",
+      internal: ["Commuting"],
+      tags: ["Role Blocker", "Reflexive"],
+      description: "Is untargetable from all actions.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Astral: {
+      category: "Visits",
+      internal: ["Astral"],
+      tags: ["Visits", "Astral"],
+      description: "All actions done by this player are not visits.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Resolute: {
+      category: "Visits",
+      internal: ["Resolute"],
+      tags: ["Unblockable"],
+      description:
+        "All actions done by this player cannot be roleblocked or controlled.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+
+
+    //Proactive+Global+Lazy+Sudective
+    Proactive: {
+      category: "Visits",
+      internal: ["MustAct"],
+      tags: ["Action"],
+      description: "Must take actions.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Global: {
+      category: "Visits",
+      internal: ["GlobalModifier"],
+      tags: ["Visits", "Dawn"],
+      description: "Will target All players at Night",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Lazy: {
+      category: "Visits",
+      internal: ["ModifierLazy"],
+      tags: ["Manipulative", "Delayed"],
+      description:
+        "Actions taken on night will only execute after a full day/night phase.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Seductive: {
+      category: "Visits",
+      internal: ["BlockTargets"],
+      tags: ["Visits", "Role Blocker"],
+      description: "While visiting a player, that player will be roleblocked.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+
+    //Visiting Info
+    Loud: {
+      category: "Visits",
+      internal: ["ModifierLoud"],
+      tags: ["Reflexive", "Information"],
+      description:
+        "If visited, cries out the identity of players who visited them during the night.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Checking: {
+      category: "Visits",
+      internal: ["CheckSuccessfulVisit"],
+      tags: ["Information", "Visits"],
+      description: "Learns if their visit was successful or if it was blocked.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Clumsy: {
+      category: "Visits",
+      internal: ["RevealRoleToTarget"],
+      tags: ["Information", "Visits", "Roles"],
+      description:
+        "Announces the player's role to the targets of their night actions.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Noisy: {
+      category: "Visits",
+      internal: ["RevealNameToTarget"],
+      tags: ["Information", "Visits"],
+      description:
+        "Announces the player's name to the targets of their night actions.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+
+
+
+    //Redirection
+    Bouncy: {
+      category: "Visits",
+      internal: ["Bouncy"],
+      tags: ["Redirection"],
+      description:
+        "If possible, night kills will be redirected to another player of the same alignment.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Magnetic: {
+      category: "Visits",
+      internal: ["Magnetic"],
+      tags: ["Redirection"],
+      description:
+        "If possible, night kills will be redirected onto this player if someone with the same alignment as them is targeted.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Random: {
+      category: "Visits",
+      internal: ["TargetRandom"],
+      tags: ["Redirection", "RNG"],
+      description: "Each night is redirected onto a random player.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Narcissistic: {
+      category: "Visits",
+      internal: ["TargetSelf50Percent"],
+      tags: ["Redirection", "RNG"],
+      description:
+        "Each night has 50% chance to be redirected onto themselves.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    //Meeting Mods
+    "X-Shot": {
+      category: "Visits",
+      internal: ["OneShot"],
+      tags: ["X-Shot"],
+      description: "Can only perform actions X times. X is equal the number of times this modifier is added.",
+      eventDescription: "This Event will only occur once.",
+      allowDuplicate: true,
+    },
+    Even: {
+      category: "Visits",
+      internal: ["Even"],
+      tags: ["Even", "Meetings"],
+      description:
+        "Can only attend secondary meetings on even days and nights.",
+      eventDescription: "This Event will only occur on Even nights.",
+      incompatible: ["Odd", "Delayed"],
+    },
+    Odd: {
+      category: "Visits",
+      internal: ["Odd"],
+      tags: ["Odd", "Meetings"],
+      description: "Can only attend secondary meetings on odd days and nights.",
+      eventDescription: "This Event will only occur on Odd nights.",
+      incompatible: ["Even"],
+    },
+    Delayed: {
+      category: "Visits",
+      internal: ["Delayed"],
+      tags: ["Delayed", "Meetings"],
+      description:
+        "Cannot attend secondary meetings for the first day and night.",
+      eventDescription: "This Event will not occur on the first night.",
+      incompatible: ["Suspended"],
+      allowDuplicate: true,
+    },
+    Suspended: {
+      category: "Visits",
+      internal: ["Suspended"],
+      tags: ["Suspended", "Meetings"],
+      description:
+        "Can only attend secondary meetings for the first day and night.",
+      eventDescription: "This Event can only occur on the first night.",
+      allowDuplicate: true,
+      incompatible: ["Delayed"],
+    },
+
+
+    //Targeting Mods
+    Fair: {
+      category: "Visits",
+      internal: ["FairModifier"],
+      tags: ["Fair", "Visits"],
+      description:
+        "Cannot target a previously targeted player.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Nonconsecutive", "Consecutive"],
+    },
+    Consecutive: {
+      category: "Visits",
+      internal: ["Consecutive"],
+      tags: ["Visits", "Consecutive"],
+      description:
+      "Can only target players they targeted previously.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Fair", "Nonconsecutive"],
+    },
+    Nonconsecutive: {
+      category: "Visits",
+      internal: ["Nonconsecutive"],
+      tags: ["Visits", "Nonconsecutive"],
+      description:
+        "Cannot target a player they targeted the previous night",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Fair", "Consecutive"],
+    },
+    Selfish: {
+      category: "Visits",
+      internal: ["CanVisitSelf"],
+      tags: ["Visits", "Role Blocker", "Selfish"],
+      description: "Can target themselves.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Liminal: {
+      category: "Visits",
+      internal: ["VisitDeadOrAlive"],
+      tags: ["Visits", "Dead", "Liminal"],
+      description: "Secondary actions can be used on dead or living players.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Morbid"],
+    },
+    Morbid: {
+      category: "Visits",
+      internal: ["VisitOnlyDead"],
+      tags: ["Visits", "Dead", "Morbid"],
+      description: "Secondary actions can only be used on dead players.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Liminal"],
+    },
+    //Death Meeting Mods
+    Transcendent: {
+      category: "Visits",
+      internal: ["ActAliveOrDead"],
+      tags: ["Dead", "Graveyard", "Transcendent", "Graveyard Participation"],
+      description: "Can perform secondary actions while either alive or dead.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Restless", "Vengeful"],
+    },
+    Restless: {
+      category: "Visits",
+      internal: ["ActWhileDead"],
+      tags: ["Dead", "Graveyard", "Restless", "Graveyard Participation"],
+      description: "Can only perform secondary actions while dead.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Transcendent", "Vengeful"],
+    },
+    Vengeful: {
+      category: "Visits",
+      internal: ["ActAfterNightKilled"],
+      tags: ["Graveyard", "Vengeful", "Graveyard Participation"],
+      description: "Can perform secondary actions after being killed at night",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Transcendent", "Restless"],
+    },
+    //Death Visit
+    Vain: {
+      category: "Visits",
+      internal: ["Vain"],
+      tags: ["Visits", "Killing", "Alignments", "Self Kill"],
+      description:
+        "If this player visits a player of the same alignment, they die.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Weak"],
     },
     Weak: {
       category: "Visits",
@@ -1072,35 +816,345 @@ const modifierData = {
       eventDescription: "This modifier does nothing when on an Event.",
       incompatible: ["Vain"],
     },
-    Wise: {
-      category: "Other",
-      internal: ["MakePlayerLearnOneOfTwoPlayersOnDeath"],
-      tags: ["Sacrificial", "Information", "Graveyard Participation"],
-      description:
-        "If killed at night, a player with this modifier learns that 1 of 2 players is evil.",
+    Regretful: {
+      category: "Visits",
+      internal: ["Regretful"],
+      tags: ["Killing", "Visits", "Self Kill"],
+      description: "Will be killed if their target was killed.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
+    Sacrificial: {
+      category: "Visits",
+      internal: ["Sacrificial"],
+      tags: ["Sacrificial", "Killing", "Self Kill"],
+      description:
+        "Will sacrifice themselves and die, if they ever visit another player.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Fragile: {
+      category: "Visits",
+      internal: ["DieIfVisited"],
+      tags: ["Killing", "Visits", "Self Kill"],
+      description: "Will be killed if visited.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+
+    //Death to self block
+    Fatal: {
+      category: "Visits",
+      internal: ["BlockedIfKilled"],
+      tags: ["Block Self", "Death"],
+      description:
+        "If killed at night, their secondary actions will be blocked.",
+      eventDescription: "This Event will not apply to Non-Evil players.",
+      incompatible: ["Sorrowful"],
+    },
+    Sorrowful: {
+      category: "Visits",
+      internal: ["BlockedUnlessKilled"],
+      tags: ["Block Self", "Death"],
+      description:
+        "Unless killed at night, their secondary actions will be blocked.",
+      eventDescription: "This Event will not apply to Non-Evil players.",
+      incompatible: ["Fatal"],
+    },
+
+    //Self Block
+    Loyal: {
+      category: "Visits",
+      internal: ["Loyal"],
+      tags: ["Visits", "Block Self", "Alignments", "Loyal"],
+      description:
+        "If this player visits a player of the opposite alignment, their secondary actions will be blocked.",
+      eventDescription: "This Event will not apply to Evil players.",
+      incompatible: ["Disloyal"],
+    },
+    Disloyal: {
+      category: "Visits",
+      internal: ["Disloyal"],
+      tags: ["Visits", "Block Self", "Alignments", "Disloyal"],
+      description:
+        "If this player visits a player of the same alignment, their secondary actions will be blocked.",
+      eventDescription: "This Event will not apply to Non-Evil players.",
+      incompatible: ["Loyal"],
+    },
+    Complex: {
+      category: "Visits",
+      internal: ["Complex"],
+      tags: ["Visits", "Block Self", "Vanilla", "Complex"],
+      description:
+        "If this player visits a player with a vanilla role, all their actions will be blocked.",
+      eventDescription:
+        "This Event will not apply to players with Vanilla roles.",
+      incompatible: ["Simple"],
+    },
+    Simple: {
+      category: "Visits",
+      internal: ["Simple"],
+      tags: ["Visits", "Block Self", "Vanilla", "Simple"],
+      description:
+        "If this player visits a player with a power role, all their actions will be blocked.",
+      eventDescription: "This Event will not apply to non-Vanilla players.",
+      incompatible: ["Complex"],
+    },
+    Holy: {
+      category: "Visits",
+      internal: ["Holy"],
+      tags: ["Visits", "Block Self", "Modifiers", "Holy"],
+      description:
+        "If this player visits a player with a Demonic role, their secondary actions will be blocked.",
+      eventDescription: "This Event will not apply to Demonic players.",
+      incompatible: ["Unholy"],
+    },
+    Unholy: {
+      category: "Visits",
+      internal: ["Unholy"],
+      tags: ["Visits", "Block Self", "Modifiers", "Unholy"],
+      description:
+        "If this player visits a player with a non-Demonic role, their secondary actions will be blocked.",
+      eventDescription: "This Event will not apply to non-Demonic players.",
+      incompatible: ["Holy"],
+    },
+    Refined: {
+      category: "Visits",
+      internal: ["Refined"],
+      tags: ["Visits", "Block Self", "Modifiers", "Refined","Banished Interaction"],
+      description:
+        "If this player visits a player with a Banished role, their secondary actions will be blocked.",
+      eventDescription: "This Event will not apply to Banished players.",
+      incompatible: ["Unrefined"],
+    },
+    Unrefined: {
+      category: "Visits",
+      internal: ["Unrefined"],
+      tags: ["Visits", "Block Self", "Modifiers", "Unrefined", "Banished Interaction"],
+      description:
+        "If this player visits a player with a non-Banished role, their secondary actions will be blocked.",
+      eventDescription: "This Event will not apply to non-Banished players.",
+      incompatible: ["Refined"],
+    },
+
+          //Sub Role Guessing
+    Picky: {
+      category: "Visits",
+      internal: ["GuessRoleOrGetBlocked"],
+      tags: ["Self Block"],
+      description: "Each night chooses a role. Actions will be blocked unless visiting a player with that role.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Choosy"],
+    },
+    Choosy: {
+      category: "Visits",
+      internal: ["GuessRoleToGetBlocked"],
+      tags: ["Self Block"],
+      description: "Each night chooses a role. Actions will be blocked if visiting a player with that role.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Picky"],
+    },
+
+    Preoccupied: {
+      category: "Visits",
+      internal: ["BlockIfVisited"],
+      tags: ["Visits", "Block Self"],
+      description:
+        "If visited during the night, blocks the player's night action.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Fearful: {
+      category: "Visits",
+      internal: ["BlockedIfScary"],
+      tags: ["Self Block"],
+      description: "Actions will be Blocked if a Scary role is alive.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Scary: {
+      category: "Visits",
+      internal: ["BlockedFearful"],
+      tags: ["Self Block"],
+      description: "Will Block any Fearful roles when alive.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+
+
+
+    //Reveal Mods
+    Exposed: {
+      category: "Appearance",
+      internal: ["PublicReveal"],
+      tags: ["Reveal Self"],
+      description: "Starts revealed to everyone.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Notable", "Infamous"],
+    },
+    Notable: {
+      category: "Appearance",
+      internal: ["RevealToVillage"],
+      tags: ["Reveal Self"],
+      description: "Starts revealed to all Village-aligned players.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Exposed"],
+    },
+    Infamous: {
+      category: "Appearance",
+      internal: ["RevealToEvils"],
+      tags: ["Reveal Self"],
+      description: "Starts revealed to all Evil players.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Exposed"],
+    },
+
+    //Self Appearance
+    Humble: {
+      category: "Appearance",
+      internal: ["Humble"],
+      tags: ["Vanilla", "Villager", "Self Appearance"],
+      description:
+        "Appears as Villager (Village) / Mafioso (Mafia) / Cultist (Cult) / Grouch (Independent) to self with no modifier.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Scatterbrained"],
+    },
+    Scatterbrained: {
+      category: "Appearance",
+      internal: ["Scatterbrained"],
+      tags: ["Visitor"],
+      description:
+        "Appears as Visitor (Village) / Trespasser (Mafia) / Bogeyman (Cult) / Fool (Independent) to self with no modifier.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Humble"],
+    },
+    Modest: {
+      category: "Appearance",
+      internal: ["Modest"],
+      tags: ["Modifiers"],
+      description: "Appears to self with no modifiers.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+
+    //Investigative Appearance Mods
+    Masked: {
+      category: "Appearance",
+      internal: ["DisguiseAsTarget"],
+      tags: ["Roles", "Deception", "Suits"],
+      description: "Gains a suit of each target's role.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    Respected: {
+      category: "Appearance",
+      internal: ["VillagerToInvestigative"],
+      tags: ["Villager", "Deception", "No Investigate"],
+      description: "Appears as a Villager to investigative roles.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Suspect", "Shady", "Camouflaged"],
+    },
+    Wannabe: {
+      category: "Appearance",
+      internal: ["Wannabe"],
+      tags: ["Deception"],
+      description:
+        "Appears to visit a player who dies at night, prioritizing players who are killed by the mafia.",
+      eventDescription: "This modifier does nothing when on an Event.",
+    },
+    //Death Appearance Mods
+    Suspect: {
+      category: "Appearance",
+      internal: ["AppearAsVanillaEvil"],
+      tags: ["Deception", "No Investigate"],
+      description:
+        "Appears as a Vanilla Evil Role from the setup when investigated or condemned. Appears as their real role on death.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Faceless", "Unassuming", "Shady", "Phony", "Respected", "Camouflaged"],
+    },
+    Shady: {
+      category: "Appearance",
+      internal: ["AppearAsRandomEvil"],
+      tags: ["Deception", "No Investigate"],
+      description:
+        "Appears as a Random Evil Role from the setup when investigated or condemned. Appears as their real role on death.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Faceless", "Unassuming", "Suspect", "Phony", "Respected", "Camouflaged"],
+    },
+    Unassuming: {
+      category: "Appearance",
+      internal: ["AppearAsVillagerOnDeath"],
+      tags: ["Villager", "Deception"],
+      description: "Appears as Villager when condemned or on death.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Shady", "Faceless", "Suspect", "Phony", "Camouflaged"],
+    },
+    Phony: {
+      category: "Appearance",
+      internal: ["AppearAsVillagePROnDeath"],
+      tags: ["Deception"],
+      description: "Appears as Village Power Role when condemned or on death.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Shady", "Faceless", "Suspect", "Unassuming", "Camouflaged"],
+    },
+    Camouflaged: {
+      category: "Appearance",
+      internal: ["AppearAsRandomRole"],
+      tags: ["Roles", "Deception", "No Investigate"],
+      description:
+        "Appears on death and to information roles as a random role in the game that is not Villager, Impersonator or Impostor.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Shady", "Faceless", "Suspect", "Unassuming", "Phony"],
+    },
+    Faceless: {
+      category: "Appearance",
+      internal: ["AppearAsFliplessOnDeath"],
+      tags: ["Deception", "No Reveal"],
+      description:
+        "Player's role will be hidden from the town when condemned or on death.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Shady", "Unassuming", "Phony", "Suspect", "Camouflaged"],
+    },
+    //Sanity Mods
     Sane: {
       category: "Appearance",
       internal: ["TrueModifier"],
-      tags: ["FalseMode"],
+      tags: ["Information", "Sanity"],
       description: "All Information received by this role is true.",
       eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Confused", "Insane", "Naive", "Paranoid"],
+    },
+    Insane: {
+      category: "Appearance",
+      internal: ["FalseModifier"],
+      tags: ["Information", "Sanity"],
+      description: "All Information received by this role is false.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Sane", "Confused", "Naive", "Paranoid"],
     },
     Paranoid: {
       category: "Appearance",
       internal: ["UnfavorableModifier"],
-      tags: ["FalseMode"],
+      tags: ["Information", "Sanity"],
       description:
         "All Information received by this role will be unfavorable to the player being checked.",
       eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Sane", "Insane", "Confused", "Naive"],
     },
     Naive: {
       category: "Appearance",
       internal: ["FavorableModifier"],
-      tags: ["FalseMode"],
+      tags: ["Information", "Sanity"],
       description:
         "All Information received by this role will be favorable to the player being checked.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Sane", "Insane", "Confused", "Paranoid"],
+    },
+    Confused: {
+      category: "Appearance",
+      internal: ["ModifierConfused"],
+      tags: ["Information", "Sanity", "RNG"],
+      description: "Investigative reports appear incorrect 50% of the time.",
+      eventDescription: "This modifier does nothing when on an Event.",
+      incompatible: ["Sane", "Insane", "Naive", "Paranoid"],
+    },
+    Biased: {
+      category: "Appearance",
+      internal: ["OnePlayerShowsAsEvil"],
+      tags: ["Information"],
+      description: "One Village-aligned player will have unfavorable results to this role's information abilities.",
       eventDescription: "This modifier does nothing when on an Event.",
     },
     /*

--- a/react_main/src/components/Roles.jsx
+++ b/react_main/src/components/Roles.jsx
@@ -728,12 +728,12 @@ export function ModifierSearch(props) {
   const user = useContext(UserContext);
   const siteInfo = useContext(SiteInfoContext);
   const popover = useContext(PopoverContext);
-/*
+
   function onAlignNavClick(alignment) {
     setSearchVal("");
     setRoleListType(alignment);
   }
-
+/*
   const roleAbbreviations = {
     blue: ["Villager"],
     nilla: ["Villager", "Mafioso"],
@@ -764,7 +764,7 @@ export function ModifierSearch(props) {
 
     if (query !== "" && roleListType.length > 0) setRoleListType("");
     else if (query === "" && roleListType.length === 0)
-      setRoleListType(Alignments[props.gameType][0]);
+      setRoleListType("Items");
   }
 
   function onRoleCellClick(roleCellEl, role) {
@@ -800,6 +800,15 @@ export function ModifierSearch(props) {
 
   if (!siteInfo.modifiers) return <NewLoading small />;
 
+  const alignButtons = ["Items", "Visits", "Appearance", "Other"].map((type) => (
+    <Tab
+      label={type}
+      value={type}
+      onClick={() => onAlignNavClick(type)}
+      key={type}
+    />
+  ));
+
   const roleCells = siteInfo.modifiers[props.gameType].map((role, i) => {
     const searchTerms = searchVal
       .split(",")
@@ -823,7 +832,7 @@ export function ModifierSearch(props) {
 
     if (
       !role.disabled && getCompatibleModifiersOther(props.curMods).includes(role.name) &&
-      ((searchVal.length > 0 && (role.name.toLowerCase().indexOf(searchVal) !== -1 || matchesSearch)) || searchVal.length <= 0)
+      ((role.category === roleListType || (searchVal.length > 0 && (role.name.toLowerCase().indexOf(searchVal) !== -1 || matchesSearch)))
     ) {
       return (
         <Card

--- a/react_main/src/components/Roles.jsx
+++ b/react_main/src/components/Roles.jsx
@@ -720,7 +720,7 @@ export function ModifierSearch(props) {
   const theme = useTheme();
   
   const [roleListType, setRoleListType] = useState(
-    Alignments[props.gameType][0]
+    "Items"
   );
   
   const [searchVal, setSearchVal] = useState("");
@@ -832,7 +832,7 @@ export function ModifierSearch(props) {
 
     if (
       !role.disabled && getCompatibleModifiersOther(props.curMods).includes(role.name) &&
-      ((role.category === roleListType || (searchVal.length > 0 && (role.name.toLowerCase().indexOf(searchVal) !== -1 || matchesSearch)))
+      ((role.category === roleListType || (searchVal.length > 0 && (role.name.toLowerCase().indexOf(searchVal) !== -1 || matchesSearch))))
     ) {
       return (
         <Card
@@ -875,6 +875,13 @@ export function ModifierSearch(props) {
   return (
     <Box className="role-list-container">
       <Box className="bot-bar">
+        <Tabs
+          value={roleListType}
+          onChange={(_, value) => setRoleListType(value)}
+          centered
+        >
+          {alignButtons}
+        </Tabs>
         <Tabs
           value={roleListType}
           onChange={(_, value) => setRoleListType(value)}


### PR DESCRIPTION
Modifiers have 4 categories to choose from so they are not visible by default. "Items", "Visits", "Appearance", "Other"

Some modifiers that do similar things are now next to each other in the list. Disloyal+Loyal, Holy+Unholy, etc.

Exposed no longer reveals players to self so it can be used with humble for Meme setups.
Confused no longer does delirium.