### PR TITLE
Princess changes + Soprano role + Connect 4 Fixes + Modifiers for Prankster, Princess, Monkey, Ape

### DIFF
--- a/Games/types/ConnectFour/Game.js
+++ b/Games/types/ConnectFour/Game.js
@@ -91,14 +91,12 @@ module.exports = class ConnectFourGame extends Game {
     const rowNew = row;
     const colNew = col;
     if (
-      this.checkRecursive(player, rowNew, colNew, 0, "Up") == true ||
-      this.checkRecursive(player, rowNew, colNew, 0, "Down") == true ||
-      this.checkRecursive(player, rowNew, colNew, 0, null, "Left") == true ||
-      this.checkRecursive(player, rowNew, colNew, 0, null, "Right") == true ||
-      this.checkRecursive(player, rowNew, colNew, 0, "Up", "Left") == true ||
-      this.checkRecursive(player, rowNew, colNew, 0, "Up", "Right") == true ||
-      this.checkRecursive(player, rowNew, colNew, 0, "Down", "Left") == true ||
-      this.checkRecursive(player, rowNew, colNew, 0, "Down", "Right") == true
+      (this.checkRecursive(player, rowNew, colNew, 0, "Up") + this.checkRecursive(player, rowNew, colNew, 0, "Down")) >= 3 ||
+      (this.checkRecursive(player, rowNew, colNew, 0, null, "Left")+
+      this.checkRecursive(player, rowNew, colNew, 0, null, "Right")) >= 3 ||
+      (this.checkRecursive(player, rowNew, colNew, 0, "Up", "Left") + this.checkRecursive(player, rowNew, colNew, 0, "Down", "Right")) >= 3 ||
+      (this.checkRecursive(player, rowNew, colNew, 0, "Up", "Right") +
+      this.checkRecursive(player, rowNew, colNew, 0, "Down", "Left")) >= 3
     ) {
       return true;
     }
@@ -108,7 +106,12 @@ module.exports = class ConnectFourGame extends Game {
   checkRecursive(player, row, col, distance, Direction1, Direction2) {
     if (this.board[row] && this.board[row][col] == player.name) {
       if (distance == 3) {
-        return true;
+        /*
+        this.sendAlert(
+        `${Direction1} ${Direction2} Distance ${distance+1}`
+      );
+      */
+        return distance;
       } else {
         if (Direction1 == "Up") {
           row = row - 1;
@@ -130,7 +133,12 @@ module.exports = class ConnectFourGame extends Game {
         );
       }
     } else {
-      return false;
+      /*
+      this.sendAlert(
+        `${Direction1} ${Direction2} Distance ${distance-1}`
+      );
+      */
+      return distance-1;
     }
   }
 

--- a/Games/types/ConnectFour/Game.js
+++ b/Games/types/ConnectFour/Game.js
@@ -91,12 +91,18 @@ module.exports = class ConnectFourGame extends Game {
     const rowNew = row;
     const colNew = col;
     if (
-      (this.checkRecursive(player, rowNew, colNew, 0, "Up") + this.checkRecursive(player, rowNew, colNew, 0, "Down")) >= 3 ||
-      (this.checkRecursive(player, rowNew, colNew, 0, null, "Left")+
-      this.checkRecursive(player, rowNew, colNew, 0, null, "Right")) >= 3 ||
-      (this.checkRecursive(player, rowNew, colNew, 0, "Up", "Left") + this.checkRecursive(player, rowNew, colNew, 0, "Down", "Right")) >= 3 ||
-      (this.checkRecursive(player, rowNew, colNew, 0, "Up", "Right") +
-      this.checkRecursive(player, rowNew, colNew, 0, "Down", "Left")) >= 3
+      this.checkRecursive(player, rowNew, colNew, 0, "Up") +
+        this.checkRecursive(player, rowNew, colNew, 0, "Down") >=
+        3 ||
+      this.checkRecursive(player, rowNew, colNew, 0, null, "Left") +
+        this.checkRecursive(player, rowNew, colNew, 0, null, "Right") >=
+        3 ||
+      this.checkRecursive(player, rowNew, colNew, 0, "Up", "Left") +
+        this.checkRecursive(player, rowNew, colNew, 0, "Down", "Right") >=
+        3 ||
+      this.checkRecursive(player, rowNew, colNew, 0, "Up", "Right") +
+        this.checkRecursive(player, rowNew, colNew, 0, "Down", "Left") >=
+        3
     ) {
       return true;
     }
@@ -138,7 +144,7 @@ module.exports = class ConnectFourGame extends Game {
         `${Direction1} ${Direction2} Distance ${distance-1}`
       );
       */
-      return distance-1;
+      return distance - 1;
     }
   }
 

--- a/Games/types/Mafia/Player.js
+++ b/Games/types/Mafia/Player.js
@@ -206,7 +206,11 @@ module.exports = class MafiaPlayer extends Player {
                 this.actor.queueAlert(
                   `You Privatly Reveal to ${this.target.name}.`
                 );
-                this.actor.role.revealToPlayer(targetPlayer, null, "investigate");
+                this.actor.role.revealToPlayer(
+                  targetPlayer,
+                  null,
+                  "investigate"
+                );
               },
             });
             this.game.instantAction(action);

