### PR TITLE
More Assassin Updates (everyone loves Assassin Updates) + Jazzman Updates (No one loves Jazzman)

### DIFF
--- a/Games/core/Meeting.js
+++ b/Games/core/Meeting.js
@@ -13,6 +13,7 @@ module.exports = class Meeting {
     this.id = shortid.generate();
     this.game = game;
     this.events = game.events;
+    
 
     /* Flags */
     this.group = false;

--- a/Games/core/Meeting.js
+++ b/Games/core/Meeting.js
@@ -13,7 +13,6 @@ module.exports = class Meeting {
     this.id = shortid.generate();
     this.game = game;
     this.events = game.events;
-    
 
     /* Flags */
     this.group = false;

--- a/Games/types/Mafia/Player.js
+++ b/Games/types/Mafia/Player.js
@@ -114,6 +114,12 @@ module.exports = class MafiaPlayer extends Player {
               game: this.game,
               labels: ["hidden"],
               run: function () {
+                if(!this.actor.isInSameRoom(this.target)){
+                  this.actor.queueAlert(
+                  `You can only share with players in your Room.`
+                );
+                return;
+                }
                 this.target.queueAlert(
                   `${this.actor.name} wants to Role Share.`
                 );
@@ -123,7 +129,9 @@ module.exports = class MafiaPlayer extends Player {
               },
             });
             this.game.instantAction(action);
-
+              if(!this.isInSameRoom(player)){
+                return;
+              }
             let ShareWith = player.holdItem(
               "RoleShareAccept",
               this,
@@ -157,6 +165,12 @@ module.exports = class MafiaPlayer extends Player {
               game: this.game,
               labels: ["hidden"],
               run: function () {
+                if(!this.actor.isInSameRoom(this.target)){
+                  this.actor.queueAlert(
+                  `You can only share with players in your Room.`
+                );
+                return;
+                }
                 this.target.queueAlert(
                   `${this.actor.name} wants to Alignment Share.`
                 );
@@ -166,7 +180,9 @@ module.exports = class MafiaPlayer extends Player {
               },
             });
             this.game.instantAction(action);
-
+             if(!this.isInSameRoom(player)){
+                return;
+              }
             let ShareWith = player.holdItem(
               "RoleShareAccept",
               this,
@@ -200,6 +216,12 @@ module.exports = class MafiaPlayer extends Player {
               game: this.game,
               labels: ["hidden"],
               run: function () {
+                if(!this.actor.isInSameRoom(this.target)){
+                  this.actor.queueAlert(
+                  `You can only Private Reveal to players in your Room.`
+                );
+                return;
+                }
                 this.target.queueAlert(
                   `${this.actor.name} Private Reveals to you.`
                 );
@@ -234,10 +256,19 @@ module.exports = class MafiaPlayer extends Player {
           game: this.game,
           labels: ["hidden"],
           run: function () {
-            this.game.queueAlert(
+            for(let player of this.game.alivePlayers()){
+                if(this.actor.isInSameRoom(player)){
+                  player.queueAlert(
               `${this.actor.name} Public Reveals to Everyone.`
             );
-            this.actor.role.revealToAll(null, "investigate");
+                  this.actor.role.revealToPlayer(
+                  player,
+                  null,
+                  "investigate"
+                );
+                }
+            }
+            //this.actor.role.revealToAll(null, "investigate");
           },
         });
         this.game.instantAction(action);
@@ -652,6 +683,22 @@ module.exports = class MafiaPlayer extends Player {
       }
     }
     return votePower;
+  }
+
+  isInSameRoom(player){
+    if(this.game.Rooms && this.game.Rooms.length >0){
+      for(let Room of this.game.Rooms){
+        if(Room.members.includes(this)){
+          if(Room.members.includes(player)){
+            return true;
+          }
+          else{
+            return false;
+          }
+        }
+      }
+    }
+    return true;
   }
 
   customizeMeetingTargets(meeting) {

--- a/Games/types/Mafia/Player.js
+++ b/Games/types/Mafia/Player.js
@@ -114,11 +114,11 @@ module.exports = class MafiaPlayer extends Player {
               game: this.game,
               labels: ["hidden"],
               run: function () {
-                if(!this.actor.isInSameRoom(this.target)){
+                if (!this.actor.isInSameRoom(this.target)) {
                   this.actor.queueAlert(
-                  `You can only share with players in your Room.`
-                );
-                return;
+                    `You can only share with players in your Room.`
+                  );
+                  return;
                 }
                 this.target.queueAlert(
                   `${this.actor.name} wants to Role Share.`
@@ -129,9 +129,9 @@ module.exports = class MafiaPlayer extends Player {
               },
             });
             this.game.instantAction(action);
-              if(!this.isInSameRoom(player)){
-                return;
-              }
+            if (!this.isInSameRoom(player)) {
+              return;
+            }
             let ShareWith = player.holdItem(
               "RoleShareAccept",
               this,
@@ -165,11 +165,11 @@ module.exports = class MafiaPlayer extends Player {
               game: this.game,
               labels: ["hidden"],
               run: function () {
-                if(!this.actor.isInSameRoom(this.target)){
+                if (!this.actor.isInSameRoom(this.target)) {
                   this.actor.queueAlert(
-                  `You can only share with players in your Room.`
-                );
-                return;
+                    `You can only share with players in your Room.`
+                  );
+                  return;
                 }
                 this.target.queueAlert(
                   `${this.actor.name} wants to Alignment Share.`
@@ -180,9 +180,9 @@ module.exports = class MafiaPlayer extends Player {
               },
             });
             this.game.instantAction(action);
-             if(!this.isInSameRoom(player)){
-                return;
-              }
+            if (!this.isInSameRoom(player)) {
+              return;
+            }
             let ShareWith = player.holdItem(
               "RoleShareAccept",
               this,
@@ -216,11 +216,11 @@ module.exports = class MafiaPlayer extends Player {
               game: this.game,
               labels: ["hidden"],
               run: function () {
-                if(!this.actor.isInSameRoom(this.target)){
+                if (!this.actor.isInSameRoom(this.target)) {
                   this.actor.queueAlert(
-                  `You can only Private Reveal to players in your Room.`
-                );
-                return;
+                    `You can only Private Reveal to players in your Room.`
+                  );
+                  return;
                 }
                 this.target.queueAlert(
                   `${this.actor.name} Private Reveals to you.`
@@ -256,17 +256,13 @@ module.exports = class MafiaPlayer extends Player {
           game: this.game,
           labels: ["hidden"],
           run: function () {
-            for(let player of this.game.alivePlayers()){
-                if(this.actor.isInSameRoom(player)){
-                  player.queueAlert(
-              `${this.actor.name} Public Reveals to Everyone.`
-            );
-                  this.actor.role.revealToPlayer(
-                  player,
-                  null,
-                  "investigate"
+            for (let player of this.game.alivePlayers()) {
+              if (this.actor.isInSameRoom(player)) {
+                player.queueAlert(
+                  `${this.actor.name} Public Reveals to Everyone.`
                 );
-                }
+                this.actor.role.revealToPlayer(player, null, "investigate");
+              }
             }
             //this.actor.role.revealToAll(null, "investigate");
           },
@@ -685,14 +681,13 @@ module.exports = class MafiaPlayer extends Player {
     return votePower;
   }
 
-  isInSameRoom(player){
-    if(this.game.Rooms && this.game.Rooms.length >0){
-      for(let Room of this.game.Rooms){
-        if(Room.members.includes(this)){
-          if(Room.members.includes(player)){
+  isInSameRoom(player) {
+    if (this.game.Rooms && this.game.Rooms.length > 0) {
+      for (let Room of this.game.Rooms) {
+        if (Room.members.includes(this)) {
+          if (Room.members.includes(player)) {
             return true;
-          }
-          else{
+          } else {
             return false;
           }
         }

--- a/Games/types/Mafia/const/ImportantMeetings.js
+++ b/Games/types/Mafia/const/ImportantMeetings.js
@@ -21,9 +21,12 @@ const STARTS_WITH_MEETINGS = [
 ];
 const IMPORTANT_MEETINGS_DAY = [
   "Village",
-  "Magus Game",
   "Room 1",
   "Room 2",
+  "Room 3",
+  "Room 4",
+  "Room 5",
+  "Room 6",
   "Extra Condemn",
   "Bonus Condemn",
 ];

--- a/Games/types/Mafia/effects/CursedVote.js
+++ b/Games/types/Mafia/effects/CursedVote.js
@@ -11,7 +11,7 @@ module.exports = class CursedVote extends Effect {
     this.listeners = {
       vote: function (vote) {
         if (
-          (vote.meeting.useVotingPower == true) &&
+          vote.meeting.useVotingPower == true &&
           vote.voter === this.player &&
           vote.target === this.target.id
         ) {

--- a/Games/types/Mafia/effects/CursedVote.js
+++ b/Games/types/Mafia/effects/CursedVote.js
@@ -11,9 +11,7 @@ module.exports = class CursedVote extends Effect {
     this.listeners = {
       vote: function (vote) {
         if (
-          (vote.meeting.name === "Village" ||
-            vote.meeting.name === "Room 1" ||
-            vote.meeting.name === "Room 2") &&
+          (vote.meeting.useVotingPower == true) &&
           vote.voter === this.player &&
           vote.target === this.target.id
         ) {

--- a/Games/types/Mafia/effects/DayTask.js
+++ b/Games/types/Mafia/effects/DayTask.js
@@ -155,9 +155,7 @@ module.exports = class DayTask extends Effect {
       },
       vote: function (vote) {
         if (
-          (vote.meeting.name === "Village" ||
-            vote.meeting.name === "Room 1" ||
-            vote.meeting.name === "Room 2") &&
+          (vote.meeting.useVotingPower == true) &&
           vote.voter === this.player
         ) {
           if (

--- a/Games/types/Mafia/effects/DayTask.js
+++ b/Games/types/Mafia/effects/DayTask.js
@@ -154,10 +154,7 @@ module.exports = class DayTask extends Effect {
         this.remove();
       },
       vote: function (vote) {
-        if (
-          (vote.meeting.useVotingPower == true) &&
-          vote.voter === this.player
-        ) {
+        if (vote.meeting.useVotingPower == true && vote.voter === this.player) {
           if (
             vote.target === this.ExtraPlayer.id &&
             this.task == "VoteForAPlayer" &&

--- a/Games/types/Mafia/effects/Wrangled.js
+++ b/Games/types/Mafia/effects/Wrangled.js
@@ -15,9 +15,7 @@ module.exports = class Wrangled extends Effect {
         if (this.NotFirstVoter == true) {
           return;
         }
-        if (
-          vote.meeting.useVotingPower == true
-        ) {
+        if (vote.meeting.useVotingPower == true) {
           if (vote.voter != this.player) {
             this.NotFirstVoter = true;
             return;

--- a/Games/types/Mafia/effects/Wrangled.js
+++ b/Games/types/Mafia/effects/Wrangled.js
@@ -16,9 +16,7 @@ module.exports = class Wrangled extends Effect {
           return;
         }
         if (
-          vote.meeting.name === "Village" ||
-          vote.meeting.name === "Room 1" ||
-          vote.meeting.name === "Room 2"
+          vote.meeting.useVotingPower == true
         ) {
           if (vote.voter != this.player) {
             this.NotFirstVoter = true;

--- a/Games/types/Mafia/items/Room.js
+++ b/Games/types/Mafia/items/Room.js
@@ -42,10 +42,9 @@ module.exports = class Room extends Item {
         item: this,
         run: function () {
           let hasChanged = false;
-          if(this.item.Room.leader == null){
+          if (this.item.Room.leader == null) {
             hasChanged = false;
-          }
-          else if(this.item.Room.leader != this.target) {
+          } else if (this.item.Room.leader != this.target) {
             hasChanged = true;
           }
           this.item.Room.leader = this.target;
@@ -60,35 +59,39 @@ module.exports = class Room extends Item {
     };
 
     this.listeners = {
-      death: function(){
-        if(this.game.alivePlayers().filter((p) => p.hasEffect("AssassinEffect")).length > 0){
+      death: function () {
+        if (
+          this.game.alivePlayers().filter((p) => p.hasEffect("AssassinEffect"))
+            .length > 0
+        ) {
           return;
         }
         for (let player of this.game.players) {
-        for (let item of player.items) {
+          for (let item of player.items) {
             if (item.name == "NoVillageMeeting") {
               item.drop();
+            }
           }
-          }
-          }
+        }
         this.drop();
       },
       roleAssigned: function (player) {
-        if(this.game.alivePlayers().filter((p) => p.hasEffect("AssassinEffect")).length > 0){
+        if (
+          this.game.alivePlayers().filter((p) => p.hasEffect("AssassinEffect"))
+            .length > 0
+        ) {
           return;
         }
         for (let player of this.game.players) {
-        for (let item of player.items) {
+          for (let item of player.items) {
             if (item.name == "NoVillageMeeting") {
               item.drop();
+            }
           }
-          }
-          }
+        }
         this.drop();
       },
     };
-
-
   }
 };
 function cannotBeVoted(player) {

--- a/Games/types/Mafia/roles/cards/BookieWager.js
+++ b/Games/types/Mafia/roles/cards/BookieWager.js
@@ -77,7 +77,7 @@ module.exports = class RiskyPrediction extends Card {
         if (leader === this.predictedVote && this.player.alive) {
           this.predictedCorrect = true;
           this.player.queueAlert(
-            `Room ${room} has Elected ${this.predictedVote.name}, giving you a bonus kill.`
+            `Room ${room.number} has Elected ${this.predictedVote.name}, giving you a bonus kill.`
           );
         }
       },

--- a/Games/types/Mafia/roles/cards/DeliriateEveryoneOnEvilCondemn.js
+++ b/Games/types/Mafia/roles/cards/DeliriateEveryoneOnEvilCondemn.js
@@ -8,7 +8,6 @@ module.exports = class DeliriateEveryoneOnEvilCondemn extends Card {
 
     this.listeners = {
       state: function (stateInfo) {
-
         if (stateInfo.name.match(/Day/)) {
           this.player.role.evilDied = false;
           return;
@@ -45,7 +44,7 @@ module.exports = class DeliriateEveryoneOnEvilCondemn extends Card {
       },
       death: function (player, killer, deathType) {
         if (!this.canTargetPlayer(leader)) {
-            return;
+          return;
         }
         /*
         if (
@@ -57,20 +56,19 @@ module.exports = class DeliriateEveryoneOnEvilCondemn extends Card {
           ) == "Mafia"
         ) {
           */
-          if (deathType != "condemn") return;
+        if (deathType != "condemn") return;
 
-          this.evilDied = true;
-        
+        this.evilDied = true;
       },
       ElectedRoomLeader: function (leader, room, HasChanged) {
         if (!this.canDoSpecialInteractions()) {
           return;
         }
-        if(!room.members.includes(this.player)){
+        if (!room.members.includes(this.player)) {
           return;
         }
         if (!this.canTargetPlayer(leader)) {
-            return;
+          return;
         }
         /*
         if (
@@ -82,8 +80,7 @@ module.exports = class DeliriateEveryoneOnEvilCondemn extends Card {
           ) == "Mafia"
         ) {
           */
-          this.evilDied = true;
-        
+        this.evilDied = true;
       },
     };
   }

--- a/Games/types/Mafia/roles/cards/DeliriateEveryoneOnEvilCondemn.js
+++ b/Games/types/Mafia/roles/cards/DeliriateEveryoneOnEvilCondemn.js
@@ -8,12 +8,13 @@ module.exports = class DeliriateEveryoneOnEvilCondemn extends Card {
 
     this.listeners = {
       state: function (stateInfo) {
-        if (!this.hasAbility(["Delirium"])) {
-          return;
-        }
 
         if (stateInfo.name.match(/Day/)) {
           this.player.role.evilDied = false;
+          return;
+        }
+
+        if (!this.hasAbility(["Delirium"])) {
           return;
         }
 
@@ -43,6 +44,10 @@ module.exports = class DeliriateEveryoneOnEvilCondemn extends Card {
         }
       },
       death: function (player, killer, deathType) {
+        if (!this.canTargetPlayer(leader)) {
+            return;
+        }
+        /*
         if (
           this.game.getRoleAlignment(
             player.getRoleAppearance().split(" (")[0]
@@ -51,15 +56,23 @@ module.exports = class DeliriateEveryoneOnEvilCondemn extends Card {
             player.getRoleAppearance().split(" (")[0]
           ) == "Mafia"
         ) {
+          */
           if (deathType != "condemn") return;
 
           this.evilDied = true;
-        }
+        
       },
       ElectedRoomLeader: function (leader, room, HasChanged) {
         if (!this.canDoSpecialInteractions()) {
           return;
         }
+        if(!room.members.includes(this.player)){
+          return;
+        }
+        if (!this.canTargetPlayer(leader)) {
+            return;
+        }
+        /*
         if (
           this.game.getRoleAlignment(
             leader.getRoleAppearance().split(" (")[0]
@@ -68,8 +81,9 @@ module.exports = class DeliriateEveryoneOnEvilCondemn extends Card {
             leader.getRoleAppearance().split(" (")[0]
           ) == "Mafia"
         ) {
+          */
           this.evilDied = true;
-        }
+        
       },
     };
   }

--- a/Games/types/Mafia/roles/cards/ForceSplitDecision.js
+++ b/Games/types/Mafia/roles/cards/ForceSplitDecision.js
@@ -1,10 +1,7 @@
 const Card = require("../../Card");
 const Action = require("../../Action");
 const Random = require("../../../../../lib/Random");
-const {
-  PRIORITY_INVESTIGATIVE_AFTER_RESOLVE_DEFAULT,
-} = require("../../const/Priority");
-const { PRIORITY_ROOM_SWAP } = require("../../const/Priority");
+const { PRIORITY_ROOM_SWAP, PRIORITY_INVESTIGATIVE_AFTER_RESOLVE_DEFAULT } = require("../../const/Priority");
 
 module.exports = class ForceSplitDecision extends Card {
   constructor(role) {
@@ -126,6 +123,7 @@ module.exports = class ForceSplitDecision extends Card {
             members: [],
             leader: null,
             number: x + 1,
+            game: this.game,
           };
           for (let y = 0; y < playersPerRoom; y++) {
             room.members.push(playersRandom.pop());
@@ -204,10 +202,13 @@ module.exports = class ForceSplitDecision extends Card {
         var villageBlock = new Action({
           actor: this.player,
           game: this.player.game,
-          priority: PRIORITY_ROOM_SWAP + 5,
+          priority: PRIORITY_INVESTIGATIVE_AFTER_RESOLVE_DEFAULT+100,
           labels: ["absolute", "hidden"],
           run: function () {
             if (!this.actor.alive) {
+              return;
+            }
+            if(!this.actor.hasEffect("AssassinEffect")){
               return;
             }
             if (this.game.Rooms.length > 0) {
@@ -232,6 +233,12 @@ module.exports = class ForceSplitDecision extends Card {
             priority: PRIORITY_ROOM_SWAP + 5,
             labels: ["absolute", "hidden"],
             run: function () {
+              if (!this.actor.alive) {
+                return;
+              }
+              if(!this.actor.hasEffect("AssassinEffect")){
+              return;
+            }
               let playerCount = this.game.alivePlayers().length;
               if (
                 playerCount <= 10 ||
@@ -283,12 +290,7 @@ module.exports = class ForceSplitDecision extends Card {
                 }
 
                 Room.leader.holdItem("RoomLeader", this.game, Room);
-              }
-
-              if (this.actor.alive && this.game.Rooms.length > 0) {
-                for (let player of this.game.players) {
-                  player.holdItem("NoVillageMeeting");
-                }
+                this.game.queueAlert(`${Room.leader.name} is ${Room.name}'s Leader this round!`);
               }
             },
           });
@@ -303,10 +305,8 @@ module.exports = class ForceSplitDecision extends Card {
               if (!this.actor.alive) {
                 return;
               }
-              if (this.game.Rooms.length > 0) {
-                for (let player of this.game.players) {
-                  player.holdItem("NoVillageMeeting");
-                }
+              if(!this.actor.hasEffect("AssassinEffect")){
+              return;
               }
               for (let Room of this.game.Rooms) {
                 if (Room.leader == null) {

--- a/Games/types/Mafia/roles/cards/ForceSplitDecision.js
+++ b/Games/types/Mafia/roles/cards/ForceSplitDecision.js
@@ -1,7 +1,10 @@
 const Card = require("../../Card");
 const Action = require("../../Action");
 const Random = require("../../../../../lib/Random");
-const { PRIORITY_ROOM_SWAP, PRIORITY_INVESTIGATIVE_AFTER_RESOLVE_DEFAULT } = require("../../const/Priority");
+const {
+  PRIORITY_ROOM_SWAP,
+  PRIORITY_INVESTIGATIVE_AFTER_RESOLVE_DEFAULT,
+} = require("../../const/Priority");
 
 module.exports = class ForceSplitDecision extends Card {
   constructor(role) {
@@ -202,13 +205,13 @@ module.exports = class ForceSplitDecision extends Card {
         var villageBlock = new Action({
           actor: this.player,
           game: this.player.game,
-          priority: PRIORITY_INVESTIGATIVE_AFTER_RESOLVE_DEFAULT+100,
+          priority: PRIORITY_INVESTIGATIVE_AFTER_RESOLVE_DEFAULT + 100,
           labels: ["absolute", "hidden"],
           run: function () {
             if (!this.actor.alive) {
               return;
             }
-            if(!this.actor.hasEffect("AssassinEffect")){
+            if (!this.actor.hasEffect("AssassinEffect")) {
               return;
             }
             if (this.game.Rooms.length > 0) {
@@ -236,9 +239,9 @@ module.exports = class ForceSplitDecision extends Card {
               if (!this.actor.alive) {
                 return;
               }
-              if(!this.actor.hasEffect("AssassinEffect")){
-              return;
-            }
+              if (!this.actor.hasEffect("AssassinEffect")) {
+                return;
+              }
               let playerCount = this.game.alivePlayers().length;
               if (
                 playerCount <= 10 ||
@@ -290,7 +293,9 @@ module.exports = class ForceSplitDecision extends Card {
                 }
 
                 Room.leader.holdItem("RoomLeader", this.game, Room);
-                this.game.queueAlert(`${Room.leader.name} is ${Room.name}'s Leader this round!`);
+                this.game.queueAlert(
+                  `${Room.leader.name} is ${Room.name}'s Leader this round!`
+                );
               }
             },
           });
@@ -305,8 +310,8 @@ module.exports = class ForceSplitDecision extends Card {
               if (!this.actor.alive) {
                 return;
               }
-              if(!this.actor.hasEffect("AssassinEffect")){
-              return;
+              if (!this.actor.hasEffect("AssassinEffect")) {
+                return;
               }
               for (let Room of this.game.Rooms) {
                 if (Room.leader == null) {

--- a/Games/types/Mafia/roles/cards/IfVotedForceCondemn.js
+++ b/Games/types/Mafia/roles/cards/IfVotedForceCondemn.js
@@ -8,7 +8,7 @@ module.exports = class IfVotedForceCondemn extends Card {
 
     this.listeners = {
       vote: function (vote) {
-        if (vote.meeting.name === "Village" && vote.target === this.player.id) {
+        if (vote.meeting.useVotingPower == true && vote.target === this.player.id) {
           if (this.data.hasBeenVoted == true) return;
 
           this.data.hasBeenVoted = true;

--- a/Games/types/Mafia/roles/cards/IfVotedForceCondemn.js
+++ b/Games/types/Mafia/roles/cards/IfVotedForceCondemn.js
@@ -8,7 +8,10 @@ module.exports = class IfVotedForceCondemn extends Card {
 
     this.listeners = {
       vote: function (vote) {
-        if (vote.meeting.useVotingPower == true && vote.target === this.player.id) {
+        if (
+          vote.meeting.useVotingPower == true &&
+          vote.target === this.player.id
+        ) {
           if (this.data.hasBeenVoted == true) return;
 
           this.data.hasBeenVoted = true;

--- a/Games/types/Mafia/roles/cards/WinByCondemning.js
+++ b/Games/types/Mafia/roles/cards/WinByCondemning.js
@@ -43,7 +43,7 @@ module.exports = class WinByCondemning extends Card {
           confirmedFinished &&
           this.canDoSpecialInteractions() &&
           this.hasFailedToPreventLeaderSwitch != true &&
-          this.AssassinWasPresent == true
+          this.AssassinWasPresent == true && !winners.groups[this.name]
         ) {
           winners.addPlayer(this.player, this.name);
         }

--- a/Games/types/Mafia/roles/cards/WinByCondemning.js
+++ b/Games/types/Mafia/roles/cards/WinByCondemning.js
@@ -43,7 +43,8 @@ module.exports = class WinByCondemning extends Card {
           confirmedFinished &&
           this.canDoSpecialInteractions() &&
           this.hasFailedToPreventLeaderSwitch != true &&
-          this.AssassinWasPresent == true && !winners.groups[this.name]
+          this.AssassinWasPresent == true &&
+          !winners.groups[this.name]
         ) {
           winners.addPlayer(this.player, this.name);
         }
@@ -53,7 +54,9 @@ module.exports = class WinByCondemning extends Card {
       roleAssigned: function (player) {
         if (
           this.canDoSpecialInteractions() &&
-          this.game.players.filter((p) => p.hasEffect("AssassinEffect")).length > 0 && this.AssassinWasPresent != true
+          this.game.players.filter((p) => p.hasEffect("AssassinEffect"))
+            .length > 0 &&
+          this.AssassinWasPresent != true
         ) {
           this.player.queueAlert(
             `You wish to see that no Room Leader gets voted out of office.`
@@ -92,7 +95,7 @@ module.exports = class WinByCondemning extends Card {
         if (!room.members.includes(this.player)) {
           return;
         }
-        if(HasChanged) {
+        if (HasChanged) {
           this.player.queueAlert(
             `You failed to stop ${leader.name} from usurping the Room Leader! Better hope you can get ${this.target.name} condemned!`
           );

--- a/Games/types/Mafia/roles/cards/WinByCondemning.js
+++ b/Games/types/Mafia/roles/cards/WinByCondemning.js
@@ -51,6 +51,15 @@ module.exports = class WinByCondemning extends Card {
     };
     this.listeners = {
       roleAssigned: function (player) {
+        if (
+          this.canDoSpecialInteractions() &&
+          this.game.players.filter((p) => p.hasEffect("AssassinEffect")).length > 0 && this.AssassinWasPresent != true
+        ) {
+          this.player.queueAlert(
+            `You wish to see that no Room Leader gets voted out of office.`
+          );
+          this.AssassinWasPresent = true;
+        }
         if (player !== this.player) {
           return;
         }
@@ -66,15 +75,6 @@ module.exports = class WinByCondemning extends Card {
         this.player.queueAlert(
           `You wish to see ${this.target.name} condemned for ${this.pettyReason}.`
         );
-        if (
-          this.canDoSpecialInteractions() &&
-          this.game.players.filter((p) => p.role.name == "Assassin").length > 0
-        ) {
-          this.player.queueAlert(
-            `You also wish to see that no Room Leader gets voted out of office.`
-          );
-          this.AssassinWasPresent = true;
-        }
       },
       death: function (player, killer, deathType) {
         if (
@@ -92,7 +92,10 @@ module.exports = class WinByCondemning extends Card {
         if (!room.members.includes(this.player)) {
           return;
         }
-        if (HasChanged) {
+        if(HasChanged) {
+          this.player.queueAlert(
+            `You failed to stop ${leader.name} from usurping the Room Leader! Better hope you can get ${this.target.name} condemned!`
+          );
           this.hasFailedToPreventLeaderSwitch = true;
         }
       },

--- a/Games/types/Mafia/roles/cards/WinByCondemning.js
+++ b/Games/types/Mafia/roles/cards/WinByCondemning.js
@@ -36,8 +36,11 @@ module.exports = class WinByCondemning extends Card {
     this.winCheck = {
       priority: PRIORITY_WIN_BY_CONDEMNING,
       againOnFinished: true,
-      check: function (counts, winners, aliveCount) {
+      check: function (counts, winners, aliveCount, confirmedFinished) {
         if (this.data.targetcondemned) {
+          winners.addPlayer(this.player, this.name);
+        }
+        else if(confirmedFinished && this.canDoSpecialInteractions() && this.hasFailedToPreventLeaderSwitch != true && this.AssassinWasPresent == true){
           winners.addPlayer(this.player, this.name);
         }
       },
@@ -59,6 +62,13 @@ module.exports = class WinByCondemning extends Card {
         this.player.queueAlert(
           `You wish to see ${this.target.name} condemned for ${this.pettyReason}.`
         );
+        if(this.canDoSpecialInteractions() && this.game.players.filter((p) => p.role.name == "Assassin").length > 0){
+          this.player.queueAlert(
+          `You also wish to see that no Room Leader gets voted out of office.`
+        );
+          this.AssassinWasPresent = true;
+        }
+        
       },
       death: function (player, killer, deathType) {
         if (
@@ -67,6 +77,17 @@ module.exports = class WinByCondemning extends Card {
           this.player.alive
         ) {
           this.data.targetcondemned = true;
+        }
+      },
+      ElectedRoomLeader: function (leader, room, HasChanged) {
+        if (!this.canDoSpecialInteractions()) {
+          return;
+        }
+        if (!room.members.includes(this.player)) {
+          return;
+        }
+        if (HasChanged) {
+          this.hasFailedToPreventLeaderSwitch = true;
         }
       },
     };

--- a/Games/types/Mafia/roles/cards/WinByCondemning.js
+++ b/Games/types/Mafia/roles/cards/WinByCondemning.js
@@ -39,8 +39,12 @@ module.exports = class WinByCondemning extends Card {
       check: function (counts, winners, aliveCount, confirmedFinished) {
         if (this.data.targetcondemned) {
           winners.addPlayer(this.player, this.name);
-        }
-        else if(confirmedFinished && this.canDoSpecialInteractions() && this.hasFailedToPreventLeaderSwitch != true && this.AssassinWasPresent == true){
+        } else if (
+          confirmedFinished &&
+          this.canDoSpecialInteractions() &&
+          this.hasFailedToPreventLeaderSwitch != true &&
+          this.AssassinWasPresent == true
+        ) {
           winners.addPlayer(this.player, this.name);
         }
       },
@@ -62,13 +66,15 @@ module.exports = class WinByCondemning extends Card {
         this.player.queueAlert(
           `You wish to see ${this.target.name} condemned for ${this.pettyReason}.`
         );
-        if(this.canDoSpecialInteractions() && this.game.players.filter((p) => p.role.name == "Assassin").length > 0){
+        if (
+          this.canDoSpecialInteractions() &&
+          this.game.players.filter((p) => p.role.name == "Assassin").length > 0
+        ) {
           this.player.queueAlert(
-          `You also wish to see that no Room Leader gets voted out of office.`
-        );
+            `You also wish to see that no Room Leader gets voted out of office.`
+          );
           this.AssassinWasPresent = true;
         }
-        
       },
       death: function (player, killer, deathType) {
         if (

--- a/Games/types/Mafia/roles/cards/WinIfCondemned.js
+++ b/Games/types/Mafia/roles/cards/WinIfCondemned.js
@@ -11,12 +11,12 @@ module.exports = class WinIfCondemned extends Card {
       check: function (counts, winners, aliveCount, confirmedFinished) {
         if (this.data.condemned && !winners.groups[this.name]) {
           winners.addPlayer(this.player, this.name);
-        }
-        else if (
+        } else if (
           confirmedFinished &&
           this.canDoSpecialInteractions() &&
           this.hasBeenRoomLeader &&
-          this.hasBeenRoomLeader.length >= 2 && !winners.groups[this.name]
+          this.hasBeenRoomLeader.length >= 2 &&
+          !winners.groups[this.name]
         ) {
           winners.addPlayer(this.player, this.name);
         }

--- a/Games/types/Mafia/roles/cards/WinIfCondemned.js
+++ b/Games/types/Mafia/roles/cards/WinIfCondemned.js
@@ -16,7 +16,7 @@ module.exports = class WinIfCondemned extends Card {
           confirmedFinished &&
           this.canDoSpecialInteractions() &&
           this.hasBeenRoomLeader &&
-          this.hasBeenRoomLeader.length >= 2 && !winners.groups[this.name])
+          this.hasBeenRoomLeader.length >= 2 && !winners.groups[this.name]
         ) {
           winners.addPlayer(this.player, this.name);
         }

--- a/Games/types/Mafia/roles/cards/WinIfCondemned.js
+++ b/Games/types/Mafia/roles/cards/WinIfCondemned.js
@@ -9,7 +9,12 @@ module.exports = class WinIfCondemned extends Card {
       priority: PRIORITY_WIN_CHECK_DEFAULT,
       againOnFinished: true,
       check: function (counts, winners, aliveCount, confirmedFinished) {
-        if(confirmedFinished && this.canDoSpecialInteractions() && this.hasBeenRoomLeader && this.hasBeenRoomLeader.length >= 2){
+        if (
+          confirmedFinished &&
+          this.canDoSpecialInteractions() &&
+          this.hasBeenRoomLeader &&
+          this.hasBeenRoomLeader.length >= 2
+        ) {
           winners.addPlayer(this.player, this.name);
         }
         if (this.data.condemned && !winners.groups[this.name]) {
@@ -26,17 +31,16 @@ module.exports = class WinIfCondemned extends Card {
         if (!this.canDoSpecialInteractions()) {
           return;
         }
-        if(leader != this.player){
+        if (leader != this.player) {
           return;
         }
-        if(!this.hasBeenRoomLeader){
+        if (!this.hasBeenRoomLeader) {
           this.hasBeenRoomLeader = [];
         }
-        if(this.hasBeenRoomLeader.includes(room.name)){
+        if (this.hasBeenRoomLeader.includes(room.name)) {
           return;
         }
-         this.hasBeenRoomLeader.push(room.name);
-        
+        this.hasBeenRoomLeader.push(room.name);
       },
     };
   }

--- a/Games/types/Mafia/roles/cards/WinIfCondemned.js
+++ b/Games/types/Mafia/roles/cards/WinIfCondemned.js
@@ -9,15 +9,15 @@ module.exports = class WinIfCondemned extends Card {
       priority: PRIORITY_WIN_CHECK_DEFAULT,
       againOnFinished: true,
       check: function (counts, winners, aliveCount, confirmedFinished) {
-        if (
+        if (this.data.condemned && !winners.groups[this.name]) {
+          winners.addPlayer(this.player, this.name);
+        }
+        else if (
           confirmedFinished &&
           this.canDoSpecialInteractions() &&
           this.hasBeenRoomLeader &&
-          this.hasBeenRoomLeader.length >= 2
+          this.hasBeenRoomLeader.length >= 2 && !winners.groups[this.name])
         ) {
-          winners.addPlayer(this.player, this.name);
-        }
-        if (this.data.condemned && !winners.groups[this.name]) {
           winners.addPlayer(this.player, this.name);
         }
       },

--- a/Games/types/Mafia/roles/cards/WinIfCondemned.js
+++ b/Games/types/Mafia/roles/cards/WinIfCondemned.js
@@ -8,7 +8,10 @@ module.exports = class WinIfCondemned extends Card {
     this.winCheck = {
       priority: PRIORITY_WIN_CHECK_DEFAULT,
       againOnFinished: true,
-      check: function (counts, winners, aliveCount) {
+      check: function (counts, winners, aliveCount, confirmedFinished) {
+        if(confirmedFinished && this.canDoSpecialInteractions() && this.hasBeenRoomLeader && this.hasBeenRoomLeader.length >= 2){
+          winners.addPlayer(this.player, this.name);
+        }
         if (this.data.condemned && !winners.groups[this.name]) {
           winners.addPlayer(this.player, this.name);
         }
@@ -18,6 +21,22 @@ module.exports = class WinIfCondemned extends Card {
       death: function (player, killer, deathType) {
         if (player == this.player && deathType == "condemn")
           this.data.condemned = true;
+      },
+      ElectedRoomLeader: function (leader, room, HasChanged) {
+        if (!this.canDoSpecialInteractions()) {
+          return;
+        }
+        if(leader != this.player){
+          return;
+        }
+        if(!this.hasBeenRoomLeader){
+          this.hasBeenRoomLeader = [];
+        }
+        if(this.hasBeenRoomLeader.includes(room.name)){
+          return;
+        }
+         this.hasBeenRoomLeader.push(room.name);
+        
       },
     };
   }

--- a/Games/types/Mafia/roles/cards/WinIfTargetDead.js
+++ b/Games/types/Mafia/roles/cards/WinIfTargetDead.js
@@ -11,16 +11,17 @@ module.exports = class WinIfTargetDead extends Card {
       priority: PRIORITY_WIN_CHECK_DEFAULT,
       againOnFinished: true,
       check: function (counts, winners, aliveCount, confirmedFinished) {
-
+        if(this.canDoSpecialInteractions() && this.game.players.filter((p) => p.hasEffect("AssassinEffect")).length > 0){
         if(confirmedFinished &&
-           this.canDoSpecialInteractions() &&
-           this.game.players.filter((p) => p.hasEffect("AssassinEffect")).length > 0 &&
            !this.player.alive &&
-           his.game.players.filter((p) => !p.alive && (p.hasEffect("PresidentEffect") || p.hasEffect("SenatorEffect") || p.role.modifier.split("/").includes("Vital"))).length <= 0
+           this.game.players.filter((p) => !p.alive && (p.hasEffect("PresidentEffect") || p.hasEffect("SenatorEffect") || p.role.modifier.split("/").includes("Vital"))).length <= 0
           ){
           winners.addPlayer(this.player, this.name);
         }
-        
+        else{
+        return;
+        }
+        }
         if (this.player.alive && aliveCount == 1) {
           winners.addGroup("No one");
           return;

--- a/Games/types/Mafia/roles/cards/WinIfTargetDead.js
+++ b/Games/types/Mafia/roles/cards/WinIfTargetDead.js
@@ -11,11 +11,21 @@ module.exports = class WinIfTargetDead extends Card {
       priority: PRIORITY_WIN_CHECK_DEFAULT,
       againOnFinished: true,
       check: function (counts, winners, aliveCount, confirmedFinished) {
+
+        if(confirmedFinished &&
+           this.canDoSpecialInteractions() &&
+           this.game.players.filter((p) => p.hasEffect("AssassinEffect")).length > 0 &&
+           !this.player.alive &&
+           his.game.players.filter((p) => !p.alive && (p.hasEffect("PresidentEffect") || p.hasEffect("SenatorEffect") || p.role.modifier.split("/").includes("Vital"))).length <= 0
+          ){
+          winners.addPlayer(this.player, this.name);
+        }
+        
         if (this.player.alive && aliveCount == 1) {
           winners.addGroup("No one");
           return;
         }
-
+        
         if (!confirmedFinished && counts["Village"] != aliveCount) {
           // game not ended
           return;

--- a/Games/types/Mafia/roles/cards/WinIfTargetDead.js
+++ b/Games/types/Mafia/roles/cards/WinIfTargetDead.js
@@ -11,22 +11,33 @@ module.exports = class WinIfTargetDead extends Card {
       priority: PRIORITY_WIN_CHECK_DEFAULT,
       againOnFinished: true,
       check: function (counts, winners, aliveCount, confirmedFinished) {
-        if(this.canDoSpecialInteractions() && this.game.players.filter((p) => p.hasEffect("AssassinEffect")).length > 0){
-        if(confirmedFinished &&
-           !this.player.alive &&
-           this.game.players.filter((p) => !p.alive && (p.hasEffect("PresidentEffect") || p.hasEffect("SenatorEffect") || (p.role.modifier.split("/").includes("Vital") && p.role.alignment == "Village"))).length <= 0
-          ){
-          winners.addPlayer(this.player, this.name);
-        }
-        else{
-        return;
-        }
+        if (
+          this.canDoSpecialInteractions() &&
+          this.game.players.filter((p) => p.hasEffect("AssassinEffect"))
+            .length > 0
+        ) {
+          if (
+            confirmedFinished &&
+            !this.player.alive &&
+            this.game.players.filter(
+              (p) =>
+                !p.alive &&
+                (p.hasEffect("PresidentEffect") ||
+                  p.hasEffect("SenatorEffect") ||
+                  (p.role.modifier.split("/").includes("Vital") &&
+                    p.role.alignment == "Village"))
+            ).length <= 0
+          ) {
+            winners.addPlayer(this.player, this.name);
+          } else {
+            return;
+          }
         }
         if (this.player.alive && aliveCount == 1) {
           winners.addGroup("No one");
           return;
         }
-        
+
         if (!confirmedFinished && counts["Village"] != aliveCount) {
           // game not ended
           return;

--- a/Games/types/Mafia/roles/cards/WinIfTargetDead.js
+++ b/Games/types/Mafia/roles/cards/WinIfTargetDead.js
@@ -14,7 +14,7 @@ module.exports = class WinIfTargetDead extends Card {
         if(this.canDoSpecialInteractions() && this.game.players.filter((p) => p.hasEffect("AssassinEffect")).length > 0){
         if(confirmedFinished &&
            !this.player.alive &&
-           this.game.players.filter((p) => !p.alive && (p.hasEffect("PresidentEffect") || p.hasEffect("SenatorEffect") || p.role.modifier.split("/").includes("Vital"))).length <= 0
+           this.game.players.filter((p) => !p.alive && (p.hasEffect("PresidentEffect") || p.hasEffect("SenatorEffect") || (p.role.modifier.split("/").includes("Vital") && p.role.alignment == "Village"))).length <= 0
           ){
           winners.addPlayer(this.player, this.name);
         }

--- a/data/modifiers.js
+++ b/data/modifiers.js
@@ -864,7 +864,7 @@ const modifierData = {
       tags: ["Block Self", "Death"],
       description:
         "If killed at night, their secondary actions will be blocked.",
-      eventDescription: "This Event will not apply to Non-Evil players.",
+      eventDescription: "This modifier does nothing when on an Event.",
       incompatible: ["Sorrowful"],
     },
     Sorrowful: {
@@ -873,7 +873,7 @@ const modifierData = {
       tags: ["Block Self", "Death"],
       description:
         "Unless killed at night, their secondary actions will be blocked.",
-      eventDescription: "This Event will not apply to Non-Evil players.",
+      eventDescription: "This modifier does nothing when on an Event.",
       incompatible: ["Fatal"],
     },
 

--- a/data/roles.js
+++ b/data/roles.js
@@ -1542,7 +1542,7 @@ const roleData = {
           "If an Assassin is Present, All players are Delirious if an Evil Player is Elected as Room Leader.",
         ],
       },
-        SpecialInteractionsModifiers: {
+      SpecialInteractionsModifiers: {
         Loyal: [
           "Players will only become Delirious if the condemned player is the same alignment as the Jazzman.",
         ],

--- a/data/roles.js
+++ b/data/roles.js
@@ -1532,7 +1532,7 @@ const roleData = {
       category: "Voting",
       tags: ["Condemn Interaction", "Delirium", "Alignment", "Advanced"],
       description: [
-        "If an Evil player is condemned, All players are Delirious that night.",
+        "If a player is condemned, All players are Delirious that night.",
       ],
       nightOrder: [
         ["Give Everyone Delirium If Evil Condemned", PRIORITY_BLOCK_EARLY],
@@ -1540,6 +1540,32 @@ const roleData = {
       SpecialInteractions: {
         Assassin: [
           "If an Assassin is Present, All players are Delirious if an Evil Player is Elected as Room Leader.",
+        ],
+      },
+        SpecialInteractionsModifiers: {
+        Loyal: [
+          "Players will only become Delirious if the condemned player is the same alignment as the Jazzman.",
+        ],
+        Disloyal: [
+          "Players will only become Delirious if the condemned player is a different alignment to the Jazzman.",
+        ],
+        Holy: [
+          "Players will only become Delirious if the condemned player is non-Demonic.",
+        ],
+        Unholy: [
+          "Players will only become Delirious if the condemned player is Demonic.",
+        ],
+        Simple: [
+          "Players will only become Delirious if the condemned player is a Vanilla role.",
+        ],
+        Complex: [
+          "Players will only become Delirious if the condemned player is a Power role.",
+        ],
+        Refined: [
+          "Players will only become Delirious if the condemned player is a non-Banished role.",
+        ],
+        Unrefined: [
+          "Players will only become Delirious if the condemned player is a Banished role.",
         ],
       },
       skins: [
@@ -4401,7 +4427,7 @@ const roleData = {
       ],
       SpecialInteractions: {
         Assassin: [
-          "If an Assassin is Present, Executioner will win at the end of the game if they were never in a room where the Room Leader changed.",
+          "If an Assassin is Present, an Executioner will win at the end of the game if they were never in a room when the Room Leader changed.",
         ],
       },
     },

--- a/data/roles.js
+++ b/data/roles.js
@@ -4386,6 +4386,11 @@ const roleData = {
         "Independent roles with the Scatterbrained modifier appear as this role to self.",
       ],
       nightOrder: [["Visit", PRIORITY_SUPPORT_VISIT_DEFAULT]],
+      SpecialInteractions: {
+        Assassin: [
+          "If an Assassin is Present, Fool will win at the end of the game if they were elected as Room Leader in 2 diffrent rooms.",
+        ],
+      },
     },
     Executioner: {
       alignment: "Independent",
@@ -4394,6 +4399,11 @@ const roleData = {
         "Randomly assigned a Village/Independent player as a target.",
         "Wins if their target player is condemned in Village meeting while alive.",
       ],
+      SpecialInteractions: {
+        Assassin: [
+          "If an Assassin is Present, Executioner will win at the end of the game if they were never in a room where the Room Leader changed.",
+        ],
+      },
     },
     Dodo: {
       alignment: "Independent",
@@ -4577,6 +4587,11 @@ const roleData = {
       ],
       nightOrder: [["Kill", PRIORITY_KILL_DEFAULT + 1]],
       graveyardParticipation: "self",
+      SpecialInteractions: {
+        Assassin: [
+          "If an Assassin is Present, a Vengeful Spirit will win at the end of the game if they are dead and no Presidents, Senators, or Vital Village roles are dead.",
+        ],
+      },
     },
     Phantom: {
       alignment: "Independent",

--- a/react_main/src/components/Setup.jsx
+++ b/react_main/src/components/Setup.jsx
@@ -458,6 +458,7 @@ export function FullRoleList({ setup }) {
             gameType={gameType}
             showSecondaryHover
             key={role}
+            otherRoles={setup.roles}
           />
         )
       );
@@ -516,6 +517,7 @@ export function FullRoleList({ setup }) {
       gameType={gameType}
       showSecondaryHover
       key={role}
+      otherRoles={setup.roles}
     />
   ));
 


### PR DESCRIPTION
Role Sharing can now only be done within a room.
Talking and Voting Dead work in rooms.

Various roles now work in Assassin roles.

 Added Mastermind from 2 Rooms and a Boom as a Special Interaction for Fool, If an Assassin is present, a Fool will win at the end of the game if they were elected Leader of 2 different Rooms during the game.

Added Minion from 2 Rooms and a Boom as Special Interaction for Executioner, If an Assassin is present, an Executioner will win at the end of the game if they are never in a room when the room leader changes.

Added Bomb-Bot from 2 Rooms and a Boom as Special Interaction for Vengeful Spirit, If an Assassin is present, a Vengeful Spirit will win if the Assassin kills them and the Assassin does not kill any Presidents, Senators, or Vital Village roles.

Made Special Interactions show on role pages.

Jazzman- now makes everyone delirious when any player is condemned.
Jazzman can now use Loyal, Disloyal, Simple, etc.  (Makes the delirium only happen when a player the modifier allows is condemned)
Old Jazzman = Jazzman (Disloyal);