### PR TITLE
Added migration script, added game setting icons to popver

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -1471,7 +1471,7 @@ module.exports = class Game {
 
   calculateStateOffset() {
     let start = this.setup.startState;
-    if (this.hasGameSetting("Day Start")) {
+    if (this.getGameSetting("Day Start")) {
       start = "Day";
     } else {
       start = "Night";
@@ -2269,162 +2269,145 @@ module.exports = class Game {
   //Game Settings Section
 
   isDayStart() {
-    if (this.hasGameSetting("Day Start")) {
+    if (this.getGameSetting("Day Start")) {
       return true;
     }
     return false;
   }
 
   isWhispers() {
-    if (this.hasGameSetting("Whispers")) {
+    if (this.getGameSetting("Whispers")) {
       return true;
     }
     return false;
   }
 
   getWhisperLeakChance() {
-    if (this.hasGameSetting("Whisper Leak Chance")) {
-      let temp = this.setup.gameSettings[0].filter(
-        (m) =>
-          (Array.isArray(m) && m[0] == "Whisper Leak Chance") ||
-          m == "Whisper Leak Chance"
-      );
-      if (temp[0] == "Whisper Leak Chance") {
-        return 1;
-      } else {
-        return temp[0].length;
-      }
+    const leakPercentage = this.getGameSetting("Whisper Leak Chance");
+    if (leakPercentage) {
+      return leakPercentage;
     }
     return 0;
   }
 
   isMustAct() {
-    if (this.hasGameSetting("Must Act")) {
+    if (this.getGameSetting("Must Act")) {
       return true;
     }
     return false;
   }
 
   isMustCondemn() {
-    if (this.hasGameSetting("Must Condemn")) {
+    if (this.getGameSetting("Must Condemn")) {
       return true;
     }
     return false;
   }
 
   isNoReveal() {
-    if (this.hasGameSetting("No Reveal")) {
+    if (this.getGameSetting("No Reveal")) {
       return true;
     }
     return false;
   }
 
   isAlignmentOnlyReveal() {
-    if (this.hasGameSetting("Alignment Only Reveal")) {
+    if (this.getGameSetting("Alignment Only Reveal")) {
       return true;
     }
     return false;
   }
 
   isHiddenVotes() {
-    if (this.hasGameSetting("Hidden Votes")) {
+    if (this.getGameSetting("Hidden Votes")) {
       return true;
     }
     return false;
   }
 
   isTalkingDead() {
-    if (this.hasGameSetting("Talking Dead")) {
+    if (this.getGameSetting("Talking Dead")) {
       return true;
     }
     return false;
   }
 
   isVotingDead() {
-    if (this.hasGameSetting("Voting Dead")) {
+    if (this.getGameSetting("Voting Dead")) {
       return true;
     }
     return false;
   }
 
   isMajorityVoting() {
-    if (this.hasGameSetting("Majority Voting")) {
+    if (this.getGameSetting("Majority Voting")) {
       return true;
     }
     return false;
   }
 
   isRoleSharing() {
-    if (this.hasGameSetting("Role Sharing")) {
+    if (this.getGameSetting("Role Sharing")) {
       return true;
     }
     return false;
   }
 
   isAlignmentSharing() {
-    if (this.hasGameSetting("Alignment Sharing")) {
+    if (this.getGameSetting("Alignment Sharing")) {
       return true;
     }
     return false;
   }
 
   isPrivateRevealing() {
-    if (this.hasGameSetting("Private Revealing")) {
+    if (this.getGameSetting("Private Revealing")) {
       return true;
     }
     return false;
   }
 
   isPublicRevealing() {
-    if (this.hasGameSetting("Public Revealing")) {
+    if (this.getGameSetting("Public Revealing")) {
       return true;
     }
     return false;
   }
 
   isHiddenConverts() {
-    if (this.hasGameSetting("Hidden Conversions")) {
+    if (this.getGameSetting("Hidden Conversions")) {
       return true;
     }
     return false;
   }
 
   isLastWills() {
-    if (this.hasGameSetting("Last Wills")) {
+    if (this.getGameSetting("Last Wills")) {
       return true;
     }
     return false;
   }
 
   isHostileVsMafia() {
-    if (this.hasGameSetting("Hostiles Vs Mafia")) {
+    if (this.getGameSetting("Hostiles Vs Mafia")) {
       return true;
     }
     return false;
   }
 
   isCultVsMafia() {
-    if (this.hasGameSetting("Competing Evil Factions")) {
+    if (this.getGameSetting("Competing Evil Factions")) {
       return true;
     }
     return false;
   }
 
-  hasGameSetting(gameSetting) {
+  getGameSetting(gameSetting) {
     //Object.entries(gameSettingData[this.type]).map((m) => m[1].in)
-    let tempgameSettings;
-    if (this.setup.gameSettings && this.setup.gameSettings[0]) {
-      tempgameSettings = this.setup.gameSettings[0].map((k) =>
-        Array.isArray(k) ? k[0] : k
-      );
-    } else {
-      return false;
+    if (this.setup.gameSettings && gameSetting in this.setup.gameSettings) {
+      return this.setup.gameSettings[gameSetting];
     }
-    if (tempgameSettings && tempgameSettings.includes(gameSetting)) {
-      return true;
-    } else {
-      return false;
-    }
+    return null;
   }
 
   //End Game Settings Section

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -188,8 +188,8 @@ module.exports = class MafiaGame extends Game {
     super.incrementState(index, skipped);
 
     if (
-      (!this.hasGameSetting("Day Start") && this.getStateName() == "Night") ||
-      (this.hasGameSetting("Day Start") && this.getStateName() == "Day")
+      (!this.getGameSetting("Day Start") && this.getStateName() == "Night") ||
+      (this.getGameSetting("Day Start") && this.getStateName() == "Day")
     ) {
       this.dayCount++;
     }
@@ -396,7 +396,7 @@ module.exports = class MafiaGame extends Game {
       this.setup.dawn &&
       this.getStateName() == "Night" &&
       (this.dayCount == 0 ||
-        (this.dayCount == 1 && this.hasGameSetting("Day Start")))
+        (this.dayCount == 1 && this.getGameSetting("Day Start")))
     );
   }
 

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -159,7 +159,7 @@ var schemas = {
     roles: String,
     count: { type: Map, of: Number },
     total: Number,
-    gameSettings: [],
+    gameSettings: { type: mongoose.Mixed, default: {} },
     startState: { type: String, default: "Night" },
     gameStartPrompt: { type: String, default: undefined },
     EventsPerNight: Number,
@@ -188,7 +188,7 @@ var schemas = {
         elo: { type: Number },
       },
     ],
-  }),
+  }, { minimize: false }),
   SetupVersion: new mongoose.Schema({
     version: { type: Number, index: true },
     setup: { type: mongoose.Schema.Types.ObjectId, ref: "Setup", index: true },

--- a/react_main/src/components/Roles.jsx
+++ b/react_main/src/components/Roles.jsx
@@ -640,7 +640,8 @@ export function GameSettingCount(props) {
     }
   }
 
-  const digits = props.count;
+  const digits =
+    props.count && !props.hideCount ? props.count.toString().split("") : "";
 
   const popoverDisabled = Boolean(props.showPopover === false);
   const popoverOpen = !popoverDisabled && canOpenPopover;
@@ -1178,11 +1179,9 @@ export function GameSettingSearch(props) {
 
   function getCompatibleGameSettingsOther(mods) {
     if (!mods) {
-      mods = [];
+      mods = {};
     }
-    const mappedMods = siteInfo.gamesettings[props.gameType].filter((t) =>
-      mods.includes(t.name)
-    );
+    const mappedMods = siteInfo.gamesettings[props.gameType].filter((t) => t.name in mods);
     let temp = [];
     for (let mod of mappedMods) {
       if (mod && mod.incompatible) {
@@ -1192,7 +1191,7 @@ export function GameSettingSearch(props) {
     const incompatibles = temp;
     const modifierOptions = siteInfo.gamesettings[props.gameType]
       .filter((e) => !e.hidden)
-      .filter((e) => e.allowDuplicate || !mods.includes(e.name))
+      .filter((e) => e.allowDuplicate || !(e.name in mods))
       .filter((e) => !incompatibles.includes(e.name))
       .map((modifier) => modifier.name);
     return modifierOptions;

--- a/react_main/src/css/roles.css
+++ b/react_main/src/css/roles.css
@@ -79,6 +79,8 @@
 }
 
 .gamesetting {
+  position: relative;
+
   width: 1rem;
   height: 1rem;
 
@@ -189,7 +191,7 @@
 
 .digits-wrapper {
   position: absolute;
-  top: 1.125rem;
+  top: calc(100% - 0.75em);
   width: auto;
   z-index: 1;
 }
@@ -204,7 +206,7 @@
 .digit {
   float: left;
   width: 0.50625rem;
-  height: 0.75rem;
+  height: 0.75em;
   background-size: 100% 100%;
 }
 

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -720,6 +720,14 @@ function GameWrapper(props) {
     }
   }
 
+  function getSetupGameSetting(gameSetting) {
+    if (setup && setup.gameSettings && gameSetting in setup.gameSettings) {
+      return setup.gameSettings[gameSetting];
+    }
+
+    return null;
+  }
+
   if (leave === "review") return <Navigate to={`/game/${gameId}/review`} />;
   else if (leave) return <Navigate to="/play" />;
   else if (rehostId) return <Navigate to={`/game/${rehostId}`} />;
@@ -735,6 +743,7 @@ function GameWrapper(props) {
       socket: socket,
       review: props.review,
       setup: setup,
+      getSetupGameSetting: getSetupGameSetting,
       startTime: startTime,
       history: history,
       updateHistory: updateHistory,
@@ -1274,11 +1283,11 @@ export function TextMeetingLayout(props) {
               selTab={selTab}
               players={players}
               options={props.options}
-              setup={props.setup}
               socket={props.socket}
               setAutoScroll={setAutoScroll}
               speechInput={speechInput}
               setSpeechInput={setSpeechInput}
+              whispersEnabled={game.getSetupGameSetting("Whispers")}
             />
           </>
         )}
@@ -1864,9 +1873,7 @@ function ObituariesMessage(props) {
         deaths={deaths}
         onFullyAnimated={() => game.setIsObituaryPlaying(false)}
         playAudio={game.playAudio}
-        isAlignmentReveal={game.setup?.gameSettings[0].includes(
-          "Alignment Only Reveal"
-        )}
+        isAlignmentReveal={game.getSetupGameSetting("Alignment Only Reveal")}
       />
     </>
   );
@@ -1934,7 +1941,7 @@ function SpeechInput(props) {
         });
       }
     }
-    if (props.setup.gameSettings[0].includes("Whispers")) {
+    if (props.whispersEnabled) {
       newDropdownOptions.push("divider");
       newDropdownOptions.push({
         id: "forceLeak",

--- a/react_main/src/pages/Game/MafiaGame.jsx
+++ b/react_main/src/pages/Game/MafiaGame.jsx
@@ -547,7 +547,7 @@ export default function MafiaGame() {
             {!game.review &&
               !isSpectator &&
               history.currentState >= 0 &&
-              game.setup.gameSettings[0].includes("Last Wills") && (
+              game.getSetupGameSetting("Last Wills") && (
                 <LastWillEntry
                   lastWill={game.lastWill}
                   cannotModifyLastWill={history.states[

--- a/scripts/mongo/migrate-setup-game-settings.js
+++ b/scripts/mongo/migrate-setup-game-settings.js
@@ -1,0 +1,38 @@
+db.setups.updateMany(
+  { },
+  [
+    {
+      $set: {
+        gameSettings: {
+          $arrayToObject: {
+            $concatArrays: [
+              [],
+              { $cond: [{ $eq: ["$startState", "Day"] }, [["Day Start", true]], []] },
+              { $cond: [{ $eq: ["$whispers", true] }, [["Whispers", true]], []] },
+              { $cond: [{ $and: [
+                { $gt: ["$leakPercentage", 0] },
+                { $eq: ["$whispers", true] },
+              ]}, [["Whisper Leak Chance", "$leakPercentage"]], []] },
+              { $cond: [{ $eq: ["$mustAct", true] }, [["Must Act", true]], []] },
+              { $cond: [{ $eq: ["$noReveal", true] }, [["No Reveal", true]], []] },
+              { $cond: [{ $eq: ["$alignmentReveal", true] }, [["Alignment Only Reveal", true]], []] },
+              { $cond: [{ $eq: ["$mustCondemn", true] }, [["Must Condemn", true]], []] },
+              { $cond: [{ $eq: ["$votesInvisible", true] }, [["Hidden Votes", true]], []] },
+              { $cond: [{ $eq: ["$majorityVoting", true] }, [["Majority Voting", true]], []] },
+              { $cond: [{ $eq: ["$votingDead", true] }, [["Voting Dead", true]], []] },
+              { $cond: [{ $eq: ["$RoleShare", true] }, [["Role Sharing", true]], []] },
+              { $cond: [{ $eq: ["$AlignmentShare", true] }, [["Alignment Sharing", true]], []] },
+              { $cond: [{ $eq: ["$PrivateShare", true] }, [["Private Revealing", true]], []] },
+              { $cond: [{ $eq: ["$PublicShare", true] }, [["Public Revealing", true]], []] },
+              { $cond: [{ $eq: ["$talkingDead", true] }, [["Talking Dead", true]], []] },
+              { $cond: [{ $eq: ["$hiddenConverts", true] }, [["Hidden Conversions", true]], []] },
+              { $cond: [{ $eq: ["$lastWill", true] }, [["Last Wills", true]], []] },
+              { $cond: [{ $eq: ["$HostileVsMafia", true] }, [["Hostiles Vs Mafia", true]], []] },
+              { $cond: [{ $eq: ["$CultVsMafia", true] }, [["Competing Evil Factions", true]], []] },
+            ]
+          }
+        }
+      }
+    }
+  ]
+)


### PR DESCRIPTION
- Converted gameSettings DB representation to object of key value pairs where the value is either a boolean or a number
- Added migration script, the script is safe to run multiple times and can be done in advance of upgrading (run using mongosh, instructions below
- Added game settings icons to setup popover, kudos to SawJester for adding the game settings icon component
- Fixed rendering of digits for all sizes of icons (previously they were misaligned for closed setups)

Migration instructions (syntax is probably a bit off, I wrote this from memory):
```
docker exec -it mongodb mongosh
use admin
db.auth('admin', <password>)
use beyondmafia
load('/scripts/migrate-setup-game-settings.js')
```