--- a/Games/types/Mafia/Player.js
+++ b/Games/types/Mafia/Player.js
@@ -206,7 +206,7 @@ module.exports = class MafiaPlayer extends Player {
                 this.actor.queueAlert(
                   `You Privatly Reveal to ${this.target.name}.`
                 );
-                this.actor.role.revealToPlayer(targetPlayer);
+                this.actor.role.revealToPlayer(targetPlayer, null, "investigate");
               },
             });
             this.game.instantAction(action);
@@ -233,7 +233,7 @@ module.exports = class MafiaPlayer extends Player {
             this.game.queueAlert(
               `${this.actor.name} Public Reveals to Everyone.`
             );
-            this.actor.role.revealToAll();
+            this.actor.role.revealToAll(null, "investigate");
           },
         });
         this.game.instantAction(action);

--- a/Games/types/Mafia/information/RevealInfo.js
+++ b/Games/types/Mafia/information/RevealInfo.js
@@ -56,7 +56,7 @@ module.exports = class RevealInfo extends Information {
     );
     OtherRoles = Random.randomizeArray(OtherRoles);
     if (this.truthValue == "Normal") {
-      this.revealTarget();
+      this.revealTarget(null, this.investType);
     } else if (this.truthValue == "True") {
       this.target.setTempAppearance(
         this.investType,

--- a/Games/types/Mafia/items/RoleShareAccept.js
+++ b/Games/types/Mafia/items/RoleShareAccept.js
@@ -40,8 +40,16 @@ module.exports = class RoleShareAccept extends Item {
         run: function () {
           if (this.target == "Yes") {
             if (this.item.type == "Role Share") {
-              this.actor.role.revealToPlayer(this.item.proposer, null, "investigate");
-              this.item.proposer.role.revealToPlayer(this.actor, null, "investigate");
+              this.actor.role.revealToPlayer(
+                this.item.proposer,
+                null,
+                "investigate"
+              );
+              this.item.proposer.role.revealToPlayer(
+                this.actor,
+                null,
+                "investigate"
+              );
               this.game.events.emit(
                 "ShareRole",
                 this.actor,

--- a/Games/types/Mafia/items/RoleShareAccept.js
+++ b/Games/types/Mafia/items/RoleShareAccept.js
@@ -40,8 +40,8 @@ module.exports = class RoleShareAccept extends Item {
         run: function () {
           if (this.target == "Yes") {
             if (this.item.type == "Role Share") {
-              this.actor.role.revealToPlayer(this.item.proposer);
-              this.item.proposer.role.revealToPlayer(this.actor);
+              this.actor.role.revealToPlayer(this.item.proposer, null, "investigate");
+              this.item.proposer.role.revealToPlayer(this.actor, null, "investigate");
               this.game.events.emit(
                 "ShareRole",
                 this.actor,
@@ -49,10 +49,10 @@ module.exports = class RoleShareAccept extends Item {
                 false
               );
             } else if (this.item.type == "Alignment Share") {
-              var roleActor = this.actor.getAppearance("reveal", true);
+              var roleActor = this.actor.getAppearance("investigate", true);
               var alignmentActor = this.game.getRoleAlignment(roleActor);
               var roleProposer = this.item.proposer.getAppearance(
-                "reveal",
+                "investigate",
                 true
               );
               var alignmentProposer = this.game.getRoleAlignment(roleProposer);

--- a/Games/types/Mafia/roles/Village/Soprano.js
+++ b/Games/types/Mafia/roles/Village/Soprano.js
@@ -1,0 +1,15 @@
+const Role = require("../../Role");
+
+module.exports = class Soprano extends Role {
+  constructor(player, data) {
+    super("Soprano", player, data);
+
+    this.alignment = "Village";
+    this.cards = [
+      "VillageCore",
+      "WinWithFaction",
+      "MeetingFaction",
+      "NightSaveAndLifeLink",
+    ];
+  }
+};

--- a/Games/types/Mafia/roles/cards/AppearAsVanillaEvil.js
+++ b/Games/types/Mafia/roles/cards/AppearAsVanillaEvil.js
@@ -37,6 +37,7 @@ module.exports = class AppearAsVanillaEvil extends Card {
     this.hideModifier = {
       condemn: true,
       investigate: true,
+      reveal: true,
     };
   }
 };

--- a/Games/types/Mafia/roles/cards/AppearAsVanillaEvil.js
+++ b/Games/types/Mafia/roles/cards/AppearAsVanillaEvil.js
@@ -37,7 +37,6 @@ module.exports = class AppearAsVanillaEvil extends Card {
     this.hideModifier = {
       condemn: true,
       investigate: true,
-      reveal: true,
     };
   }
 };

--- a/Games/types/Mafia/roles/cards/BecomeRoleForNight.js
+++ b/Games/types/Mafia/roles/cards/BecomeRoleForNight.js
@@ -11,11 +11,10 @@ module.exports = class BecomeRoleForNight extends Card {
         action: {
           role: this.role,
           run: function () {
-
-            if(!this.role.canTargetPlayer(this.target)){
+            if (!this.role.canTargetPlayer(this.target)) {
               return;
             }
-            
+
             let effect = this.actor.giveEffect(
               "ExtraRoleEffect",
               this.game.formatRoleInternal(

--- a/Games/types/Mafia/roles/cards/BecomeRoleForNight.js
+++ b/Games/types/Mafia/roles/cards/BecomeRoleForNight.js
@@ -9,7 +9,13 @@ module.exports = class BecomeRoleForNight extends Card {
         states: ["Night"],
         flags: ["voting", "instant", "mustAct"],
         action: {
+          role: this.role,
           run: function () {
+
+            if(!this.role.canTargetPlayer(this.target)){
+              return;
+            }
+            
             let effect = this.actor.giveEffect(
               "ExtraRoleEffect",
               this.game.formatRoleInternal(

--- a/Games/types/Mafia/roles/cards/IfVotedForceCondemn.js
+++ b/Games/types/Mafia/roles/cards/IfVotedForceCondemn.js
@@ -16,11 +16,16 @@ module.exports = class IfVotedForceCondemn extends Card {
           if (!this.hasAbility(["Condemn"])) {
             return;
           }
+          /*
           if (
             this.game.getRoleAlignment(
               vote.voter.getRoleAppearance().split(" (")[0]
             ) != "Village"
           ) {
+            return;
+          }
+          */
+          if (!this.canTargetPlayer(vote.voter)) {
             return;
           }
           this.data.playerVoter = vote.voter;

--- a/Games/types/Mafia/roles/cards/NightSaveAndLifeLink.js
+++ b/Games/types/Mafia/roles/cards/NightSaveAndLifeLink.js
@@ -39,6 +39,7 @@ module.exports = class NightSaveAndLifeLink extends Card {
             target: this.data.playerToKill,
             game: this.game,
             labels: ["kill"],
+            power: 2,
             run: function () {
               if (this.dominates())
                 this.target.kill("basic", this.actor, instant);

--- a/Games/types/Mafia/roles/cards/NightSaveAndLifeLink.js
+++ b/Games/types/Mafia/roles/cards/NightSaveAndLifeLink.js
@@ -34,7 +34,7 @@ module.exports = class NightSaveAndLifeLink extends Card {
             return;
           }
 
-            var action = new Action({
+          var action = new Action({
             actor: this.player,
             target: this.data.playerToKill,
             game: this.game,
@@ -51,7 +51,5 @@ module.exports = class NightSaveAndLifeLink extends Card {
         }
       },
     };
-
-    
   }
 };

--- a/Games/types/Mafia/roles/cards/NightSaveAndLifeLink.js
+++ b/Games/types/Mafia/roles/cards/NightSaveAndLifeLink.js
@@ -1,4 +1,5 @@
 const Card = require("../../Card");
+const Action = require("../../Action");
 const { PRIORITY_NIGHT_SAVER } = require("../../const/Priority");
 
 module.exports = class NightSaveAndLifeLink extends Card {

--- a/Games/types/Mafia/roles/cards/NightSaveAndLifeLink.js
+++ b/Games/types/Mafia/roles/cards/NightSaveAndLifeLink.js
@@ -1,0 +1,57 @@
+const Card = require("../../Card");
+const { PRIORITY_NIGHT_SAVER } = require("../../const/Priority");
+
+module.exports = class NightSaveAndLifeLink extends Card {
+  constructor(role) {
+    super(role);
+
+    this.meetings = {
+      Save: {
+        actionName: "Sing To",
+        states: ["Night"],
+        flags: ["voting"],
+        action: {
+          labels: ["save"],
+          priority: PRIORITY_NIGHT_SAVER,
+          role: this.role,
+          run: function () {
+            this.heal(1);
+            this.role.data.playerToKill = this.target;
+          },
+        },
+      },
+    };
+
+    this.listeners = {
+      state: function (stateInfo) {
+        if (stateInfo.name.match(/Night/)) {
+          this.data.playerToKill = null;
+        }
+      },
+      death: function (player, killer, deathType, instant) {
+        if (player == this.player && this.data.playerToKill) {
+          if (!this.hasAbility(["Kill", "WhenDead"])) {
+            return;
+          }
+
+            var action = new Action({
+            actor: this.player,
+            target: this.data.playerToKill,
+            game: this.game,
+            labels: ["kill"],
+            run: function () {
+              if (this.dominates())
+                this.target.kill("basic", this.actor, instant);
+            },
+          });
+
+          action.do();
+
+          //this.data.playerToReveal.role.revealToAll();
+        }
+      },
+    };
+
+    
+  }
+};

--- a/Games/types/Mafia/roles/cards/Pranked.js
+++ b/Games/types/Mafia/roles/cards/Pranked.js
@@ -8,7 +8,7 @@ module.exports = class Pranked extends Card {
 
     this.listeners = {
       vote: function (vote) {
-        if (vote.meeting.name === "Village" && vote.target === this.player.id) {
+        if (vote.meeting.useVotingPower == true && vote.target === this.player.id) {
           if (this.data.hasBeenVoted == true) return;
 
           this.data.hasBeenVoted = true;

--- a/Games/types/Mafia/roles/cards/Pranked.js
+++ b/Games/types/Mafia/roles/cards/Pranked.js
@@ -8,7 +8,10 @@ module.exports = class Pranked extends Card {
 
     this.listeners = {
       vote: function (vote) {
-        if (vote.meeting.useVotingPower == true && vote.target === this.player.id) {
+        if (
+          vote.meeting.useVotingPower == true &&
+          vote.target === this.player.id
+        ) {
           if (this.data.hasBeenVoted == true) return;
 
           this.data.hasBeenVoted = true;

--- a/Games/types/Mafia/roles/cards/Pranked.js
+++ b/Games/types/Mafia/roles/cards/Pranked.js
@@ -16,6 +16,9 @@ module.exports = class Pranked extends Card {
           if (!this.hasAbility(["Convert"])) {
             return;
           }
+          if (!this.canTargetPlayer(vote.voter)) {
+            return;
+          }
           this.data.playerVoter = vote.voter;
 
           var action = new Action({

--- a/data/roles.js
+++ b/data/roles.js
@@ -297,6 +297,16 @@ const roleData = {
       description: ["Saves another player from dying each night."],
       nightOrder: [["Protect", PRIORITY_NIGHT_SAVER]],
     },
+    Soprano: {
+      alignment: "Village",
+      category: "Protective",
+      tags: ["Protective", "Visiting", "Basic", "Killing"],
+      description: [
+        "Saves another player from dying each night.",
+        "If the Soprano dies, the player they most recently saved will die.",
+        ],
+      nightOrder: [["Protect", PRIORITY_NIGHT_SAVER]],
+    },
     Martyr: {
       alignment: "Village",
       category: "Protective",
@@ -1549,9 +1559,19 @@ const roleData = {
         "Advanced",
       ],
       description: [
-        "If the first player to vote for a Princess appears as Village-aligned, The day ends and that player is condemned.",
-        "If the first player to vote for a Princess does not appear as Village-aligned, nothing happens.",
+        "The first player to vote for a Princess is condemned and ends the day.",
+        //"If the first player to vote for a Princess does not appear as Village-aligned, nothing happens.",
       ],
+      SpecialInteractionsModifiers: {
+        Loyal: ["If the first player to vote for the Princess is a different alignment to the Princess, nothing happens."],
+        Disloyal: ["If the first player to vote for the Princess is the same alignment of the Princess, nothing happens."],
+        Holy: ["If the first player to vote for the Princess is Demonic, nothing happens."],
+        Unholy: ["If the first player to vote for the Princess is non-Demonic, nothing happens."],
+        Simple: ["If the first player to vote for the Princess is a Power Role, nothing happens."],
+        Complex: ["If the first player to vote for the Princess is a Vanilla Role, nothing happens."],
+        Refined: ["If the first player to vote for the Princess is a Banished Role, nothing happens."],
+        Unrefined: ["If the first player to vote for the Princess is a non-Banished Role, nothing happens."],
+      },
     },
     Troublemaker: {
       alignment: "Village",
@@ -3313,6 +3333,16 @@ const roleData = {
       category: "Gaming",
       tags: ["Voting", "Conversion", "Expert"],
       description: ["The first player to vote the Prankster becomes Fool."],
+      SpecialInteractionsModifiers: {
+        Loyal: ["If the first player to vote for the Prankster is a different alignment to the Prankster, nothing happens."],
+        Disloyal: ["If the first player to vote for the Prankster is the same alignment of the Prankster, nothing happens."],
+        Holy: ["If the first player to vote for the Prankster is Demonic, nothing happens."],
+        Unholy: ["If the first player to vote for the Prankster is non-Demonic, nothing happens."],
+        Simple: ["If the first player to vote for the Prankster is a Power Role, nothing happens."],
+        Complex: ["If the first player to vote for the Prankster is a Vanilla Role, nothing happens."],
+        Refined: ["If the first player to vote for the Prankster is a Banished Role, nothing happens."],
+        Unrefined: ["If the first player to vote for the Prankster is a non-Banished Role, nothing happens."],
+      },
       RolesMadeBy: ["Fool"],
     },
 

--- a/data/roles.js
+++ b/data/roles.js
@@ -304,7 +304,7 @@ const roleData = {
       description: [
         "Saves another player from dying each night.",
         "If the Soprano dies, the player they most recently saved will die.",
-        ],
+      ],
       nightOrder: [["Protect", PRIORITY_NIGHT_SAVER]],
     },
     Martyr: {
@@ -1563,14 +1563,30 @@ const roleData = {
         //"If the first player to vote for a Princess does not appear as Village-aligned, nothing happens.",
       ],
       SpecialInteractionsModifiers: {
-        Loyal: ["If the first player to vote for the Princess is a different alignment to the Princess, nothing happens."],
-        Disloyal: ["If the first player to vote for the Princess is the same alignment of the Princess, nothing happens."],
-        Holy: ["If the first player to vote for the Princess is Demonic, nothing happens."],
-        Unholy: ["If the first player to vote for the Princess is non-Demonic, nothing happens."],
-        Simple: ["If the first player to vote for the Princess is a Power Role, nothing happens."],
-        Complex: ["If the first player to vote for the Princess is a Vanilla Role, nothing happens."],
-        Refined: ["If the first player to vote for the Princess is a Banished Role, nothing happens."],
-        Unrefined: ["If the first player to vote for the Princess is a non-Banished Role, nothing happens."],
+        Loyal: [
+          "If the first player to vote for the Princess is a different alignment to the Princess, nothing happens.",
+        ],
+        Disloyal: [
+          "If the first player to vote for the Princess is the same alignment of the Princess, nothing happens.",
+        ],
+        Holy: [
+          "If the first player to vote for the Princess is Demonic, nothing happens.",
+        ],
+        Unholy: [
+          "If the first player to vote for the Princess is non-Demonic, nothing happens.",
+        ],
+        Simple: [
+          "If the first player to vote for the Princess is a Power Role, nothing happens.",
+        ],
+        Complex: [
+          "If the first player to vote for the Princess is a Vanilla Role, nothing happens.",
+        ],
+        Refined: [
+          "If the first player to vote for the Princess is a Banished Role, nothing happens.",
+        ],
+        Unrefined: [
+          "If the first player to vote for the Princess is a non-Banished Role, nothing happens.",
+        ],
       },
     },
     Troublemaker: {
@@ -3334,14 +3350,30 @@ const roleData = {
       tags: ["Voting", "Conversion", "Expert"],
       description: ["The first player to vote the Prankster becomes Fool."],
       SpecialInteractionsModifiers: {
-        Loyal: ["If the first player to vote for the Prankster is a different alignment to the Prankster, nothing happens."],
-        Disloyal: ["If the first player to vote for the Prankster is the same alignment of the Prankster, nothing happens."],
-        Holy: ["If the first player to vote for the Prankster is Demonic, nothing happens."],
-        Unholy: ["If the first player to vote for the Prankster is non-Demonic, nothing happens."],
-        Simple: ["If the first player to vote for the Prankster is a Power Role, nothing happens."],
-        Complex: ["If the first player to vote for the Prankster is a Vanilla Role, nothing happens."],
-        Refined: ["If the first player to vote for the Prankster is a Banished Role, nothing happens."],
-        Unrefined: ["If the first player to vote for the Prankster is a non-Banished Role, nothing happens."],
+        Loyal: [
+          "If the first player to vote for the Prankster is a different alignment to the Prankster, nothing happens.",
+        ],
+        Disloyal: [
+          "If the first player to vote for the Prankster is the same alignment of the Prankster, nothing happens.",
+        ],
+        Holy: [
+          "If the first player to vote for the Prankster is Demonic, nothing happens.",
+        ],
+        Unholy: [
+          "If the first player to vote for the Prankster is non-Demonic, nothing happens.",
+        ],
+        Simple: [
+          "If the first player to vote for the Prankster is a Power Role, nothing happens.",
+        ],
+        Complex: [
+          "If the first player to vote for the Prankster is a Vanilla Role, nothing happens.",
+        ],
+        Refined: [
+          "If the first player to vote for the Prankster is a Banished Role, nothing happens.",
+        ],
+        Unrefined: [
+          "If the first player to vote for the Prankster is a non-Banished Role, nothing happens.",
+        ],
       },
       RolesMadeBy: ["Fool"],
     },


### PR DESCRIPTION
Princess, Prankster, Monkey, Ape can now use Disloyal, Loyal, etc.

Princess- Will now condemn the first to vote them regardless of alignment.
For Old Princess use Princess (Loyal)
For BOTC Virgin use Princess (Loyal/Refined)

 Soprano role from shego's suggestion in the discord

You can now win in connect four if your chip is placed in the middle of a chain of 4.

Role Sharing now works properly with Appearance changing roles