### PR TITLE
State switcher UI, Mobile UI rework

### DIFF
--- a/data/contributors.js
+++ b/data/contributors.js
@@ -331,7 +331,7 @@ const artContributors = {
       "Heartbreaker:noir",
     ],
   },
-  aleph: {
+  megido: {
     Mafia: [
       "Count:vivid",
       "Harpy:vivid",

--- a/data/donors.js
+++ b/data/donors.js
@@ -1,6 +1,6 @@
 const donors = [
   "Eudia",
-  "JaNa",
+  "shego",
   "RangoonEnjoyer",
   "Ego",
   "MetalAF",
@@ -9,7 +9,7 @@ const donors = [
   "jacobkrin",
   "Joesaurus",
   "Natalia",
-  "aleph",
+  "megido",
   "nearbear",
 ];
 

--- a/react_main/src/Main.jsx
+++ b/react_main/src/Main.jsx
@@ -382,7 +382,7 @@ function Header({ setShowAnnouncementTemporarily }) {
             left: "0",
             zIndex: 1000,
             width: "10%",
-            height: "10%",
+            aspectRatio: "1",
             display: window.innerWidth <= 768 ? "none" : "block",
           }}
         />

--- a/react_main/src/components/Achievements.js
+++ b/react_main/src/components/Achievements.js
@@ -382,8 +382,7 @@ export function RoleCell(props) {
   const popover = useContext(PopoverContext);
   const user = useContext(UserContext);
   const roleCellRef = useRef();
-  const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const isPhoneDevice = useIsPhoneDevice();
 
   const myHeight = `calc(1.2 * ${iconLength} + 2 * var(--mui-spacing))`;
 
@@ -420,7 +419,7 @@ export function RoleCell(props) {
       className="role-cell"
       key={role.name}
       sx={{
-        p: isSmallScreen ? 0.5 : 1,
+        p: isPhoneDevice ? 0.5 : 1,
         lineHeight: "normal",
         height: myHeight,
       }}

--- a/react_main/src/components/Roles.jsx
+++ b/react_main/src/components/Roles.jsx
@@ -22,7 +22,6 @@ import {
   useMediaQuery,
   Button,
 } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
 import { usePopoverOpen } from "../hooks/usePopoverOpen";
 import { NewLoading } from "../pages/Welcome/NewLoading";
 import { useIsPhoneDevice } from "../hooks/useIsPhoneDevice";
@@ -698,8 +697,7 @@ export function RoleCell(props) {
   const popover = useContext(PopoverContext);
   const user = useContext(UserContext);
   const roleCellRef = useRef();
-  const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const isPhoneDevice = useIsPhoneDevice();
 
   const myHeight = `calc(1.2 * ${iconLength} + 2 * var(--mui-spacing))`;
 
@@ -736,7 +734,7 @@ export function RoleCell(props) {
       className="role-cell"
       key={role.name}
       sx={{
-        p: isSmallScreen ? 0.5 : 1,
+        p: isPhoneDevice ? 0.5 : 1,
         lineHeight: "normal",
         height: myHeight,
       }}
@@ -817,14 +815,13 @@ export function RoleCell(props) {
 }
 
 export function RoleSearch(props) {
-  const theme = useTheme();
   const [roleListType, setRoleListType] = useState(
     Alignments[props.gameType][0]
   );
   const [searchVal, setSearchVal] = useState("");
   const user = useContext(UserContext);
   const siteInfo = useContext(SiteInfoContext);
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const isPhoneDevice = useIsPhoneDevice();
 
   function onAlignNavClick(alignment) {
     setSearchVal("");
@@ -913,14 +910,14 @@ export function RoleSearch(props) {
 
   return (
     <Stack direction="column">
-      <Stack direction={isSmallScreen ? "column-reverse" : "row"} spacing={1}>
+      <Stack direction={isPhoneDevice ? "column-reverse" : "row"} spacing={1}>
         <Tabs
           value={roleListType}
           onChange={(_, value) => setRoleListType(value)}
         >
           {alignButtons}
         </Tabs>
-        <Box sx={{ ml: isSmallScreen ? undefined : "auto !important" }}>
+        <Box sx={{ ml: isPhoneDevice ? undefined : "auto !important" }}>
           <SearchBar
             value={searchVal}
             placeholder="🔎 Role Name"
@@ -939,8 +936,6 @@ export function RoleSearch(props) {
 }
 
 export function ModifierSearch(props) {
-  const theme = useTheme();
-
   const [roleListType, setRoleListType] = useState("Items");
 
   const [searchVal, setSearchVal] = useState("");
@@ -948,7 +943,7 @@ export function ModifierSearch(props) {
   const user = useContext(UserContext);
   const siteInfo = useContext(SiteInfoContext);
   const popover = useContext(PopoverContext);
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const isPhoneDevice = useIsPhoneDevice();
 
   function onAlignNavClick(alignment) {
     setSearchVal("");
@@ -1047,14 +1042,14 @@ export function ModifierSearch(props) {
 
   return (
     <Stack direction="column" spacing={1}>
-      <Stack direction={isSmallScreen ? "column-reverse" : "row"} spacing={1}>
+      <Stack direction={isPhoneDevice ? "column-reverse" : "row"} spacing={1}>
         <Tabs
           value={roleListType}
           onChange={(_, value) => setRoleListType(value)}
         >
           {alignButtons}
         </Tabs>
-        <Box sx={{ ml: isSmallScreen ? undefined : "auto !important" }}>
+        <Box sx={{ ml: isPhoneDevice ? undefined : "auto !important" }}>
           <SearchBar
             value={searchVal}
             placeholder="🔎 Role Name"
@@ -1073,8 +1068,6 @@ export function ModifierSearch(props) {
 }
 
 export function GameSettingSearch(props) {
-  const theme = useTheme();
-
   const [roleListType, setRoleListType] = useState("Standard");
 
   const [searchVal, setSearchVal] = useState("");
@@ -1082,7 +1075,7 @@ export function GameSettingSearch(props) {
   const user = useContext(UserContext);
   const siteInfo = useContext(SiteInfoContext);
   const popover = useContext(PopoverContext);
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const isPhoneDevice = useIsPhoneDevice();
 
   function onAlignNavClick(alignment) {
     setSearchVal("");
@@ -1178,14 +1171,14 @@ export function GameSettingSearch(props) {
 
   return (
     <Stack direction="column" spacing={1}>
-      <Stack direction={isSmallScreen ? "column-reverse" : "row"} spacing={1}>
+      <Stack direction={isPhoneDevice ? "column-reverse" : "row"} spacing={1}>
         <Tabs
           value={roleListType}
           onChange={(_, value) => setRoleListType(value)}
         >
           {alignButtons}
         </Tabs>
-        <Box sx={{ ml: isSmallScreen ? undefined : "auto !important" }}>
+        <Box sx={{ ml: isPhoneDevice ? undefined : "auto !important" }}>
           <SearchBar
             value={searchVal}
             placeholder="🔎 Game Setting Name"

--- a/react_main/src/components/Setup.jsx
+++ b/react_main/src/components/Setup.jsx
@@ -405,8 +405,7 @@ export function FullRoleList({ setup }) {
   const gameType = setup.gameType;
 
   const siteInfo = useContext(SiteInfoContext);
-  const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const isPhoneDevice = useIsPhoneDevice();
 
   var rolesDividedByAlignment = {};
   const events = [];
@@ -436,7 +435,7 @@ export function FullRoleList({ setup }) {
   // holy fricken FREAK this is a 3-dimensional effort
   const rolesetAlignments = Object.keys(rolesDividedByAlignment).map((i) => {
     const alignmentKeys = Object.keys(rolesDividedByAlignment[i]);
-    const gridItemSize = isSmallScreen ? 12 : 12 / alignmentKeys.length;
+    const gridItemSize = isPhoneDevice ? 12 : 12 / alignmentKeys.length;
     var sectionName =
       setup.roles.length > 1 ? INDEXED_ROLE_GROUP_LABELS[i] : null;
     if (sectionName && setup.useRoleGroups) {
@@ -485,7 +484,7 @@ export function FullRoleList({ setup }) {
 
     return (
       <Stack
-        direction={isSmallScreen ? "column" : "row"}
+        direction={isPhoneDevice ? "column" : "row"}
         sx={{
           alignItems: "center",
         }}

--- a/react_main/src/components/Setup.jsx
+++ b/react_main/src/components/Setup.jsx
@@ -5,6 +5,7 @@ import { Alignments } from "Constants";
 import { RoleCount } from "components/Roles";
 import { filterProfanity } from "components/Basic";
 import { SearchBar } from "components/Nav";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 import { hyphenDelimit } from "utils";
 
 import {

--- a/react_main/src/components/StateIcon.jsx
+++ b/react_main/src/components/StateIcon.jsx
@@ -16,15 +16,19 @@ export const statesIcons = {
   nowin: require("images/game_state/nowin-state.png"),
   triwin: require("images/game_state/triwin-state.png"),
   villagewin: require("images/game_state/villagewin-state.png"),
+  ghost: require("images/roles/ghost-vivid.png"),
+  admiral: require("images/roles/village/admiral-vivid.png"),
 };
 
 const stateIconMap = {
   pregame: "pregame",
-  dawn: "day",
+  dawn: "night",
   day: "day",
   dusk: "night",
   night: "night",
   postgame: "bakerflagwin",
+  "give clue": "ghost",
+  "treasure chest": "admiral",
 };
 
 export default function StateIcon({ stateName, stateNum, unfocused = false, size = 40 }) {

--- a/react_main/src/components/StateIcon.jsx
+++ b/react_main/src/components/StateIcon.jsx
@@ -1,3 +1,4 @@
+import { Tooltip } from "@mui/material";
 import React from "react";
 
 export const statesIcons = {
@@ -17,18 +18,34 @@ export const statesIcons = {
   villagewin: require("images/game_state/villagewin-state.png"),
 };
 
-export default function StateIcon({ stateType, size = 40, number }) {
+const stateIconMap = {
+  pregame: "pregame",
+  dawn: "day",
+  day: "day",
+  dusk: "night",
+  night: "night",
+  postgame: "bakerflagwin",
+};
+
+export default function StateIcon({ stateName, stateNum, unfocused = false, size = 40 }) {
+  const normalizedName = stateName.toLowerCase().replace(/[0-9]/g, "").trim();
+  const stateType = stateIconMap[normalizedName] || "nowin";
+
+  const numberMatch = stateName.match(/\d+/);
+  const number = numberMatch ? parseInt(numberMatch[0]) : null;
+
   const iconSrc = statesIcons[stateType];
 
   const digits = number ? String(number).split("") : [];
 
-  return (
+  const icon = (
     <div
       style={{
         position: "relative",
         display: "inline-block",
         width: size,
         height: size,
+        filter: unfocused ? "opacity(50%)" : undefined,
       }}
     >
       <img
@@ -44,9 +61,8 @@ export default function StateIcon({ stateType, size = 40, number }) {
           className="digit-wrapper"
           style={{
             position: "absolute",
-            bottom: "2px",
-            right: "2px",
-            display: "flex",
+            bottom: "0px",
+            right: "0px",
           }}
         >
           {digits.map((digit, i) => (
@@ -56,4 +72,18 @@ export default function StateIcon({ stateType, size = 40, number }) {
       )}
     </div>
   );
+
+  if(unfocused) {
+    return icon;
+  }
+  else {
+    return (
+      <Tooltip
+        title={stateName}
+        key={stateNum}
+      >
+        {icon}
+      </Tooltip>
+    );
+  }
 }

--- a/react_main/src/components/gameComponents/ChangeHead.jsx
+++ b/react_main/src/components/gameComponents/ChangeHead.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Helmet } from "react-helmet";
 
-export const ChangeHead = ({ title, duration }) => {
+export default function ChangeHead({ title, duration }) {
   const [alive, setAlive] = useState(true);
 
   useEffect(() => {

--- a/react_main/src/components/gameComponents/ChangeHeadPing.jsx
+++ b/react_main/src/components/gameComponents/ChangeHeadPing.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { ChangeHead } from "./ChangeHead";
+import ChangeHead from "components/gameComponents/ChangeHead";
 
 const FLASH_INTERVAL = 800;
 

--- a/react_main/src/components/gameComponents/StateSwitcher.jsx
+++ b/react_main/src/components/gameComponents/StateSwitcher.jsx
@@ -3,13 +3,10 @@ import { Box, IconButton, Paper, Stack, Tab, Tabs, Tooltip, Typography } from "@
 import StateIcon from "../StateIcon";
 import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
-const STATE_RANGE = 2;
-
-export default function StateSwitcher(props) {
-  const { history, stateViewing, updateStateViewing, onStateNavigation, timer } =
-    props;
-
+export default function StateSwitcher({ history, stateViewing, updateStateViewing, onStateNavigation, hideFastForward = false }) {
   const isPhoneDevice = useIsPhoneDevice();
+
+  const STATE_RANGE = isPhoneDevice ? 1 : 2;
 
   const leftArrowVisible = stateViewing !== -1;
   const rightArrowVisible =
@@ -53,8 +50,6 @@ export default function StateSwitcher(props) {
 
     const isInRange = (index >= currentStateIndex - STATE_RANGE) && (index <= currentStateIndex + STATE_RANGE);
 
-    console.log(stateNum, stateViewing)
-
     // If you change the sizing of this, make sure to tweak the padInvisibleLeft and padInvisibleRight calcs accordingly
     return (
       <Tab
@@ -86,72 +81,69 @@ export default function StateSwitcher(props) {
   };
 
   return (
-    <Paper>
-      <Stack direction="row"
+    <Stack direction="row"
+      sx={{
+        alignItems: "center",
+        justifyContent: "center",
+        py: .5,
+        borderRadius: 1,
+      }}
+    >
+      {/* <IconButton
         sx={{
-          alignItems: "center",
-          justifyContent: "center",
-          py: .5,
-          borderRadius: 1,
+          visibility: leftArrowVisible ? undefined : "hidden",
         }}
+        onClick={() => handleClick({ type: "backward" })}
       >
-        {/* <IconButton
-          sx={{
-            visibility: leftArrowVisible ? undefined : "hidden",
-          }}
-          onClick={() => handleClick({ type: "backward" })}
-        >
-          <i className="fas fa-angle-left" style={iconStyle} />
-        </IconButton> */}
+        <i className="fas fa-angle-left" style={iconStyle} />
+      </IconButton> */}
 
-        <IconButton
-          sx={{
-            visibility: leftArrowVisible ? undefined : "hidden",
-          }}
-          onClick={() => handleClick({ type: "first" })}
-        >
-          <i className="fas fa-angle-double-left" style={iconStyle} />
-        </IconButton>
+      {!hideFastForward && (<IconButton
+        sx={{
+          visibility: leftArrowVisible ? undefined : "hidden",
+        }}
+        onClick={() => handleClick({ type: "first" })}
+      >
+        <i className="fas fa-angle-double-left" style={iconStyle} />
+      </IconButton>)}
 
-        <Stack direction="column" sx={{
-          alignItems: "center",
-        }}>
-          <Tabs
-            value={reverseStateNums[stateViewing]}
-            onChange={handleChange}
-            sx={{
-              maxWidth: "100%",
-              minHeight: 0,
-              paddingLeft: `calc(${padInvisibleLeft} * (var(--mui-spacing) + ${stateIconSize}px))`,
-              paddingRight: `calc(${padInvisibleRight} * (var(--mui-spacing) + ${stateIconSize}px))`,
-              '& .MuiTabs-indicator': {
-                transition: "none",
-              },
-            }}
-          >
-            {paginatedStates}
-          </Tabs>
-          {timer}
-        </Stack>
-
-        <IconButton
+      <Stack direction="column" sx={{
+        alignItems: "center",
+      }}>
+        <Tabs
+          value={reverseStateNums[stateViewing]}
+          onChange={handleChange}
           sx={{
-            visibility: rightArrowVisible ? undefined : "hidden",
+            maxWidth: "100%",
+            minHeight: 0,
+            paddingLeft: `calc(${padInvisibleLeft} * (var(--mui-spacing) + ${stateIconSize}px))`,
+            paddingRight: `calc(${padInvisibleRight} * (var(--mui-spacing) + ${stateIconSize}px))`,
+            '& .MuiTabs-indicator': {
+              transition: "none",
+            },
           }}
-          onClick={() => handleClick({ type: "current" })}
         >
-          <i className="fas fa-angle-double-right" style={iconStyle} />
-        </IconButton>
-
-        {/* <IconButton
-          sx={{
-            visibility: rightArrowVisible ? undefined : "hidden",
-          }}
-          onClick={() => handleClick({ type: "forward" })}
-        >
-          <i className="fas fa-angle-right" style={iconStyle}  />
-        </IconButton> */}
+          {paginatedStates}
+        </Tabs>
       </Stack>
-    </Paper>
+
+      {!hideFastForward && (<IconButton
+        sx={{
+          visibility: rightArrowVisible ? undefined : "hidden",
+        }}
+        onClick={() => handleClick({ type: "current" })}
+      >
+        <i className="fas fa-angle-double-right" style={iconStyle} />
+      </IconButton>)}
+
+      {/* <IconButton
+        sx={{
+          visibility: rightArrowVisible ? undefined : "hidden",
+        }}
+        onClick={() => handleClick({ type: "forward" })}
+      >
+        <i className="fas fa-angle-right" style={iconStyle}  />
+      </IconButton> */}
+    </Stack>
   );
 }

--- a/react_main/src/components/gameComponents/StateSwitcher.jsx
+++ b/react_main/src/components/gameComponents/StateSwitcher.jsx
@@ -1,12 +1,22 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Box, IconButton, Paper, Stack, Tab, Tabs, Tooltip, Typography } from "@mui/material";
 import StateIcon from "../StateIcon";
 import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
+import { GameContext } from "Contexts";
 
-export default function StateSwitcher({ history, stateViewing, updateStateViewing, onStateNavigation, hideFastForward = false }) {
+export default function StateSwitcher({ stateRange = null, }) {
+  const game = useContext(GameContext);
   const isPhoneDevice = useIsPhoneDevice();
+  const hideFastForward = isPhoneDevice;
 
-  const STATE_RANGE = isPhoneDevice ? 1 : 2;
+  const {
+    history,
+    stateViewing,
+    updateStateViewing,
+    onStateNavigation,
+  } = game;
+
+  const STATE_RANGE = stateRange !== null ? stateRange : isPhoneDevice ? 1 : 2;
 
   const leftArrowVisible = stateViewing !== -1;
   const rightArrowVisible =

--- a/react_main/src/components/gameComponents/StateSwitcher.jsx
+++ b/react_main/src/components/gameComponents/StateSwitcher.jsx
@@ -1,87 +1,157 @@
-import React from "react";
-import { Box, IconButton, Tooltip, Typography } from "@mui/material";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Box, IconButton, Paper, Stack, Tab, Tabs, Tooltip, Typography } from "@mui/material";
 import StateIcon from "../StateIcon";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
-const stateIconMap = {
-  pregame: "pregame",
-  dawn: "day",
-  day: "day",
-  dusk: "night",
-  night: "night",
-  postgame: "bakerflagwin",
-};
+const STATE_RANGE = 2;
 
 export default function StateSwitcher(props) {
-  const { history, stateViewing, updateStateViewing, onStateNavigation } =
+  const { history, stateViewing, updateStateViewing, onStateNavigation, timer } =
     props;
-  const currentState = history.states[stateViewing];
-  const stateName = currentState ? currentState.name : "";
 
-  const normalizedName = stateName.toLowerCase().replace(/[0-9]/g, "").trim();
-  const mappedIconType = stateIconMap[normalizedName] || "nowin";
-
-  const numberMatch = stateName.match(/\d+/);
-  const number = numberMatch ? parseInt(numberMatch[0]) : null;
+  const isPhoneDevice = useIsPhoneDevice();
 
   const leftArrowVisible = stateViewing !== -1;
   const rightArrowVisible =
     stateViewing < history.currentState ||
     (history.currentState === -2 && stateViewing !== history.currentState);
 
-  const handleClick = (direction) => {
-    updateStateViewing({ type: direction });
+  const handleClick = (action) => {
+    updateStateViewing(action);
+    onStateNavigation();
+  };
+
+  const stateIconSize = 40;
+  const iconStyle = {
+    width: "1em",
+    height: "1em",
+  };
+
+  let stateNums = Object.keys(history.states).map(stateNum => Number.parseInt(stateNum));
+  stateNums.sort((a, b) => {
+    // Postgame is always greater
+    if(a === -2) {
+      return 1;
+    }
+    if(b === -2) {
+      return -1;
+    }
+    else {
+      return a - b;
+    }
+  });
+  const reverseStateNums = Object.fromEntries(stateNums.map((stateNum, i) => [stateNum, i]));
+  const currentStateIndex = reverseStateNums[stateViewing];
+
+  const padInvisibleLeft = Math.max(0, STATE_RANGE - currentStateIndex);
+  const padInvisibleRight = Math.max(0, STATE_RANGE - stateNums.length + 1 + currentStateIndex);
+
+  const paginatedStates = stateNums.map((stateNum) => {
+    const state = history.states[stateNum];
+    const stateName = state ? state.name : "Unknown State";
+    const index = reverseStateNums[stateNum];
+
+    const isInRange = (index >= currentStateIndex - STATE_RANGE) && (index <= currentStateIndex + STATE_RANGE);
+
+    console.log(stateNum, stateViewing)
+
+    // If you change the sizing of this, make sure to tweak the padInvisibleLeft and padInvisibleRight calcs accordingly
+    return (
+      <Tab
+        component="div"
+        key={stateNum}
+        aria-label={stateName}
+        icon={<StateIcon
+          stateName={stateName}
+          stateNum={stateNum}
+          unfocused={stateNum !== stateViewing}
+          size={stateIconSize}
+        />}
+        sx={{
+          display: isInRange ? undefined : "none",
+          px: 0.5,
+          paddingBottom: 0.5,
+          paddingTop: 0,
+          minWidth: 0,
+          minHeight: 0,
+        }}
+      />
+    );
+  });
+
+  const handleChange = (event, newValue) => {
+    const newState = stateNums[newValue];
+    handleClick({ type: "set", stateNum: newState });
     onStateNavigation();
   };
 
   return (
-    <Box
-      className="state-nav"
-      sx={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: 0.5,
-        px: 0.5,
-        py: 0.25,
-        borderRadius: 1,
-        bgcolor: "rgba(255, 255, 255, 0.05)",
-      }}
-    >
-      <IconButton
-        size="small"
+    <Paper>
+      <Stack direction="row"
         sx={{
-          color: leftArrowVisible ? "inherit" : "transparent",
-          lineHeight: 1,
+          alignItems: "center",
+          justifyContent: "center",
+          py: .5,
+          borderRadius: 1,
         }}
-        onClick={() => handleClick("backward")}
       >
-        ‹
-      </IconButton>
-
-      <Tooltip title={stateName || "Unknown"}>
-        <Box
-          onClick={() => handleClick("current")}
+        {/* <IconButton
           sx={{
-            cursor: "pointer",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
+            visibility: leftArrowVisible ? undefined : "hidden",
           }}
+          onClick={() => handleClick({ type: "backward" })}
         >
-          <StateIcon stateType={mappedIconType} size={32} number={number} />
-        </Box>
-      </Tooltip>
+          <i className="fas fa-angle-left" style={iconStyle} />
+        </IconButton> */}
 
-      <IconButton
-        size="small"
-        sx={{
-          color: rightArrowVisible ? "inherit" : "transparent",
-          lineHeight: 1,
-        }}
-        onClick={() => handleClick("forward")}
-      >
-        ›
-      </IconButton>
-    </Box>
+        <IconButton
+          sx={{
+            visibility: leftArrowVisible ? undefined : "hidden",
+          }}
+          onClick={() => handleClick({ type: "first" })}
+        >
+          <i className="fas fa-angle-double-left" style={iconStyle} />
+        </IconButton>
+
+        <Stack direction="column" sx={{
+          alignItems: "center",
+        }}>
+          <Tabs
+            value={reverseStateNums[stateViewing]}
+            onChange={handleChange}
+            sx={{
+              maxWidth: "100%",
+              minHeight: 0,
+              paddingLeft: `calc(${padInvisibleLeft} * (var(--mui-spacing) + ${stateIconSize}px))`,
+              paddingRight: `calc(${padInvisibleRight} * (var(--mui-spacing) + ${stateIconSize}px))`,
+              '& .MuiTabs-indicator': {
+                transition: "none",
+              },
+            }}
+          >
+            {paginatedStates}
+          </Tabs>
+          {timer}
+        </Stack>
+
+        <IconButton
+          sx={{
+            visibility: rightArrowVisible ? undefined : "hidden",
+          }}
+          onClick={() => handleClick({ type: "current" })}
+        >
+          <i className="fas fa-angle-double-right" style={iconStyle} />
+        </IconButton>
+
+        {/* <IconButton
+          sx={{
+            visibility: rightArrowVisible ? undefined : "hidden",
+          }}
+          onClick={() => handleClick({ type: "forward" })}
+        >
+          <i className="fas fa-angle-right" style={iconStyle}  />
+        </IconButton> */}
+      </Stack>
+    </Paper>
   );
 }

--- a/react_main/src/components/gameComponents/Timer.jsx
+++ b/react_main/src/components/gameComponents/Timer.jsx
@@ -1,0 +1,196 @@
+import { useContext, useEffect, useReducer, useState } from "react";
+import ChangeHead from "components/gameComponents/ChangeHead";
+import { GameContext } from "Contexts";
+
+function formatTimerTime(time) {
+  if (time > 0) time = Math.round(time / 1000);
+  else time = 0;
+
+  const minutes = String(Math.floor(time / 60)).padStart(2, "0");
+  const seconds = String(time % 60).padStart(2, "0");
+
+  return `${minutes}:${seconds}`;
+}
+
+function useTimersReducer() {
+  return useReducer((timers, action) => {
+    var newTimers = { ...timers };
+
+    switch (action.type) {
+      case "create":
+        newTimers[action.timer.name] = {
+          delay: action.timer.delay,
+          time: 0,
+        };
+        break;
+      case "clear":
+        delete newTimers[action.name];
+        break;
+      case "update":
+        newTimers[action.name].time = action.time;
+        break;
+      case "updateAll":
+        // for (var timerName in newTimers) newTimers[timerName].time += 200;
+
+        const timer =
+          newTimers["pregameCountdown"] ||
+          newTimers["secondary"] ||
+          newTimers["main"];
+
+        if (!timer) break;
+
+        const intTime = Math.round((timer.delay - timer.time) / 1000);
+        if (intTime !== timer?.lastTickTime) {
+          if (intTime < 16 && intTime > 0) action.playAudio("tick");
+        }
+        timer.lastTickTime = intTime;
+
+        const canVegPing =
+          !timer.lastVegPingDate ||
+          new Date() - timer?.lastVegPingDate >= 10 * 1000; // note: 10 * 1000 might not work, cuz lastVegPingDate becomes null upon reset/restart anyway...
+        if (canVegPing && intTime >= 25 && intTime <= 30) {
+          action.playAudio("vegPing");
+          timer.lastVegPingDate = new Date();
+        }
+        break;
+    }
+
+    return newTimers;
+  }, {});
+}
+
+export function Timer(props) {
+  const game = useContext(GameContext);
+  const [timers, updateTimers] = useTimersReducer();
+  const [started, setStarted] = useState(null);
+  const [winners, setWinners] = useState(null);
+
+  const socket = game.socket;
+  const playAudio = game.playAudio;
+
+  useEffect(() => {
+    var timerInterval = setInterval(() => {
+      updateTimers({
+        type: "updateAll",
+        playAudio,
+      });
+    }, 200);
+
+    if (socket && socket.on) {
+      socket.on("timerInfo", (info) => {
+        if (info?.name === "vegKick") {
+          playAudio("vegPing");
+        }
+        updateTimers({
+          type: "create",
+          timer: info,
+        });
+
+        if (
+          info.name === "pregameCountdown" &&
+          Notification &&
+          Notification.permission === "granted" &&
+          !document.hasFocus()
+        ) {
+          new Notification("Your game is starting!");
+        }
+      });
+
+      socket.on("clearTimer", (name) => {
+        updateTimers({
+          type: "clear",
+          name,
+        });
+      });
+
+      socket.on("time", (info) => {
+        updateTimers({
+          type: "update",
+          name: info.name,
+          time: info.time,
+        });
+      });
+
+      socket.on("start", () => setStarted(true));
+
+      socket.on("isStarted", (isStarted) => setStarted(isStarted));
+
+      socket.on("winners", ({ groups }) => {
+        const newGroups = groups.map((group) => {
+          if (group === "Village") return "⛪ Village";
+          if (group === "Mafia") return "🔪 Mafia";
+          return group;
+        });
+        setWinners(`${newGroups.join("/")} won!`);
+      });
+    }
+
+    // cleanup
+    return () => {
+      clearInterval(timerInterval);
+    };
+  }, []);
+
+  const numPlayers = Object.values(game.players).filter((p) => !p?.left).length;
+
+  const isFilled = numPlayers === game.setup?.total;
+  const filledEmoji = isFilled ? " 🔔🔔" : "";
+  const fillingTitle = `🔪 ${numPlayers}/${game.setup?.total}${filledEmoji} Ultimafia`;
+  const ChangeHeadFilling = <ChangeHead title={fillingTitle} />;
+
+  const currentState = game.history?.states[game.history?.currentState]?.name;
+  const isFinished = currentState === "Postgame";
+
+  const mainTimer = formatTimerTime(timers?.main?.delay - timers?.main?.time);
+  const ChangeHeadInProgress = (
+    <ChangeHead title={`🔪 ${mainTimer} - ${currentState}`} />
+  );
+
+  let HeadChanges = null;
+  if (!game.review) {
+    if (isFinished) {
+      if (winners) HeadChanges = <ChangeHead title={winners} />;
+      else HeadChanges = <ChangeHead title=" Ultimafia" />;
+    } else if (started) HeadChanges = ChangeHeadInProgress;
+    else HeadChanges = ChangeHeadFilling;
+  }
+
+  var timerName;
+
+  if (!timers["pregameCountdown"] && timers["pregameWait"])
+    timerName = "pregameWait";
+  else if (game.history.currentState == -1) timerName = "pregameCountdown";
+  else if (game.history.currentState == -2) timerName = "postgame";
+  else if (timers["secondary"]) timerName = "secondary";
+  else if (timers["vegKick"]) timerName = "vegKick";
+  else if (timers["vegKickCountdown"]) timerName = "vegKickCountdown";
+  else timerName = "main";
+
+  const timer = timers[timerName];
+
+  if (game.review) return <div className="state-timer">{"Game Over"}</div>;
+  if (!timer) return <div className="state-timer"></div>;
+
+  var time = timer.delay - timer.time;
+
+  if (timers["secondary"]) {
+    // show main timer if needed
+    const mainTimer = timers["main"];
+    if (mainTimer) {
+      var mainTime = mainTimer.delay - mainTimer.time;
+      time = Math.min(time, mainTime);
+    }
+  }
+
+  time = formatTimerTime(time);
+
+  if (timerName === "vegKick") {
+    return <div className="state-timer">Kicking in {time}</div>;
+  }
+  return (
+    <>
+      {HeadChanges}
+      <div className="state-timer">{time}</div>
+    </>
+  );
+}

--- a/react_main/src/components/gameComponents/Timer.jsx
+++ b/react_main/src/components/gameComponents/Timer.jsx
@@ -27,6 +27,11 @@ function useTimersReducer() {
         delete newTimers[action.name];
         break;
       case "update":
+        if(!(action.name in newTimers)) {
+          newTimers[action.name] = {
+            time: 0,
+          };
+        }
         newTimers[action.name].time = action.time;
         break;
       case "updateAll":
@@ -168,8 +173,7 @@ export function Timer(props) {
 
   const timer = timers[timerName];
 
-  if (game.review) return <div className="state-timer">{"Game Over"}</div>;
-  if (!timer) return <div className="state-timer"></div>;
+  if (!timer || game.review) return <div className="state-timer">{"--:--"}</div>;
 
   var time = timer.delay - timer.time;
 

--- a/react_main/src/constants/themes.jsx
+++ b/react_main/src/constants/themes.jsx
@@ -77,6 +77,10 @@ const commonComponents = {
       variant: "contained",
       color: "primary",
       sx: { textTransform: "none" },
+    },
+  },
+  MuiButtonBase: {
+    defaultProps: {
       disableRipple: true,
     },
   },

--- a/react_main/src/css/form.css
+++ b/react_main/src/css/form.css
@@ -1,5 +1,5 @@
 .form {
-  align-self: flex-start;
+  /* align-self: flex-start; */
 
   display: flex;
   flex-flow: column;

--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -8,6 +8,8 @@
   height: 100%;
   width: 100%;
 
+  isolation: isolate;
+
   background-image: url("/src/images/white-diamond-dark.png");
 }
 
@@ -41,6 +43,8 @@
 
   background-color: var(--scheme-color-sec);
   border-radius: var(--mui-shape-borderRadius);
+
+  font-family: RobotoMono;
 }
 
 .game .main {
@@ -93,6 +97,7 @@
   height: calc(1em + 4 * var(--mui-spacing));
   padding: var(--mui-spacing);
   line-height: normal;
+  flex: none;
 }
 
 .game .meeting-tabs {
@@ -927,10 +932,12 @@
  */
 
 @media (max-width: 900px) {
+  .game {
+    padding: 0px !important;
+  }
+
   .game .main {
-    overflow-x: scroll;
-    scrollbar-width: none;
-    scroll-snap-type: x mandatory;
+    padding: 0px !important;
   }
 
   .game .main::-webkit-scrollbar {
@@ -946,46 +953,19 @@
   }
 
   .game .left-panel {
-    width: calc(100vw - 3 * var(--mui-spacing)) !important;
-
-    scroll-snap-align: start;
-    scroll-snap-stop: always;
+    width: 100vw !important;
   }
 
   .game .center-panel {
-    flex-basis: initial !important;
-    flex-grow: 0 !important;
-
-    width: calc(100vw - 3 * var(--mui-spacing)) !important;
-
-    scroll-snap-align: center;
-    scroll-snap-stop: always;
+    width: 100vw !important;
   }
 
   .game .right-panel {
-    width: calc(100vw - 3 * var(--mui-spacing)) !important;
-
-    scroll-snap-align: end;
-    scroll-snap-stop: always;
+    width: 100vw !important;
   }
 
   .game .message .sender {
     padding-left: 0px;
-  }
-}
-
-@media (max-width: 600px) {
-  .game .modal.settings,
-  .game .modal.first-game {
-    width: 300px;
-  }
-
-  .hide-on-mobile {
-    display: none !important;
-  }
-
-  .game .rehost-game {
-    display: none;
   }
 }
 

--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -95,6 +95,9 @@
   padding: var(--mui-spacing);
   line-height: normal;
   flex: none;
+
+  border-top-left-radius: var(--mui-shape-borderRadius);
+  border-top-right-radius: var(--mui-shape-borderRadius);
 }
 
 .game .meeting-tabs {
@@ -105,8 +108,6 @@
   gap: var(--mui-spacing);
 
   background-color: var(--scheme-color-background);
-  border-top-left-radius: var(--mui-shape-borderRadius);
-  border-top-right-radius: var(--mui-shape-borderRadius);
 }
 
 .game .tab {
@@ -933,6 +934,11 @@
     padding: 0px !important;
     background-color: var(--scheme-color) !important;
     background-image: none;
+  }
+
+  .game .title-box {
+    border-top-left-radius: unset !important;
+    border-top-right-radius: unset !important;
   }
 
   .game .main {

--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -15,23 +15,6 @@
   color: var(--theme-color-light);
 }
 
-.game .loading-page {
-  height: 100%;
-}
-
-.game .top {
-  display: flex;
-  flex-flow: row nowrap;
-  justify-content: space-between;
-}
-
-.game .game-name-wrapper {
-  display: flex;
-  justify-content: flex-start;
-  cursor: pointer;
-  margin: 0px 0px 0px var(--mui-spacing);
-}
-
 .game .game-name {
   font-size: 40px;
   font-family: var(--primaryFont); /* used to be BNoir */
@@ -44,31 +27,6 @@
   text-shadow: 2px 3px 3px #f7e4dd;
 }
 
-.game .state-wrapper {
-  display: flex;
-  flex-flow: column;
-  align-items: center;
-  justify-content: center;
-}
-
-.game .state-nav {
-  display: flex;
-  flex-flow: row nowrap;
-  align-items: center;
-  justify-content: center;
-}
-
-.game .state-nav .hist-arrow {
-  margin: 0px 10px;
-
-  font-size: 25px;
-  cursor: pointer;
-}
-
-.game .state-nav .hist-arrow.invisible {
-  visibility: hidden;
-}
-
 .game .state-name {
   min-width: 100px;
 
@@ -79,19 +37,10 @@
 }
 
 .game .state-timer {
-  height: 1.5rem;
-}
+  padding: 4px var(--mui-spacing);
 
-.game .misc-wrapper {
-  display: flex;
-  flex-flow: row nowrap;
-  align-items: center;
-
-  gap: var(--mui-spacing);
-}
-
-.game .fas {
-  font-size: medium;
+  background-color: var(--scheme-color-sec);
+  border-radius: var(--mui-shape-borderRadius);
 }
 
 .game .main {
@@ -149,6 +98,7 @@
 .game .meeting-tabs {
   display: flex;
   flex-flow: row nowrap;
+  align-items: center;
 
   gap: var(--mui-spacing);
 
@@ -160,7 +110,6 @@
 .game .tab {
   padding: 4px var(--mui-spacing);
 
-  z-index: 0;
   background-color: var(--scheme-color-background);
   border-radius: var(--mui-shape-borderRadius);
   cursor: pointer;
@@ -169,7 +118,6 @@
 .game .tab.sel {
   background-color: var(--scheme-color-sec);
   box-shadow: none;
-  z-index: 1;
 }
 
 .game .message:hover {
@@ -1019,16 +967,6 @@
 
     scroll-snap-align: end;
     scroll-snap-stop: always;
-  }
-
-  .game .top {
-    flex-flow: column !important;
-  }
-
-  .game .state-wrapper {
-    order: 3;
-    margin-top: var(--mui-spacing);
-    justify-self: center;
   }
 
   .game .message .sender {

--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -2,13 +2,10 @@
   display: flex;
   flex-flow: column;
 
-  gap: var(--mui-spacing);
   padding-top: var(--mui-spacing);
 
   height: 100%;
   width: 100%;
-
-  isolation: isolate;
 
   background-image: url("/src/images/white-diamond-dark.png");
 }
@@ -934,6 +931,8 @@
 @media (max-width: 900px) {
   .game {
     padding: 0px !important;
+    background-color: var(--scheme-color) !important;
+    background-image: none;
   }
 
   .game .main {

--- a/react_main/src/hooks/useIsPhoneDevice.jsx
+++ b/react_main/src/hooks/useIsPhoneDevice.jsx
@@ -1,7 +1,8 @@
-import { useMediaQuery } from "@mui/material";
+import { useMediaQuery, useTheme } from "@mui/material";
 
 export const useIsPhoneDevice = () => {
-  const isPhoneDevice = useMediaQuery("(max-width:700px)");
+  const theme = useTheme();
+  const isPhoneDevice = useMediaQuery(theme.breakpoints.down('md'));
 
   return isPhoneDevice;
 };

--- a/react_main/src/pages/Game/AcrotopiaGame.jsx
+++ b/react_main/src/pages/Game/AcrotopiaGame.jsx
@@ -14,11 +14,13 @@ import {
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
 import "css/gameAcrotopia.css";
 
 export default function AcrotopiaGame(props) {
   const game = useContext(GameContext);
+  const isPhoneDevice = useIsPhoneDevice();
 
   const history = game.history;
   const updateHistory = game.updateHistory;
@@ -97,46 +99,20 @@ export default function AcrotopiaGame(props) {
             <span>Acrotopia</span>
           </div>
         }
+        hideStateSwitcher
       />
       <ThreePanelLayout
+        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            <PlayerList
-              players={players}
-              history={history}
-              gameType={gameType}
-              stateViewing={stateViewing}
-              activity={game.activity}
-            />
-            <SpeechFilter
-              filters={game.speechFilters}
-              setFilters={game.setSpeechFilters}
-              stateViewing={stateViewing}
-            />
-            <SettingsMenu
-              settings={game.settings}
-              updateSettings={game.updateSettings}
-              showMenu={game.showMenu}
-              setShowMenu={game.setShowMenu}
-              stateViewing={stateViewing}
-            />
+            {game.componentFactory.playerList()}
+            {!isPhoneDevice && game.componentFactory.speechFilter()}
+            {!isPhoneDevice && game.componentFactory.settingsMenu()}
           </>
         }
         centerPanelContent={
           <>
-            <TextMeetingLayout
-              combineMessagesFromAllMeetings
-              socket={game.socket}
-              history={history}
-              updateHistory={updateHistory}
-              players={players}
-              stateViewing={stateViewing}
-              settings={game.settings}
-              filters={game.speechFilters}
-              options={game.options}
-              setup={game.setup}
-              localAudioTrack={game.localAudioTrack}
-            />
+            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
           </>
         }
         rightPanelContent={
@@ -151,7 +127,7 @@ export default function AcrotopiaGame(props) {
               history={history}
               stateViewing={stateViewing}
             />
-            {!isSpectator && <Notes stateViewing={stateViewing} />}
+            {!isPhoneDevice && game.componentFactory.notes()}
           </>
         }
       />

--- a/react_main/src/pages/Game/AcrotopiaGame.jsx
+++ b/react_main/src/pages/Game/AcrotopiaGame.jsx
@@ -92,9 +92,9 @@ export default function AcrotopiaGame(props) {
       <ThreePanelLayout
         leftPanelContent={
           <>
-            {<PlayerList />}
-            {!isPhoneDevice && <SpeechFilter />}
-            {!isPhoneDevice && <SettingsMenu />}
+            <PlayerList />
+            <SpeechFilter />
+            <SettingsMenu />
           </>
         }
         centerPanelContent={
@@ -104,11 +104,19 @@ export default function AcrotopiaGame(props) {
           <>
             <HistoryKeeper history={history} stateViewing={stateViewing} />
             <ActionList />
-            {!isPhoneDevice && <Notes />}
+            <Notes />
           </>
         }
       />
-      <MobileLayout singleState />
+      <MobileLayout
+        singleState 
+        innerRightContent={
+          <>
+            <HistoryKeeper history={history} stateViewing={stateViewing} />
+            <ActionList />
+          </>
+        }
+      />
     </>
   );
 }

--- a/react_main/src/pages/Game/AcrotopiaGame.jsx
+++ b/react_main/src/pages/Game/AcrotopiaGame.jsx
@@ -11,6 +11,7 @@ import {
   SpeechFilter,
   SettingsMenu,
   Notes,
+  MobileLayout,
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
@@ -87,50 +88,27 @@ export default function AcrotopiaGame(props) {
 
   return (
     <>
-      <TopBar
-        gameType={gameType}
-        game={game}
-        history={history}
-        stateViewing={stateViewing}
-        updateStateViewing={updateStateViewing}
-        players={players}
-        gameName={
-          <div className="game-name">
-            <span>Acrotopia</span>
-          </div>
-        }
-        hideStateSwitcher
-      />
+      <TopBar hideStateSwitcher />
       <ThreePanelLayout
-        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {game.componentFactory.playerList()}
-            {!isPhoneDevice && game.componentFactory.speechFilter()}
-            {!isPhoneDevice && game.componentFactory.settingsMenu()}
+            {<PlayerList />}
+            {!isPhoneDevice && <SpeechFilter />}
+            {!isPhoneDevice && <SettingsMenu />}
           </>
         }
         centerPanelContent={
-          <>
-            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
-          </>
+          <TextMeetingLayout combineMessagesFromAllMeetings />
         }
         rightPanelContent={
           <>
             <HistoryKeeper history={history} stateViewing={stateViewing} />
-            <ActionList
-              socket={game.socket}
-              isParticipant={game.isParticipant}
-              meetings={meetings}
-              players={players}
-              self={self}
-              history={history}
-              stateViewing={stateViewing}
-            />
-            {!isPhoneDevice && game.componentFactory.notes()}
+            <ActionList />
+            {!isPhoneDevice && <Notes />}
           </>
         }
       />
+      <MobileLayout singleState />
     </>
   );
 }

--- a/react_main/src/pages/Game/AcrotopiaGame.jsx
+++ b/react_main/src/pages/Game/AcrotopiaGame.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useEffect, useContext } from "react";
 import {
   useSocketListeners,
   ThreePanelLayout,
-  BotBar,
+  TopBar,
   TextMeetingLayout,
   ActionList,
   PlayerList,
@@ -85,7 +85,7 @@ export default function AcrotopiaGame(props) {
 
   return (
     <>
-      <BotBar
+      <TopBar
         gameType={gameType}
         game={game}
         history={history}

--- a/react_main/src/pages/Game/BattlesnakesGame.jsx
+++ b/react_main/src/pages/Game/BattlesnakesGame.jsx
@@ -61,34 +61,12 @@ function SnakeGame(props) {
 
   return (
     <>
-      <TopBar
-        gameType={gameType}
-        game={game}
-        history={history}
-        stateViewing={stateViewing}
-        updateStateViewing={updateStateViewing}
-        players={players}
-        gameName={
-          <div className="game-name">
-            <span>Battlesnakes</span>
-          </div>
-        }
-        hideStateSwitcher
-      />
+      <TopBar hideStateSwitcher />
       <ThreePanelLayout
-        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {game.componentFactory.playerList()}
-            <ActionList
-              socket={game.socket}
-              isParticipant={game.isParticipant}
-              meetings={meetings}
-              players={players}
-              self={self}
-              history={history}
-              stateViewing={stateViewing}
-            />
+            <PlayerList />
+            <ActionList />
           </>
         }
         centerPanelContent={
@@ -104,19 +82,7 @@ function SnakeGame(props) {
         }
         rightPanelContent={
           <>
-            <TextMeetingLayout
-              combineMessagesFromAllMeetings
-              socket={game.socket}
-              history={history}
-              updateHistory={updateHistory}
-              players={players}
-              stateViewing={stateViewing}
-              settings={game.settings}
-              filters={game.speechFilters}
-              options={game.options}
-              setup={game.setup}
-              localAudioTrack={game.localAudioTrack}
-            />
+            <TextMeetingLayout combineMessagesFromAllMeetings />
           </>
         }
       />

--- a/react_main/src/pages/Game/BattlesnakesGame.jsx
+++ b/react_main/src/pages/Game/BattlesnakesGame.jsx
@@ -10,12 +10,15 @@ import {
   Timer,
 } from "./Game";
 import { GameContext } from "../../Contexts";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
 import "css/gameBattlesnakes.css";
 import SnakeGameDisplay from "./SnakeGameDisplay";
 
 function SnakeGame(props) {
   const game = useContext(GameContext);
+  const isPhoneDevice = useIsPhoneDevice();
+
   const history = game.history;
   const updateHistory = game.updateHistory;
   const stateViewing = game.stateViewing;
@@ -70,17 +73,13 @@ function SnakeGame(props) {
             <span>Battlesnakes</span>
           </div>
         }
+        hideStateSwitcher
       />
       <ThreePanelLayout
+        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            <PlayerList
-              players={players}
-              history={history}
-              gameType={gameType}
-              stateViewing={stateViewing}
-              activity={game.activity}
-            />
+            {game.componentFactory.playerList()}
             <ActionList
               socket={game.socket}
               isParticipant={game.isParticipant}

--- a/react_main/src/pages/Game/BattlesnakesGame.jsx
+++ b/react_main/src/pages/Game/BattlesnakesGame.jsx
@@ -59,6 +59,13 @@ function SnakeGame(props) {
     });
   }, game.socket);
 
+  if (isPhoneDevice) {
+    // Unsupported
+    game.leaveGame();
+    alert("Battlesnakes is not presently supported on mobile devices.");
+    return <></>;
+  }
+
   return (
     <>
       <TopBar hideStateSwitcher />

--- a/react_main/src/pages/Game/BattlesnakesGame.jsx
+++ b/react_main/src/pages/Game/BattlesnakesGame.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useEffect, useContext } from "react";
 import {
   useSocketListeners,
   ThreePanelLayout,
-  BotBar,
+  TopBar,
   TextMeetingLayout,
   ActionList,
   PlayerList,
@@ -58,7 +58,7 @@ function SnakeGame(props) {
 
   return (
     <>
-      <BotBar
+      <TopBar
         gameType={gameType}
         game={game}
         history={history}

--- a/react_main/src/pages/Game/CheatGame.jsx
+++ b/react_main/src/pages/Game/CheatGame.jsx
@@ -99,46 +99,21 @@ export default function CheatGame(props) {
 
   return (
     <>
-      <TopBar
-        gameType={gameType}
-        game={game}
-        history={history}
-        stateViewing={stateViewing}
-        updateStateViewing={updateStateViewing}
-        players={players}
-        gameName={
-          <div className="game-name">
-            <span
-              style={{
-                color: history.states?.[stateViewing]?.extraInfo
-                  ?.isTheFlyingDutchman
-                  ? "#48654e"
-                  : "#8B0000",
-              }}
-            >
-              Cheat
-            </span>
-          </div>
-        }
-        hideStateSwitcher
-      />
+      <TopBar hideStateSwitcher />
       <ThreePanelLayout
-        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {history.currentState == -1 && game.componentFactory.playerList()}
+            {history.currentState == -1 && <PlayerList />}
             <LiarscardcardViewWrapper
               history={history}
               stateViewing={stateViewing}
               self={self}
             />
-            {!isPhoneDevice && game.componentFactory.settingsMenu()}
+            {!isPhoneDevice && <SettingsMenu />}
           </>
         }
         centerPanelContent={
-          <>
-            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
-          </>
+          <TextMeetingLayout combineMessagesFromAllMeetings />
         }
         rightPanelContent={
           <>
@@ -162,13 +137,6 @@ export default function CheatGame(props) {
               />
             )}
             <ActionList
-              socket={game.socket}
-              isParticipant={game.isParticipant}
-              meetings={meetings}
-              players={players}
-              self={self}
-              history={history}
-              stateViewing={stateViewing}
               title="Play your Cards!"
               style={{
                 color: history.states?.[stateViewing]?.extraInfo
@@ -177,7 +145,7 @@ export default function CheatGame(props) {
                   : undefined,
               }}
             />
-            {!isPhoneDevice && game.componentFactory.notes()}
+            {!isPhoneDevice && <Notes />}
           </>
         }
       />

--- a/react_main/src/pages/Game/CheatGame.jsx
+++ b/react_main/src/pages/Game/CheatGame.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useEffect, useContext, useState } from "react";
 import {
   useSocketListeners,
   ThreePanelLayout,
-  BotBar,
+  TopBar,
   TextMeetingLayout,
   ActionList,
   PlayerList,
@@ -102,7 +102,7 @@ export default function CheatGame(props) {
 
   return (
     <>
-      <BotBar
+      <TopBar
         gameType={gameType}
         game={game}
         history={history}

--- a/react_main/src/pages/Game/CheatGame.jsx
+++ b/react_main/src/pages/Game/CheatGame.jsx
@@ -6,6 +6,11 @@ import {
   TopBar,
   ActionList,
   OptionsList,
+  PlayerList,
+  SettingsMenu,
+  TextMeetingLayout,
+  Notes,
+  MobileLayout,
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
@@ -97,19 +102,37 @@ export default function CheatGame(props) {
     });
   }, game.socket);
 
+  const playerList = (
+    <>
+      {stateViewing < 0 && <PlayerList />}
+      <LiarscardcardViewWrapper
+        history={history}
+        stateViewing={stateViewing}
+        self={self}
+      />
+    </>
+  );
+
+  const actionsList = (
+    <ActionList
+      title="Play your Cards!"
+      style={{
+        color: history.states?.[stateViewing]?.extraInfo
+          ?.isTheFlyingDutchman
+          ? "#718E77"
+          : undefined,
+      }}
+    />
+  );
+
   return (
     <>
       <TopBar hideStateSwitcher />
       <ThreePanelLayout
         leftPanelContent={
           <>
-            {history.currentState == -1 && <PlayerList />}
-            <LiarscardcardViewWrapper
-              history={history}
-              stateViewing={stateViewing}
-              self={self}
-            />
-            {!isPhoneDevice && <SettingsMenu />}
+            {playerList}
+            <SettingsMenu />
           </>
         }
         centerPanelContent={
@@ -117,35 +140,21 @@ export default function CheatGame(props) {
         }
         rightPanelContent={
           <>
-            {history.currentState == -1 && (
-              <OptionsList
-                players={players}
-                history={history}
-                gameType={gameType}
-                gameOptions={gameOptions}
-                stateViewing={stateViewing}
-                activity={game.activity}
-              />
-            )}
-            {history.currentState != -1 && (
-              <ThePot
-                players={players}
-                history={history}
-                gameType={gameType}
-                stateViewing={stateViewing}
-                activity={game.activity}
-              />
-            )}
-            <ActionList
-              title="Play your Cards!"
-              style={{
-                color: history.states?.[stateViewing]?.extraInfo
-                  ?.isTheFlyingDutchman
-                  ? "#718E77"
-                  : undefined,
-              }}
-            />
-            {!isPhoneDevice && <Notes />}
+            <OptionsList />
+            <ThePot />
+            {actionsList}
+            <Notes />
+          </>
+        }
+      />
+      <MobileLayout
+        singleState 
+        outerLeftContent={playerList}
+        innerRightContent={
+          <>
+            <OptionsList />
+            <ThePot />
+            {actionsList}
           </>
         }
       />
@@ -153,10 +162,11 @@ export default function CheatGame(props) {
   );
 }
 
-export function ThePot(props) {
-  const history = props.history;
-  const stateViewing = props.stateViewing;
-  const self = props.self;
+export function ThePot() {
+  const game = useContext(GameContext);
+
+  const history = game.history;
+  const stateViewing = game.stateViewing;
 
   if (stateViewing < 0) return <></>;
 

--- a/react_main/src/pages/Game/CheatGame.jsx
+++ b/react_main/src/pages/Game/CheatGame.jsx
@@ -4,22 +4,19 @@ import {
   useSocketListeners,
   ThreePanelLayout,
   TopBar,
-  TextMeetingLayout,
   ActionList,
-  PlayerList,
   OptionsList,
-  Timer,
-  Notes,
-  SettingsMenu,
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
 import "css/game.css";
 import "css/gameCardGames.css";
 
 export default function CheatGame(props) {
   const game = useContext(GameContext);
+  const isPhoneDevice = useIsPhoneDevice();
 
   const history = game.history;
   const updateHistory = game.updateHistory;
@@ -126,46 +123,21 @@ export default function CheatGame(props) {
         hideStateSwitcher
       />
       <ThreePanelLayout
+        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {history.currentState == -1 && (
-              <PlayerList
-                players={players}
-                history={history}
-                gameType={gameType}
-                stateViewing={stateViewing}
-                activity={game.activity}
-              />
-            )}
+            {history.currentState == -1 && game.componentFactory.playerList()}
             <LiarscardcardViewWrapper
               history={history}
               stateViewing={stateViewing}
               self={self}
             />
-            <SettingsMenu
-              settings={game.settings}
-              updateSettings={game.updateSettings}
-              showMenu={game.showMenu}
-              setShowMenu={game.setShowMenu}
-              stateViewing={stateViewing}
-            />
+            {!isPhoneDevice && game.componentFactory.settingsMenu()}
           </>
         }
         centerPanelContent={
           <>
-            <TextMeetingLayout
-              combineMessagesFromAllMeetings
-              socket={game.socket}
-              history={history}
-              updateHistory={updateHistory}
-              players={players}
-              stateViewing={stateViewing}
-              settings={game.settings}
-              filters={game.speechFilters}
-              options={game.options}
-              setup={game.setup}
-              localAudioTrack={game.localAudioTrack}
-            />
+            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
           </>
         }
         rightPanelContent={
@@ -205,7 +177,7 @@ export default function CheatGame(props) {
                   : undefined,
               }}
             />
-            {!isSpectator && <Notes stateViewing={stateViewing} />}
+            {!isPhoneDevice && game.componentFactory.notes()}
           </>
         }
       />

--- a/react_main/src/pages/Game/ConnectFourGame.jsx
+++ b/react_main/src/pages/Game/ConnectFourGame.jsx
@@ -10,6 +10,7 @@ import {
   Timer,
   Notes,
   SettingsMenu,
+  MobileLayout,
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { Avatar } from "../User/User";
@@ -81,24 +82,29 @@ export default function ConnectFourGame(props) {
       <ThreePanelLayout
         leftPanelContent={
           <>
-            {history.currentState == -1 && <PlayerList />}
+            {history.currentState < 0 && <PlayerList />}
             <ActionList />
-            {!isPhoneDevice && <SettingsMenu />}
+            <SettingsMenu />
           </>
         }
         centerPanelContent={
           <>
-            <ConnectFourBoardWrapper
-              stateViewing={stateViewing}
-              history={history}
-              players={players}
-            />
+            <ConnectFourBoardWrapper  />
           </>
         }
         rightPanelContent={
           <>
             <TextMeetingLayout combineMessagesFromAllMeetings />
-            {!isPhoneDevice && <Notes />}
+          </>
+        }
+      />
+      <MobileLayout
+        singleState
+        centerContent={<ConnectFourBoardWrapper />}
+        innerRightContent={
+          <>
+            {stateViewing >= 0 && <TextMeetingLayout combineMessagesFromAllMeetings />}
+            <ActionList />
           </>
         }
       />
@@ -106,10 +112,14 @@ export default function ConnectFourGame(props) {
   );
 }
 
-function ConnectFourBoardWrapper(props) {
-  const stateViewing = props.stateViewing;
+function ConnectFourBoardWrapper() {
+  const game = useContext(GameContext);
 
-  if (stateViewing < 0) return <></>;
+  const players = game.players;
+  const history = game.history;
+  const stateViewing = game.stateViewing;
+
+  if (stateViewing < 0) return <TextMeetingLayout combineMessagesFromAllMeetings />;
 
   return (
     <SideMenu
@@ -118,9 +128,9 @@ function ConnectFourBoardWrapper(props) {
       content={
         <>
           <ConnectFourBoard
-            history={props.history}
+            history={history}
             stateViewing={stateViewing}
-            players={props.players}
+            players={players}
           />
         </>
       }

--- a/react_main/src/pages/Game/ConnectFourGame.jsx
+++ b/react_main/src/pages/Game/ConnectFourGame.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useEffect, useContext, useState } from "react";
 import {
   useSocketListeners,
   ThreePanelLayout,
-  BotBar,
+  TopBar,
   TextMeetingLayout,
   ActionList,
   PlayerList,
@@ -75,7 +75,7 @@ export default function ConnectFourGame(props) {
 
   return (
     <>
-      <BotBar
+      <TopBar
         gameType={gameType}
         game={game}
         history={history}

--- a/react_main/src/pages/Game/ConnectFourGame.jsx
+++ b/react_main/src/pages/Game/ConnectFourGame.jsx
@@ -14,12 +14,14 @@ import {
 import { GameContext } from "../../Contexts";
 import { Avatar } from "../User/User";
 import { SideMenu } from "./Game";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
 import "css/game.css";
 import "css/gameConnectFour.css";
 
 export default function ConnectFourGame(props) {
   const game = useContext(GameContext);
+  const isPhoneDevice = useIsPhoneDevice();
 
   const history = game.history;
   const updateHistory = game.updateHistory;
@@ -90,17 +92,10 @@ export default function ConnectFourGame(props) {
         hideStateSwitcher
       />
       <ThreePanelLayout
+        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {history.currentState == -1 && (
-              <PlayerList
-                players={players}
-                history={history}
-                gameType={gameType}
-                stateViewing={stateViewing}
-                activity={game.activity}
-              />
-            )}
+            {history.currentState == -1 && game.componentFactory.playerList()}
             <ActionList
               socket={game.socket}
               isParticipant={game.isParticipant}
@@ -110,13 +105,7 @@ export default function ConnectFourGame(props) {
               history={history}
               stateViewing={stateViewing}
             />
-            <SettingsMenu
-              settings={game.settings}
-              updateSettings={game.updateSettings}
-              showMenu={game.showMenu}
-              setShowMenu={game.setShowMenu}
-              stateViewing={stateViewing}
-            />
+            {!isPhoneDevice && game.componentFactory.settingsMenu()}
           </>
         }
         centerPanelContent={
@@ -130,20 +119,8 @@ export default function ConnectFourGame(props) {
         }
         rightPanelContent={
           <>
-            <TextMeetingLayout
-              combineMessagesFromAllMeetings
-              socket={game.socket}
-              history={history}
-              updateHistory={updateHistory}
-              players={players}
-              stateViewing={stateViewing}
-              settings={game.settings}
-              filters={game.speechFilters}
-              options={game.options}
-              setup={game.setup}
-              localAudioTrack={game.localAudioTrack}
-            />
-            {!isSpectator && <Notes stateViewing={stateViewing} />}
+            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
+            {!isPhoneDevice && game.componentFactory.notes()}
           </>
         }
       />

--- a/react_main/src/pages/Game/ConnectFourGame.jsx
+++ b/react_main/src/pages/Game/ConnectFourGame.jsx
@@ -77,35 +77,13 @@ export default function ConnectFourGame(props) {
 
   return (
     <>
-      <TopBar
-        gameType={gameType}
-        game={game}
-        history={history}
-        stateViewing={stateViewing}
-        updateStateViewing={updateStateViewing}
-        players={players}
-        gameName={
-          <div className="game-name">
-            <span>Connect Four</span>
-          </div>
-        }
-        hideStateSwitcher
-      />
+      <TopBar hideStateSwitcher />
       <ThreePanelLayout
-        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {history.currentState == -1 && game.componentFactory.playerList()}
-            <ActionList
-              socket={game.socket}
-              isParticipant={game.isParticipant}
-              meetings={meetings}
-              players={players}
-              self={self}
-              history={history}
-              stateViewing={stateViewing}
-            />
-            {!isPhoneDevice && game.componentFactory.settingsMenu()}
+            {history.currentState == -1 && <PlayerList />}
+            <ActionList />
+            {!isPhoneDevice && <SettingsMenu />}
           </>
         }
         centerPanelContent={
@@ -119,8 +97,8 @@ export default function ConnectFourGame(props) {
         }
         rightPanelContent={
           <>
-            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
-            {!isPhoneDevice && game.componentFactory.notes()}
+            <TextMeetingLayout combineMessagesFromAllMeetings />
+            {!isPhoneDevice && <Notes />}
           </>
         }
       />

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -76,6 +76,9 @@ import {
   Typography,
   useTheme,
   Grid2,
+  BottomNavigation,
+  BottomNavigationAction,
+  Paper,
 } from "@mui/material";
 import { PlayerCount } from "../Play/LobbyBrowser/PlayerCount";
 import { getSetupBackgroundColor } from "../Play/LobbyBrowser/gameRowColors.js";
@@ -150,6 +153,7 @@ function GameWrapper(props) {
   const [rehostId, setRehostId] = useState();
   const [dev, setDev] = useState(false);
   const [pingInfo, setPingInfo] = useState(null);
+  const [leaveDialogOpen, setLeaveDialogOpen] = useState(false);
 
   const playersRef = useRef();
   const selfRef = useRef();
@@ -159,9 +163,112 @@ function GameWrapper(props) {
     useAudio(settings);
   const siteInfo = useContext(SiteInfoContext);
   const errorAlert = useErrorAlert();
+  const isPhoneDevice = useIsPhoneDevice();
   const { gameId } = useParams();
+  const [selectedPanel, setSelectedPanel] = useState(isPhoneDevice ? "chat" : null);
 
   const isParticipant = !isSpectator && !props.review;
+  const currentStateObject = history.states[history.currentState];
+  const unresolvedActionCount = getUnresolvedActionCount(currentStateObject ? currentStateObject.meetings : {});
+
+  // Use this factory for components that are re-used across different gameTypes
+  const componentFactory = {
+    playerList: function() {
+      return (
+        <PlayerList
+          players={players}
+          history={history}
+          gameType={gameType}
+          stateViewing={stateViewing}
+          self={self}
+          setup={setup}
+        />
+      );
+    },
+    textMeetingLayout: function(props) {
+      return (
+        <TextMeetingLayout
+          {...props}
+          socket={socket}
+          history={history}
+          updateHistory={updateHistory}
+          players={players}
+          stateViewing={stateViewing}
+          settings={settings}
+          filters={speechFilters}
+          options={options}
+          setup={setup}
+        />
+      )
+    },
+    speechFilter: function() {
+      return (
+        <SpeechFilter
+          filters={speechFilters}
+          setFilters={setSpeechFilters}
+          stateViewing={stateViewing}
+        />
+      );
+    },
+    settingsMenu: function() {
+      return (
+        <SettingsMenu
+          settings={settings}
+          updateSettings={updateSettings}
+          stateViewing={stateViewing}
+        />
+      );
+    },
+    notes: function() {
+      return (
+        <>
+          {isParticipant && (<Notes stateViewing={stateViewing} />)}
+        </>
+      )
+    },
+    pinnedMessages: function() {
+      return (
+        <>
+          {isParticipant && <PinnedMessages />}
+        </>
+      )
+    },
+  }
+
+  function onLeaveGameClick() {
+    if (
+      history.currentState == -1 ||
+      history.currentState == -2 ||
+      finished ||
+      !isParticipant
+    ) {
+      leaveGame();
+    } else {
+      setLeaveDialogOpen(true);
+    }
+  }
+
+  function leaveGame() {
+    if (finished) siteInfo.hideAllAlerts();
+
+    if (socket.on) socket.send("leave");
+    else setLeave(true);
+
+    setLeaveDialogOpen(false);
+  }
+
+  useEffect(() => {
+    function handleKeyDown(e) {
+      if (e.key === "Escape") {
+        onLeaveGameClick();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
 
   const [persistentGameData, updatePersistentGameData] = useReducer(
     (state, action) => {
@@ -775,6 +882,15 @@ function GameWrapper(props) {
     return null;
   }
 
+  function onBottomNavigationChange(event, newValue) {
+    if(newValue === "leave") {
+      onLeaveGameClick();
+    }
+    else {
+      setSelectedPanel(newValue);
+    }
+  }
+
   if (leave === "review") return <Navigate to={`/game/${gameId}/review`} />;
   else if (leave) return <Navigate to="/play" />;
   else if (rehostId) return <Navigate to={`/game/${rehostId}`} />;
@@ -789,6 +905,7 @@ function GameWrapper(props) {
       gameId: gameId,
       socket: socket,
       review: props.review,
+      componentFactory: componentFactory,
       setup: setup,
       getSetupGameSetting: getSetupGameSetting,
       startTime: startTime,
@@ -807,8 +924,10 @@ function GameWrapper(props) {
       lastWill: lastWill,
       emojis: emojis,
       setLeave: setLeave,
+      onLeaveGameClick: onLeaveGameClick,
       finished: finished,
       settings: settings,
+      selectedPanel: selectedPanel,
       updateSettings: updateSettings,
       speechFilters: speechFilters,
       setSpeechFilters: setSpeechFilters,
@@ -838,28 +957,79 @@ function GameWrapper(props) {
     return (
       <GameContext.Provider value={gameContext}>
         <ChangeHeadPing title={pingInfo?.msg} timestamp={pingInfo?.timestamp} />
-        <Box
-          className="game no-highlight"
-          sx={{
-            backgroundColor: "background.paper",
-          }}
-        >
-          <FirstGameModal
-            showModal={showFirstGameModal}
-            setShowModal={setShowFirstGameModal}
-          />
-          {gameType === "Mafia" && <MafiaGame />}
-          {gameType === "Resistance" && <ResistanceGame />}
-          {gameType === "Jotto" && <JottoGame />}
-          {gameType === "Acrotopia" && <AcrotopiaGame />}
-          {gameType === "Secret Dictator" && <SecretDictatorGame />}
-          {gameType === "Wacky Words" && <WackyWordsGame />}
-          {gameType === "Liars Dice" && <LiarsDiceGame />}
-          {gameType === "Texas Hold Em" && <TexasHoldEmGame />}
-          {gameType === "Cheat" && <CheatGame />}
-          {gameType === "Battlesnakes" && <BattlesnakesGame />}
-          {gameType === "Connect Four" && <ConnectFourGame />}
-        </Box>
+        <Stack direction="column" sx={{
+          height: "100%",
+        }}>
+          <Box
+            className="game no-highlight"
+            sx={{
+              backgroundColor: "background.paper",
+            }}
+          >
+            <FirstGameModal
+              showModal={showFirstGameModal}
+              setShowModal={setShowFirstGameModal}
+            />
+            {gameType === "Mafia" && <MafiaGame />}
+            {gameType === "Resistance" && <ResistanceGame />}
+            {gameType === "Jotto" && <JottoGame />}
+            {gameType === "Acrotopia" && <AcrotopiaGame />}
+            {gameType === "Secret Dictator" && <SecretDictatorGame />}
+            {gameType === "Wacky Words" && <WackyWordsGame />}
+            {gameType === "Liars Dice" && <LiarsDiceGame />}
+            {gameType === "Texas Hold Em" && <TexasHoldEmGame />}
+            {gameType === "Cheat" && <CheatGame />}
+            {gameType === "Battlesnakes" && <BattlesnakesGame />}
+            {gameType === "Connect Four" && <ConnectFourGame />}
+          </Box>
+          {isPhoneDevice && (
+            <Paper elevation={3}>
+              <Divider orientation="horizontal" />
+              <BottomNavigation showLabels value={selectedPanel} onChange={onBottomNavigationChange} sx={{
+                "& > .MuiBottomNavigationAction-root": {
+                  minWidth: "unset",
+                  width: "56px",
+                }
+              }}>
+                <BottomNavigationAction label="Players" value="players" icon={<i className="fas fa-user"/>} />
+                <BottomNavigationAction label="Info" value="info" icon={<i className="fas fa-info"/>} />
+                <Stack direction="row" onClick={() => setSelectedPanel("chat")} sx={{
+                  filter: selectedPanel !== "chat" ? "grayscale(100%)" : undefined,
+                }}>
+                  <Divider orientation="vertical" flexItem />
+                  <StateSwitcher
+                    history={history}
+                    stateViewing={stateViewing}
+                    updateStateViewing={updateStateViewing}
+                    onStateNavigation={onStateNavigation}
+                    hideFastForward={isPhoneDevice}
+                  />
+                  <Divider orientation="vertical" flexItem />
+                </Stack>
+                <BottomNavigationAction label="Actions" value="actions" icon={
+                  <Badge
+                    badgeContent={unresolvedActionCount}
+                    color="primary"
+                    invisible={!isParticipant || unresolvedActionCount === 0}
+                    sx={{
+                      "& .MuiBadge-badge": {
+                        transform: "scale(1) translate(100%, -50%)",
+                      }
+                    }}
+                  >
+                    <i className="fas fa-bolt"/>
+                  </Badge>
+                }/>
+                <BottomNavigationAction label="Leave" value="leave" icon={<i className="fas fa-user"/>} />
+              </BottomNavigation>
+            </Paper>
+          )}
+        </Stack>
+        <LeaveGameDialog
+          open={leaveDialogOpen}
+          onClose={() => setLeaveDialogOpen(false)}
+          onConfirm={leaveGame}
+        />
       </GameContext.Provider>
     );
   }
@@ -881,7 +1051,6 @@ export function TopBar(props) {
   const siteInfo = useContext(SiteInfoContext);
   const hideStateSwitcher = props.hideStateSwitcher;
   const game = props.game;
-  const [leaveDialogOpen, setLeaveDialogOpen] = useState(false);
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
 
   function onTestClick() {
@@ -892,41 +1061,6 @@ export function TopBar(props) {
   function onReportClick() {
     setReportDialogOpen(true);
   }
-
-  function onLeaveGameClick() {
-    if (
-      props.history.currentState == -1 ||
-      props.history.currentState == -2 ||
-      game.finished ||
-      game.review
-    ) {
-      leaveGame();
-    } else {
-      setLeaveDialogOpen(true);
-    }
-  }
-
-  function leaveGame() {
-    if (game.finished) siteInfo.hideAllAlerts();
-
-    if (game.socket.on) game.socket.send("leave");
-    else game.setLeave(true);
-
-    setLeaveDialogOpen(false);
-  }
-
-  useEffect(() => {
-    function handleKeyDown(e) {
-      if (e.key === "Escape") {
-        onLeaveGameClick();
-      }
-    }
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [game]);
 
   function onRehostGameClick() {
     game.noLeaveRef.current = true;
@@ -972,6 +1106,11 @@ export function TopBar(props) {
       });
   }
 
+  if(isPhoneDevice && game.selectedPanel !== "info") {
+    // The top bar doubles as an info panel for mobile
+    return <></>;
+  }
+
   const logo = (
     <div style={{ flex: "1", }} key="logo">
       <Link to="/play" target="_blank" rel="noopener noreferrer">
@@ -994,129 +1133,166 @@ export function TopBar(props) {
       }}
     >
       {!hideStateSwitcher && (
-        <StateSwitcher
-          history={props.history}
-          stateViewing={props.stateViewing}
-          updateStateViewing={props.updateStateViewing}
-          onStateNavigation={game.onStateNavigation}
-        />
+        <Paper>
+          <StateSwitcher
+            history={props.history}
+            stateViewing={props.stateViewing}
+            updateStateViewing={props.updateStateViewing}
+            onStateNavigation={game.onStateNavigation}
+          />
+        </Paper>
       )}
     </Stack>
   );
 
-  const miscWrapper = (
-    <Stack direction="row" spacing={1} key="miscWrapper"
-      ref={game.scrollDownTriggerRef} 
+  const setup = game.setup ? (
+    <Setup
+      setup={game.setup}
+      backgroundColor={getSetupBackgroundColor(game.options, false)}
+    />
+  ) : <></>;
+
+  const buttonGroup = (
+    <ButtonGroup
+      variant="contained"
       sx={{
-        alignItems: "center",
-        flex: "1",
+        alignSelf: "stretch",
+        backgroundColor: theme.palette.secondary.main,
+        borderRadius: 1,
       }}
     >
-      {game.setup && (
-        <Setup
-          setup={game.setup}
-          backgroundColor={getSetupBackgroundColor(game.options, false)}
-        />
-      )}
-      <ButtonGroup
-        variant="contained"
-        sx={{
-          alignSelf: "stretch",
-          backgroundColor: theme.palette.secondary.main,
-          borderRadius: 1,
-        }}
-      >
-        {game.review && (
-          <Tooltip title="Archive">
-            <IconButton size="large" onClick={onArchiveGameClick}>
-              <img src={lore} alt="Archive" />
-            </IconButton>
-          </Tooltip>
-        )}
-
-        {!isPhoneDevice && game.dev && props.history.currentState == -1 && (
-          <Tooltip title="Fill">
-            <IconButton size="large" onClick={onTestClick}>
-              <img src={poison} alt="Fill" />
-            </IconButton>
-          </Tooltip>
-        )}
-
-        {!game.review && props.history.currentState === -2 && (
-          <Tooltip title="Rehost">
-            <IconButton size="large" onClick={onRehostGameClick}>
-              <img src={veg} alt="Rehost" />
-            </IconButton>
-          </Tooltip>
-        )}
-
-        <Tooltip title="File Report">
-          <IconButton size="large" onClick={onReportClick}>
-            <img src={system} alt="Report" />
+      {game.review && (
+        <Tooltip title="Archive">
+          <IconButton size="large" onClick={onArchiveGameClick}>
+            <img src={lore} alt="Archive" />
           </IconButton>
         </Tooltip>
-        <ReportDialog
-          open={reportDialogOpen}
-          onClose={() => setReportDialogOpen(false)}
-          prefilledArgs={{ game: gameId }}
-        />
+      )}
 
-        {isPhoneDevice ? (
-          <Tooltip title="Leave">
-            <IconButton size="large" onClick={onLeaveGameClick}>
-              <img src={exit} alt="Leave" />
-            </IconButton>
-          </Tooltip>
-        ) : (
-          <Button
-            onClick={onLeaveGameClick}
-            startIcon={<img src={exit} alt="Leave" />}
-          >
-            Leave
-          </Button>
-        )}
-      </ButtonGroup>
-      <LeaveGameDialog
-        open={leaveDialogOpen}
-        onClose={() => setLeaveDialogOpen(false)}
-        onConfirm={leaveGame}
+      {game.dev && props.history.currentState == -1 && (
+        <Tooltip title="Fill">
+          <IconButton size="large" onClick={onTestClick}>
+            <img src={poison} alt="Fill" />
+          </IconButton>
+        </Tooltip>
+      )}
+
+      {!game.review && props.history.currentState === -2 && (
+        <Tooltip title="Rehost">
+          <IconButton size="large" onClick={onRehostGameClick}>
+              <img src={veg} alt="Rehost" />
+          </IconButton>
+        </Tooltip>
+      )}
+
+      <Tooltip title="File Report">
+        <IconButton size="large" onClick={onReportClick}>
+          <img src={system} alt="Report" />
+        </IconButton>
+      </Tooltip>
+      <ReportDialog
+        open={reportDialogOpen}
+        onClose={() => setReportDialogOpen(false)}
+        prefilledArgs={{ game: gameId }}
       />
-    </Stack>
+
+      {!isPhoneDevice && (
+        <Button onClick={game.onLeaveGameClick} startIcon={<img src={exit} alt="Leave" />}>
+          Leave
+        </Button>
+      )}
+    </ButtonGroup>
   );
 
-  const flexItems = isPhoneDevice ? [
-    miscWrapper,
-    stateSwitcher,
-  ] : [
-    logo,
-    stateSwitcher,
-    miscWrapper,
-  ];
-
-  return (
-    <Stack direction={isPhoneDevice ? "column" : "row"} spacing={1} sx={{
-      px: 1,
-      alignItems: isPhoneDevice ? "stretch" : "center",
-    }}>
-      {flexItems}
-    </Stack>
-  );
+  if(!isPhoneDevice) {
+    // DESKTOP ================================================================
+    return (
+      <Stack direction="row" spacing={1} sx={{
+        px: 1,
+        alignItems: "center",
+      }}>
+        {logo}
+        {stateSwitcher}
+        <Stack direction="row" spacing={1} key="miscWrapper"
+          ref={game.scrollDownTriggerRef} 
+          sx={{
+            alignItems: "center",
+            flex: "1",
+          }}
+        >
+          {setup}
+          {buttonGroup}
+        </Stack>
+      </Stack>
+    );
+  }
+  else {
+    // MOBILE ================================================================
+    return(
+      <Stack direction="column" sx={{
+        position: "relative",
+        flex: "1",
+        bgcolor: "var(--scheme-color)",
+      }}>
+        <Stack direction="column" className="title-box" sx={{
+          justifyContent: "center",
+          bgcolor: "var(--scheme-color-background)",
+        }}>
+          <Typography>
+            Info
+          </Typography>
+        </Stack>
+        <Stack direction="column" spacing={1} sx={{
+          px: 1,
+          pt: 1,
+          alignItems: "stretch",
+          flex: "1",
+        }}>
+          <Stack direction="row" spacing={1}>
+            {logo}
+            {buttonGroup}
+          </Stack>
+          {setup}
+        </Stack>
+        <Box sx={{
+          position: "absolute",
+          bottom: "0",
+          zIndex: "1",
+          width: "100%",
+        }}>
+          {game.componentFactory.notes()}
+          {game.componentFactory.pinnedMessages()}
+          {game.componentFactory.speechFilter()}
+          {game.componentFactory.settingsMenu()}
+        </Box>
+      </Stack>
+    );
+  }
 }
 
 export function ThreePanelLayout(props) {
   const isPhoneDevice = useIsPhoneDevice();
+  const selectedPanel = props.selectedPanel || "chat";
+
+  const showLeft = (!isPhoneDevice) || (selectedPanel === "players");
+  const showCenter = (!isPhoneDevice) || (selectedPanel === "chat");
+  const showRight = (!isPhoneDevice) || (selectedPanel === "actions");
+
+  if (!showLeft && !showCenter && !showRight) {
+    return <></>;
+  }
 
   return (
     <Stack className="main" direction="row" sx={{ gap: isPhoneDevice ? 1 : 2 }}>
-      <div className="left-panel panel with-radial-gradient">
+      {showLeft && (<div className="left-panel panel with-radial-gradient">
         {props.leftPanelContent}
-      </div>
-      <div className="center-panel panel with-radial-gradient">
+      </div>)}
+      {showCenter && (<div className="center-panel panel with-radial-gradient">
         {props.centerPanelContent}
-      </div>
-      <div className="right-panel panel with-radial-gradient">
+      </div>)}
+      {showRight && (<div className="right-panel panel with-radial-gradient">
         {props.rightPanelContent}
-      </div>
+      </div>)}
     </Stack>
   );
 }
@@ -2674,6 +2850,11 @@ export function ActionList(props) {
           badgeContent={unresolvedActionCount}
           color="primary"
           invisible={!isParticipant || unresolvedActionCount === 0}
+          sx={{
+            "& .MuiBadge-badge": {
+              transform: "scale(1) translate(80%, -50%)",
+            }
+          }}
         >
           {props.title || "Actions"}
         </Badge>
@@ -3351,6 +3532,10 @@ export function LastWillEntry(props) {
     var newWill = e.target.value.slice(0, MaxWillLength);
     setLastWill(newWill);
     props.socket.send("lastWill", newWill);
+  }
+
+  if (cannotModifyLastWill) {
+    return <></>;
   }
 
   return (

--- a/react_main/src/pages/Game/GhostGame.jsx
+++ b/react_main/src/pages/Game/GhostGame.jsx
@@ -92,9 +92,9 @@ export default function GhostGame(props) {
       <ThreePanelLayout
         leftPanelContent={
           <>
-            {<PlayerList />}
-            {!isPhoneDevice && <SpeechFilter />}
-            {!isPhoneDevice && <SettingsMenu />}
+            <PlayerList />
+            <SpeechFilter />
+            <SettingsMenu />
           </>
         }
         centerPanelContent={
@@ -104,8 +104,29 @@ export default function GhostGame(props) {
           <>
             <HistoryKeeper history={history} stateViewing={stateViewing} />
             <ActionList />
-            {!isPhoneDevice && <PinnedMessages />}
-            {!isPhoneDevice && <Notes />}
+            <PinnedMessages />
+            <Notes />
+          </>
+        }
+      />
+      <MobileLayout
+        singleState
+        outerLeftContent={
+          <>
+            <PlayerList />
+            <SpeechFilter />
+          </>
+        }
+        innerRightContent={
+          <>
+            <HistoryKeeper history={history} stateViewing={stateViewing} />
+            <ActionList />
+          </>
+        }
+        additionalInfoContent={
+          <>
+            <PinnedMessages />
+            <Notes />
           </>
         }
       />

--- a/react_main/src/pages/Game/GhostGame.jsx
+++ b/react_main/src/pages/Game/GhostGame.jsx
@@ -88,48 +88,24 @@ export default function GhostGame(props) {
 
   return (
     <>
-      <TopBar
-        gameType={gameType}
-        game={game}
-        history={history}
-        stateViewing={stateViewing}
-        updateStateViewing={updateStateViewing}
-        players={players}
-        gameName={
-          <div className="game-name">
-            <span>Ghost</span>
-          </div>
-        }
-        hideStateSwitcher
-      />
+      <TopBar hideStateSwitcher />
       <ThreePanelLayout
-        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {game.componentFactory.playerList()}
-            {!isPhoneDevice && game.componentFactory.speechFilter()}
-            {!isPhoneDevice && game.componentFactory.settingsMenu()}
+            {<PlayerList />}
+            {!isPhoneDevice && <SpeechFilter />}
+            {!isPhoneDevice && <SettingsMenu />}
           </>
         }
         centerPanelContent={
-          <>
-            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
-          </>
+          <TextMeetingLayout combineMessagesFromAllMeetings />
         }
         rightPanelContent={
           <>
             <HistoryKeeper history={history} stateViewing={stateViewing} />
-            <ActionList
-              socket={game.socket}
-              isParticipant={game.isParticipant}
-              meetings={meetings}
-              players={players}
-              self={self}
-              history={history}
-              stateViewing={stateViewing}
-            />
-            {!isPhoneDevice && game.componentFactory.pinnedMessages()}
-            {!isPhoneDevice && game.componentFactory.notes()}
+            <ActionList />
+            {!isPhoneDevice && <PinnedMessages />}
+            {!isPhoneDevice && <Notes />}
           </>
         }
       />

--- a/react_main/src/pages/Game/GhostGame.jsx
+++ b/react_main/src/pages/Game/GhostGame.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useEffect, useContext } from "react";
 import {
   useSocketListeners,
   ThreePanelLayout,
-  BotBar,
+  TopBar,
   TextMeetingLayout,
   ActionList,
   PlayerList,
@@ -86,7 +86,7 @@ export default function GhostGame(props) {
 
   return (
     <>
-      <BotBar
+      <TopBar
         gameType={gameType}
         game={game}
         history={history}

--- a/react_main/src/pages/Game/GhostGame.jsx
+++ b/react_main/src/pages/Game/GhostGame.jsx
@@ -15,11 +15,13 @@ import {
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
 import "css/gameGhost.css";
 
 export default function GhostGame(props) {
   const game = useContext(GameContext);
+  const isPhoneDevice = useIsPhoneDevice();
 
   const history = game.history;
   const updateHistory = game.updateHistory;
@@ -98,46 +100,20 @@ export default function GhostGame(props) {
             <span>Ghost</span>
           </div>
         }
+        hideStateSwitcher
       />
       <ThreePanelLayout
+        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            <PlayerList
-              players={players}
-              history={history}
-              gameType={gameType}
-              stateViewing={stateViewing}
-              activity={game.activity}
-            />
-            <SpeechFilter
-              filters={game.speechFilters}
-              setFilters={game.setSpeechFilters}
-              stateViewing={stateViewing}
-            />
-            <SettingsMenu
-              settings={game.settings}
-              updateSettings={game.updateSettings}
-              showMenu={game.showMenu}
-              setShowMenu={game.setShowMenu}
-              stateViewing={stateViewing}
-            />
+            {game.componentFactory.playerList()}
+            {!isPhoneDevice && game.componentFactory.speechFilter()}
+            {!isPhoneDevice && game.componentFactory.settingsMenu()}
           </>
         }
         centerPanelContent={
           <>
-            <TextMeetingLayout
-              combineMessagesFromAllMeetings
-              socket={game.socket}
-              history={history}
-              updateHistory={updateHistory}
-              players={players}
-              stateViewing={stateViewing}
-              settings={game.settings}
-              filters={game.speechFilters}
-              options={game.options}
-              setup={game.setup}
-              localAudioTrack={game.localAudioTrack}
-            />
+            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
           </>
         }
         rightPanelContent={
@@ -152,10 +128,8 @@ export default function GhostGame(props) {
               history={history}
               stateViewing={stateViewing}
             />
-            {!game.review && !isSpectator && <PinnedMessages />}
-            {!game.review && !isSpectator && (
-              <Notes stateViewing={stateViewing} />
-            )}
+            {!isPhoneDevice && game.componentFactory.pinnedMessages()}
+            {!isPhoneDevice && game.componentFactory.notes()}
           </>
         }
       />

--- a/react_main/src/pages/Game/JottoGame.jsx
+++ b/react_main/src/pages/Game/JottoGame.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useEffect, useContext, useState } from "react";
 import {
   useSocketListeners,
   ThreePanelLayout,
-  BotBar,
+  TopBar,
   TextMeetingLayout,
   ActionList,
   PlayerList,
@@ -78,7 +78,7 @@ export default function JottoGame(props) {
 
   return (
     <>
-      <BotBar
+      <TopBar
         gameType={gameType}
         game={game}
         history={history}

--- a/react_main/src/pages/Game/JottoGame.jsx
+++ b/react_main/src/pages/Game/JottoGame.jsx
@@ -13,12 +13,14 @@ import {
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
 import "css/game.css";
 import "css/gameJotto.css";
 
 export default function JottoGame(props) {
   const game = useContext(GameContext);
+  const isPhoneDevice = useIsPhoneDevice();
 
   const history = game.history;
   const updateHistory = game.updateHistory;
@@ -93,17 +95,10 @@ export default function JottoGame(props) {
         hideStateSwitcher
       />
       <ThreePanelLayout
+        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {history.currentState == -1 && (
-              <PlayerList
-                players={players}
-                history={history}
-                gameType={gameType}
-                stateViewing={stateViewing}
-                activity={game.activity}
-              />
-            )}
+            {history.currentState == -1 && game.componentFactory.playerList()}
             <HistoryKeeper history={history} stateViewing={stateViewing} />
             <ActionList
               socket={game.socket}
@@ -114,36 +109,18 @@ export default function JottoGame(props) {
               history={history}
               stateViewing={stateViewing}
             />
-            <SettingsMenu
-              settings={game.settings}
-              updateSettings={game.updateSettings}
-              showMenu={game.showMenu}
-              setShowMenu={game.setShowMenu}
-              stateViewing={stateViewing}
-            />
+            {!isPhoneDevice && game.componentFactory.settingsMenu()}
           </>
         }
         centerPanelContent={
           <>
-            <TextMeetingLayout
-              combineMessagesFromAllMeetings
-              socket={game.socket}
-              history={history}
-              updateHistory={updateHistory}
-              players={players}
-              stateViewing={stateViewing}
-              settings={game.settings}
-              filters={game.speechFilters}
-              options={game.options}
-              setup={game.setup}
-              localAudioTrack={game.localAudioTrack}
-            />
+            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
           </>
         }
         rightPanelContent={
           <>
             <JottoCheatSheetWrapper stateViewing={stateViewing} />
-            {!isSpectator && <Notes stateViewing={stateViewing} />}
+            {!isPhoneDevice && game.componentFactory.notes()}
           </>
         }
       />

--- a/react_main/src/pages/Game/JottoGame.jsx
+++ b/react_main/src/pages/Game/JottoGame.jsx
@@ -103,16 +103,16 @@ export default function JottoGame(props) {
       />
       <MobileLayout
         singleState
-        outerLeftContent={
-          <>
-            {history.currentState == -1 && <PlayerList />}
-            <HistoryKeeper history={history} stateViewing={stateViewing} />
-          </>
-        }
         innerRightContent={
           <>
-            <JottoCheatSheetWrapper stateViewing={stateViewing} />
+            <HistoryKeeper history={history} stateViewing={stateViewing} />
             <ActionList />
+          </>
+        }
+        additionalInfoContent={
+          <>
+            <JottoCheatSheetWrapper stateViewing={stateViewing} />
+            <Notes />
           </>
         }
       />

--- a/react_main/src/pages/Game/JottoGame.jsx
+++ b/react_main/src/pages/Game/JottoGame.jsx
@@ -10,6 +10,7 @@ import {
   Timer,
   Notes,
   SettingsMenu,
+  MobileLayout,
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
@@ -80,47 +81,38 @@ export default function JottoGame(props) {
 
   return (
     <>
-      <TopBar
-        gameType={gameType}
-        game={game}
-        history={history}
-        stateViewing={stateViewing}
-        updateStateViewing={updateStateViewing}
-        players={players}
-        gameName={
-          <div className="game-name">
-            <span>Jotto</span>
-          </div>
-        }
-        hideStateSwitcher
-      />
+      <TopBar hideStateSwitcher />
       <ThreePanelLayout
-        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {history.currentState == -1 && game.componentFactory.playerList()}
+            {history.currentState == -1 && <PlayerList />}
             <HistoryKeeper history={history} stateViewing={stateViewing} />
-            <ActionList
-              socket={game.socket}
-              isParticipant={game.isParticipant}
-              meetings={meetings}
-              players={players}
-              self={self}
-              history={history}
-              stateViewing={stateViewing}
-            />
-            {!isPhoneDevice && game.componentFactory.settingsMenu()}
+            <ActionList />
+            <SettingsMenu />
           </>
         }
         centerPanelContent={
-          <>
-            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
-          </>
+          <TextMeetingLayout combineMessagesFromAllMeetings />
         }
         rightPanelContent={
           <>
             <JottoCheatSheetWrapper stateViewing={stateViewing} />
-            {!isPhoneDevice && game.componentFactory.notes()}
+            <Notes />
+          </>
+        }
+      />
+      <MobileLayout
+        singleState
+        outerLeftContent={
+          <>
+            {history.currentState == -1 && <PlayerList />}
+            <HistoryKeeper history={history} stateViewing={stateViewing} />
+          </>
+        }
+        innerRightContent={
+          <>
+            <JottoCheatSheetWrapper stateViewing={stateViewing} />
+            <ActionList />
           </>
         }
       />

--- a/react_main/src/pages/Game/LiarsDiceGame.jsx
+++ b/react_main/src/pages/Game/LiarsDiceGame.jsx
@@ -91,46 +91,21 @@ export default function LiarsDiceGame(props) {
 
   return (
     <>
-      <TopBar
-        gameType={gameType}
-        game={game}
-        history={history}
-        stateViewing={stateViewing}
-        updateStateViewing={updateStateViewing}
-        players={players}
-        gameName={
-          <div className="game-name">
-            <span
-              style={{
-                color: history.states?.[stateViewing]?.extraInfo
-                  ?.isTheFlyingDutchman
-                  ? "#48654e"
-                  : "#8B0000",
-              }}
-            >
-              Liars Dice
-            </span>
-          </div>
-        }
-        hideStateSwitcher
-      />
+      <TopBar hideStateSwitcher />
       <ThreePanelLayout
-        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {history.currentState == -1 && game.componentFactory.playerList()}
+            {history.currentState == -1 && <PlayerList />}
             <LiarsDiceDiceViewWrapper
               history={history}
               stateViewing={stateViewing}
               self={self}
             />
-            {!isPhoneDevice && game.componentFactory.settingsMenu()}
+            {!isPhoneDevice && <SettingsMenu />}
           </>
         }
         centerPanelContent={
-          <>
-            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
-          </>
+          <TextMeetingLayout combineMessagesFromAllMeetings />
         }
         rightPanelContent={
           <>
@@ -145,13 +120,6 @@ export default function LiarsDiceGame(props) {
               />
             )}
             <ActionList
-              socket={game.socket}
-              isParticipant={game.isParticipant}
-              meetings={meetings}
-              players={players}
-              self={self}
-              history={history}
-              stateViewing={stateViewing}
               title="Make A Bid!"
               style={{
                 color: history.states?.[stateViewing]?.extraInfo
@@ -160,7 +128,7 @@ export default function LiarsDiceGame(props) {
                   : undefined,
               }}
             />
-            {!isPhoneDevice && game.componentFactory.notes()}
+            {!isPhoneDevice && <Notes />}
           </>
         }
       />

--- a/react_main/src/pages/Game/LiarsDiceGame.jsx
+++ b/react_main/src/pages/Game/LiarsDiceGame.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useEffect, useContext, useState } from "react";
 import {
   useSocketListeners,
   ThreePanelLayout,
-  BotBar,
+  TopBar,
   TextMeetingLayout,
   ActionList,
   PlayerList,
@@ -89,7 +89,7 @@ export default function LiarsDiceGame(props) {
 
   return (
     <>
-      <BotBar
+      <TopBar
         gameType={gameType}
         game={game}
         history={history}

--- a/react_main/src/pages/Game/LiarsDiceGame.jsx
+++ b/react_main/src/pages/Game/LiarsDiceGame.jsx
@@ -14,12 +14,14 @@ import {
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
 import "css/game.css";
 import "css/gameLiarsDice.css";
 
 export default function LiarsDiceGame(props) {
   const game = useContext(GameContext);
+  const isPhoneDevice = useIsPhoneDevice();
 
   const history = game.history;
   const updateHistory = game.updateHistory;
@@ -113,46 +115,21 @@ export default function LiarsDiceGame(props) {
         hideStateSwitcher
       />
       <ThreePanelLayout
+        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {history.currentState == -1 && (
-              <PlayerList
-                players={players}
-                history={history}
-                gameType={gameType}
-                stateViewing={stateViewing}
-                activity={game.activity}
-              />
-            )}
+            {history.currentState == -1 && game.componentFactory.playerList()}
             <LiarsDiceDiceViewWrapper
               history={history}
               stateViewing={stateViewing}
               self={self}
             />
-            <SettingsMenu
-              settings={game.settings}
-              updateSettings={game.updateSettings}
-              showMenu={game.showMenu}
-              setShowMenu={game.setShowMenu}
-              stateViewing={stateViewing}
-            />
+            {!isPhoneDevice && game.componentFactory.settingsMenu()}
           </>
         }
         centerPanelContent={
           <>
-            <TextMeetingLayout
-              combineMessagesFromAllMeetings
-              socket={game.socket}
-              history={history}
-              updateHistory={updateHistory}
-              players={players}
-              stateViewing={stateViewing}
-              settings={game.settings}
-              filters={game.speechFilters}
-              options={game.options}
-              setup={game.setup}
-              localAudioTrack={game.localAudioTrack}
-            />
+            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
           </>
         }
         rightPanelContent={
@@ -183,7 +160,7 @@ export default function LiarsDiceGame(props) {
                   : undefined,
               }}
             />
-            {!isSpectator && <Notes stateViewing={stateViewing} />}
+            {!isPhoneDevice && game.componentFactory.notes()}
           </>
         }
       />

--- a/react_main/src/pages/Game/LiarsDiceGame.jsx
+++ b/react_main/src/pages/Game/LiarsDiceGame.jsx
@@ -11,6 +11,8 @@ import {
   Timer,
   Notes,
   SettingsMenu,
+  MobileLayout,
+  SpeechFilter,
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
@@ -89,19 +91,37 @@ export default function LiarsDiceGame(props) {
     });
   }, game.socket);
 
+  const playerList = (
+    <>
+      {stateViewing < 0 && <PlayerList />}
+      <LiarsDiceDiceViewWrapper
+        history={history}
+        stateViewing={stateViewing}
+        self={self}
+      />
+    </>
+  );
+
+  const actionList = (
+    <ActionList
+      title="Make A Bid!"
+      style={{
+        color: history.states?.[stateViewing]?.extraInfo
+          ?.isTheFlyingDutchman
+          ? "#718E77"
+          : undefined,
+      }}
+    />
+  );
+
   return (
     <>
       <TopBar hideStateSwitcher />
       <ThreePanelLayout
         leftPanelContent={
           <>
-            {history.currentState == -1 && <PlayerList />}
-            <LiarsDiceDiceViewWrapper
-              history={history}
-              stateViewing={stateViewing}
-              self={self}
-            />
-            {!isPhoneDevice && <SettingsMenu />}
+            {playerList}
+            <SettingsMenu />
           </>
         }
         centerPanelContent={
@@ -109,26 +129,28 @@ export default function LiarsDiceGame(props) {
         }
         rightPanelContent={
           <>
-            {history.currentState == -1 && (
-              <OptionsList
-                players={players}
-                history={history}
-                gameType={gameType}
-                gameOptions={gameOptions}
-                stateViewing={stateViewing}
-                activity={game.activity}
-              />
-            )}
-            <ActionList
-              title="Make A Bid!"
-              style={{
-                color: history.states?.[stateViewing]?.extraInfo
-                  ?.isTheFlyingDutchman
-                  ? "#718E77"
-                  : undefined,
-              }}
-            />
-            {!isPhoneDevice && <Notes />}
+            <OptionsList />
+            {actionList}
+            <Notes />
+          </>
+        }
+      />
+      <MobileLayout
+        singleState
+        outerLeftContent={
+          <>
+            {playerList}
+          </>
+        }
+        innerRightContent={
+          <>
+            <OptionsList />
+            {actionList}
+          </>
+        }
+        additionalInfoContent={
+          <>
+            <Notes />
           </>
         }
       />

--- a/react_main/src/pages/Game/MafiaGame.jsx
+++ b/react_main/src/pages/Game/MafiaGame.jsx
@@ -14,6 +14,7 @@ import {
   SettingsMenu,
   Notes,
   PinnedMessages,
+  MobileLayout,
 } from "./Game";
 import { GameContext, SiteInfoContext } from "../../Contexts";
 import { SideMenu } from "./Game";
@@ -486,9 +487,9 @@ export default function MafiaGame() {
       <ThreePanelLayout
         leftPanelContent={
           <>
-            {<PlayerList />}
-            {!isPhoneDevice && <SpeechFilter />}
-            {!isPhoneDevice && <SettingsMenu />}
+            <PlayerList />
+            <SpeechFilter />
+            <SettingsMenu />
           </>
         }
         centerPanelContent={
@@ -496,22 +497,33 @@ export default function MafiaGame() {
         }
         rightPanelContent={
           <>
-            {<HistoryKeeper history={history} stateViewing={stateViewing} />}
+            <HistoryKeeper history={history} stateViewing={stateViewing} />
             <ActionList />
-            {!game.review &&
-              !isSpectator &&
-              history.currentState >= 0 &&
-              game.getSetupGameSetting("Last Wills") && (
-                <LastWillEntry
-                  lastWill={game.lastWill}
-                  cannotModifyLastWill={history.states[
-                    history.currentState
-                  ].name.startsWith("Day")}
-                  socket={game.socket}
-                />
-              )}
-            {!isPhoneDevice && <PinnedMessages />}
-            {!isPhoneDevice && <Notes />}
+            <LastWillEntry />
+            <PinnedMessages />
+            <Notes />
+          </>
+        }
+      />
+      <MobileLayout
+        singleState
+        outerLeftContent={
+          <>
+            <PlayerList />
+            <SpeechFilter />
+          </>
+        }
+        innerRightContent={
+          <>
+            <HistoryKeeper history={history} stateViewing={stateViewing} />
+            <ActionList />
+            <LastWillEntry />
+          </>
+        }
+        additionalInfoContent={
+          <>
+            <PinnedMessages />
+            <Notes />
           </>
         }
       />

--- a/react_main/src/pages/Game/MafiaGame.jsx
+++ b/react_main/src/pages/Game/MafiaGame.jsx
@@ -4,7 +4,7 @@ import {
   useSocketListeners,
   // useStateViewingReducer,
   ThreePanelLayout,
-  BotBar,
+  TopBar,
   TextMeetingLayout,
   getUnresolvedActionCount,
   ActionList,
@@ -481,7 +481,7 @@ export default function MafiaGame() {
 
   return (
     <>
-      <BotBar
+      <TopBar
         gameType={gameType}
         game={game}
         history={history}
@@ -577,7 +577,7 @@ function HistoryKeeper(props) {
 
   const extraInfo = history.states[stateViewing].extraInfo;
 
-  if (extraInfo.showGameInfo != true) {
+  if (!extraInfo || extraInfo.showGameInfo !== true) {
     return <></>;
   }
 

--- a/react_main/src/pages/Game/MafiaGame.jsx
+++ b/react_main/src/pages/Game/MafiaGame.jsx
@@ -6,7 +6,6 @@ import {
   ThreePanelLayout,
   TopBar,
   TextMeetingLayout,
-  getUnresolvedActionCount,
   ActionList,
   PlayerList,
   LastWillEntry,
@@ -483,41 +482,22 @@ export default function MafiaGame() {
 
   return (
     <>
-      <TopBar
-        gameType={gameType}
-        game={game}
-        history={history}
-        stateViewing={stateViewing}
-        updateStateViewing={updateStateViewing}
-        players={players}
-        gameName={<div className="game-name">Mafia</div>}
-      />
+      <TopBar />
       <ThreePanelLayout
-        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {game.componentFactory.playerList()}
-            {!isPhoneDevice && game.componentFactory.speechFilter()}
-            {!isPhoneDevice && game.componentFactory.settingsMenu()}
+            {<PlayerList />}
+            {!isPhoneDevice && <SpeechFilter />}
+            {!isPhoneDevice && <SettingsMenu />}
           </>
         }
         centerPanelContent={
-          <>
-            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: false})}
-          </>
+          <TextMeetingLayout />
         }
         rightPanelContent={
           <>
             {<HistoryKeeper history={history} stateViewing={stateViewing} />}
-            <ActionList
-              socket={game.socket}
-              isParticipant={game.isParticipant}
-              meetings={meetings}
-              players={players}
-              self={self}
-              history={history}
-              stateViewing={stateViewing}
-            />
+            <ActionList />
             {!game.review &&
               !isSpectator &&
               history.currentState >= 0 &&
@@ -530,8 +510,8 @@ export default function MafiaGame() {
                   socket={game.socket}
                 />
               )}
-            {!isPhoneDevice && game.componentFactory.pinnedMessages()}
-            {!isPhoneDevice && game.componentFactory.notes()}
+            {!isPhoneDevice && <PinnedMessages />}
+            {!isPhoneDevice && <Notes />}
           </>
         }
       />

--- a/react_main/src/pages/Game/MafiaGame.jsx
+++ b/react_main/src/pages/Game/MafiaGame.jsx
@@ -18,10 +18,12 @@ import {
 } from "./Game";
 import { GameContext, SiteInfoContext } from "../../Contexts";
 import { SideMenu } from "./Game";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
 export default function MafiaGame() {
   const game = useContext(GameContext);
   const siteInfo = useContext(SiteInfoContext);
+  const isPhoneDevice = useIsPhoneDevice();
 
   const history = game.history;
   const updateHistory = game.updateHistory;
@@ -491,47 +493,17 @@ export default function MafiaGame() {
         gameName={<div className="game-name">Mafia</div>}
       />
       <ThreePanelLayout
+        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            <PlayerList
-              players={players}
-              history={history}
-              gameType={gameType}
-              stateViewing={stateViewing}
-              self={self}
-              activity={game.activity}
-              setup={game.setup}
-            />
-            <SpeechFilter
-              filters={game.speechFilters}
-              setFilters={game.setSpeechFilters}
-              stateViewing={stateViewing}
-            />
-            <SettingsMenu
-              settings={game.settings}
-              updateSettings={game.updateSettings}
-              showMenu={game.showMenu}
-              setShowMenu={game.setShowMenu}
-              stateViewing={stateViewing}
-            />
+            {game.componentFactory.playerList()}
+            {!isPhoneDevice && game.componentFactory.speechFilter()}
+            {!isPhoneDevice && game.componentFactory.settingsMenu()}
           </>
         }
         centerPanelContent={
           <>
-            <TextMeetingLayout
-              socket={game.socket}
-              history={history}
-              updateHistory={updateHistory}
-              players={players}
-              stateViewing={stateViewing}
-              settings={game.settings}
-              filters={game.speechFilters}
-              review={game.review}
-              options={game.options}
-              setup={game.setup}
-              setTyping={game.setTyping}
-              localAudioTrack={game.localAudioTrack}
-            />
+            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: false})}
           </>
         }
         rightPanelContent={
@@ -558,10 +530,8 @@ export default function MafiaGame() {
                   socket={game.socket}
                 />
               )}
-            {!game.review && !isSpectator && <PinnedMessages />}
-            {!game.review && !isSpectator && (
-              <Notes stateViewing={stateViewing} />
-            )}
+            {!isPhoneDevice && game.componentFactory.pinnedMessages()}
+            {!isPhoneDevice && game.componentFactory.notes()}
           </>
         }
       />

--- a/react_main/src/pages/Game/ResistanceGame.jsx
+++ b/react_main/src/pages/Game/ResistanceGame.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useEffect, useContext } from "react";
 import {
   useSocketListeners,
   ThreePanelLayout,
-  BotBar,
+  TopBar,
   TextMeetingLayout,
   ActionList,
   PlayerList,
@@ -86,7 +86,7 @@ export default function ResistanceGame(props) {
 
   return (
     <>
-      <BotBar
+      <TopBar
         gameType={gameType}
         game={game}
         history={history}

--- a/react_main/src/pages/Game/ResistanceGame.jsx
+++ b/react_main/src/pages/Game/ResistanceGame.jsx
@@ -88,28 +88,17 @@ export default function ResistanceGame(props) {
 
   return (
     <>
-      <TopBar
-        gameType={gameType}
-        game={game}
-        history={history}
-        stateViewing={stateViewing}
-        updateStateViewing={updateStateViewing}
-        players={players}
-        gameName={<div className="game-name">Resistance</div>}
-      />
+      <TopBar />
       <ThreePanelLayout
-        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {game.componentFactory.playerList()}
-            {!isPhoneDevice && game.componentFactory.speechFilter()}
-            {!isPhoneDevice && game.componentFactory.settingsMenu()}
+            {<PlayerList />}
+            {!isPhoneDevice && <SpeechFilter />}
+            {!isPhoneDevice && <SettingsMenu />}
           </>
         }
         centerPanelContent={
-          <>
-            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: false})}
-          </>
+          <TextMeetingLayout />
         }
         rightPanelContent={
           <>
@@ -118,17 +107,9 @@ export default function ResistanceGame(props) {
               history={history}
               stateViewing={stateViewing}
             />
-            <ActionList
-              socket={game.socket}
-              isParticipant={game.isParticipant}
-              meetings={meetings}
-              players={players}
-              self={self}
-              history={history}
-              stateViewing={stateViewing}
-            />
-            {!isPhoneDevice && game.componentFactory.pinnedMessages()}
-            {!isPhoneDevice && game.componentFactory.notes()}
+            <ActionList />
+            {!isPhoneDevice && <PinnedMessages />}
+            {!isPhoneDevice && <Notes />}
           </>
         }
       />

--- a/react_main/src/pages/Game/ResistanceGame.jsx
+++ b/react_main/src/pages/Game/ResistanceGame.jsx
@@ -17,9 +17,11 @@ import { GameContext } from "../../Contexts";
 
 import { SideMenu } from "./Game";
 import "css/game.css";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
 export default function ResistanceGame(props) {
   const game = useContext(GameContext);
+  const isPhoneDevice = useIsPhoneDevice();
 
   const history = game.history;
   const updateHistory = game.updateHistory;
@@ -96,43 +98,17 @@ export default function ResistanceGame(props) {
         gameName={<div className="game-name">Resistance</div>}
       />
       <ThreePanelLayout
+        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            <PlayerList
-              players={players}
-              history={history}
-              gameType={gameType}
-              stateViewing={stateViewing}
-              activity={game.activity}
-            />
-            <SpeechFilter
-              filters={game.speechFilters}
-              setFilters={game.setSpeechFilters}
-              stateViewing={stateViewing}
-            />
-            <SettingsMenu
-              settings={game.settings}
-              updateSettings={game.updateSettings}
-              showMenu={game.showMenu}
-              setShowMenu={game.setShowMenu}
-              stateViewing={stateViewing}
-            />
+            {game.componentFactory.playerList()}
+            {!isPhoneDevice && game.componentFactory.speechFilter()}
+            {!isPhoneDevice && game.componentFactory.settingsMenu()}
           </>
         }
         centerPanelContent={
           <>
-            <TextMeetingLayout
-              socket={game.socket}
-              history={history}
-              updateHistory={updateHistory}
-              players={players}
-              stateViewing={stateViewing}
-              settings={game.settings}
-              filters={game.speechFilters}
-              options={game.options}
-              setup={game.setup}
-              localAudioTrack={game.localAudioTrack}
-            />
+            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: false})}
           </>
         }
         rightPanelContent={
@@ -151,10 +127,8 @@ export default function ResistanceGame(props) {
               history={history}
               stateViewing={stateViewing}
             />
-            {!game.review && !isSpectator && <PinnedMessages />}
-            {!game.review && !isSpectator && (
-              <Notes stateViewing={stateViewing} />
-            )}
+            {!isPhoneDevice && game.componentFactory.pinnedMessages()}
+            {!isPhoneDevice && game.componentFactory.notes()}
           </>
         }
       />

--- a/react_main/src/pages/Game/ResistanceGame.jsx
+++ b/react_main/src/pages/Game/ResistanceGame.jsx
@@ -12,6 +12,7 @@ import {
   SettingsMenu,
   Notes,
   PinnedMessages,
+  MobileLayout,
 } from "./Game";
 import { GameContext } from "../../Contexts";
 
@@ -92,9 +93,9 @@ export default function ResistanceGame(props) {
       <ThreePanelLayout
         leftPanelContent={
           <>
-            {<PlayerList />}
-            {!isPhoneDevice && <SpeechFilter />}
-            {!isPhoneDevice && <SettingsMenu />}
+            <PlayerList />
+            <SpeechFilter />
+            <SettingsMenu />
           </>
         }
         centerPanelContent={
@@ -102,14 +103,31 @@ export default function ResistanceGame(props) {
         }
         rightPanelContent={
           <>
-            <ScoreKeeper
-              numMissions={game.setup.numMissions}
-              history={history}
-              stateViewing={stateViewing}
-            />
+            <ScoreKeeper />
             <ActionList />
-            {!isPhoneDevice && <PinnedMessages />}
-            {!isPhoneDevice && <Notes />}
+            <PinnedMessages />
+            <Notes />
+          </>
+        }
+      />
+      <MobileLayout
+        singleState
+        outerLeftContent={
+          <>
+            <PlayerList />
+            <SpeechFilter />
+          </>
+        }
+        innerRightContent={
+          <>
+            <ScoreKeeper />
+            <ActionList />
+          </>
+        }
+        additionalInfoContent={
+          <>
+            <PinnedMessages />
+            <Notes />
           </>
         }
       />
@@ -117,11 +135,12 @@ export default function ResistanceGame(props) {
   );
 }
 
-function ScoreKeeper(props) {
-  const numMissions = props.numMissions;
-  const history = props.history;
+function ScoreKeeper() {
+  const game = useContext(GameContext);
 
-  const stateViewing = props.stateViewing;
+  const numMissions = game.numMissions;
+  const history = game.history;
+  const stateViewing = game.stateViewing;
 
   if (stateViewing < 0) return <></>;
 

--- a/react_main/src/pages/Game/SecretDictatorGame.jsx
+++ b/react_main/src/pages/Game/SecretDictatorGame.jsx
@@ -94,47 +94,23 @@ export default function SecretDictatorGame(props) {
 
   return (
     <>
-      <TopBar
-        gameType={gameType}
-        game={game}
-        history={history}
-        stateViewing={stateViewing}
-        updateStateViewing={updateStateViewing}
-        players={players}
-        gameName={
-          <div className="game-name">
-            <span>Secret Dictator</span>
-          </div>
-        }
-        hideStateSwitcher
-      />
+      <TopBar hideStateSwitcher />
       <ThreePanelLayout
-        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {game.componentFactory.playerList()}
-            {!isPhoneDevice && game.componentFactory.speechFilter()}
-            {!isPhoneDevice && game.componentFactory.settingsMenu()}
+            {<PlayerList />}
+            {!isPhoneDevice && <SpeechFilter />}
+            {!isPhoneDevice && <SettingsMenu />}
           </>
         }
         centerPanelContent={
-          <>
-            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
-          </>
+          <TextMeetingLayout combineMessagesFromAllMeetings />
         }
         rightPanelContent={
           <>
             <HistoryKeeper history={history} stateViewing={stateViewing} />
-            <ActionList
-              socket={game.socket}
-              isParticipant={game.isParticipant}
-              meetings={meetings}
-              players={players}
-              self={self}
-              history={history}
-              stateViewing={stateViewing}
-            />
-            {!isPhoneDevice && game.componentFactory.notes()}
+            <ActionList />
+            {!isPhoneDevice && <Notes />}
           </>
         }
       />

--- a/react_main/src/pages/Game/SecretDictatorGame.jsx
+++ b/react_main/src/pages/Game/SecretDictatorGame.jsx
@@ -11,6 +11,8 @@ import {
   SpeechFilter,
   SettingsMenu,
   Notes,
+  PinnedMessages,
+  MobileLayout,
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
@@ -98,9 +100,9 @@ export default function SecretDictatorGame(props) {
       <ThreePanelLayout
         leftPanelContent={
           <>
-            {<PlayerList />}
-            {!isPhoneDevice && <SpeechFilter />}
-            {!isPhoneDevice && <SettingsMenu />}
+            <PlayerList />
+            <SpeechFilter />
+            <SettingsMenu />
           </>
         }
         centerPanelContent={
@@ -110,7 +112,29 @@ export default function SecretDictatorGame(props) {
           <>
             <HistoryKeeper history={history} stateViewing={stateViewing} />
             <ActionList />
-            {!isPhoneDevice && <Notes />}
+            <PinnedMessages />
+            <Notes />
+          </>
+        }
+      />
+      <MobileLayout
+        singleState
+        outerLeftContent={
+          <>
+            <PlayerList />
+            <SpeechFilter />
+          </>
+        }
+        innerRightContent={
+          <>
+            <HistoryKeeper history={history} stateViewing={stateViewing} />
+            <ActionList />
+          </>
+        }
+        additionalInfoContent={
+          <>
+            <PinnedMessages />
+            <Notes />
           </>
         }
       />

--- a/react_main/src/pages/Game/SecretDictatorGame.jsx
+++ b/react_main/src/pages/Game/SecretDictatorGame.jsx
@@ -14,12 +14,14 @@ import {
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
 import "css/game.css";
 import "css/gameSecretDictator.css";
 
 export default function SecretDictatorGame(props) {
   const game = useContext(GameContext);
+  const isPhoneDevice = useIsPhoneDevice();
 
   const history = game.history;
   const updateHistory = game.updateHistory;
@@ -104,46 +106,20 @@ export default function SecretDictatorGame(props) {
             <span>Secret Dictator</span>
           </div>
         }
+        hideStateSwitcher
       />
       <ThreePanelLayout
+        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            <PlayerList
-              players={players}
-              history={history}
-              gameType={gameType}
-              stateViewing={stateViewing}
-              activity={game.activity}
-            />
-            <SpeechFilter
-              filters={game.speechFilters}
-              setFilters={game.setSpeechFilters}
-              stateViewing={stateViewing}
-            />
-            <SettingsMenu
-              settings={game.settings}
-              updateSettings={game.updateSettings}
-              showMenu={game.showMenu}
-              setShowMenu={game.setShowMenu}
-              stateViewing={stateViewing}
-            />
+            {game.componentFactory.playerList()}
+            {!isPhoneDevice && game.componentFactory.speechFilter()}
+            {!isPhoneDevice && game.componentFactory.settingsMenu()}
           </>
         }
         centerPanelContent={
           <>
-            <TextMeetingLayout
-              combineMessagesFromAllMeetings
-              socket={game.socket}
-              history={history}
-              updateHistory={updateHistory}
-              players={players}
-              stateViewing={stateViewing}
-              settings={game.settings}
-              filters={game.speechFilters}
-              options={game.options}
-              setup={game.setup}
-              localAudioTrack={game.localAudioTrack}
-            />
+            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
           </>
         }
         rightPanelContent={
@@ -158,7 +134,7 @@ export default function SecretDictatorGame(props) {
               history={history}
               stateViewing={stateViewing}
             />
-            {!isSpectator && <Notes stateViewing={stateViewing} />}
+            {!isPhoneDevice && game.componentFactory.notes()}
           </>
         }
       />

--- a/react_main/src/pages/Game/SecretDictatorGame.jsx
+++ b/react_main/src/pages/Game/SecretDictatorGame.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useEffect, useContext } from "react";
 import {
   useSocketListeners,
   ThreePanelLayout,
-  BotBar,
+  TopBar,
   TextMeetingLayout,
   ActionList,
   PlayerList,
@@ -92,7 +92,7 @@ export default function SecretDictatorGame(props) {
 
   return (
     <>
-      <BotBar
+      <TopBar
         gameType={gameType}
         game={game}
         history={history}

--- a/react_main/src/pages/Game/TexasHoldEmGame.jsx
+++ b/react_main/src/pages/Game/TexasHoldEmGame.jsx
@@ -14,12 +14,14 @@ import {
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
 import "css/game.css";
 import "css/gameCardGames.css";
 
 export default function TexasHoldEmGame(props) {
   const game = useContext(GameContext);
+  const isPhoneDevice = useIsPhoneDevice();
 
   const history = game.history;
   const updateHistory = game.updateHistory;
@@ -126,46 +128,21 @@ export default function TexasHoldEmGame(props) {
         hideStateSwitcher
       />
       <ThreePanelLayout
+        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {history.currentState == -1 && (
-              <PlayerList
-                players={players}
-                history={history}
-                gameType={gameType}
-                stateViewing={stateViewing}
-                activity={game.activity}
-              />
-            )}
+            {history.currentState == -1 && game.componentFactory.playerList()}
             <LiarscardcardViewWrapper
               history={history}
               stateViewing={stateViewing}
               self={self}
             />
-            <SettingsMenu
-              settings={game.settings}
-              updateSettings={game.updateSettings}
-              showMenu={game.showMenu}
-              setShowMenu={game.setShowMenu}
-              stateViewing={stateViewing}
-            />
+            {!isPhoneDevice && game.componentFactory.settingsMenu()}
           </>
         }
         centerPanelContent={
           <>
-            <TextMeetingLayout
-              combineMessagesFromAllMeetings
-              socket={game.socket}
-              history={history}
-              updateHistory={updateHistory}
-              players={players}
-              stateViewing={stateViewing}
-              settings={game.settings}
-              filters={game.speechFilters}
-              options={game.options}
-              setup={game.setup}
-              localAudioTrack={game.localAudioTrack}
-            />
+            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
           </>
         }
         rightPanelContent={
@@ -212,7 +189,7 @@ export default function TexasHoldEmGame(props) {
                   : undefined,
               }}
             />
-            {!isSpectator && <Notes stateViewing={stateViewing} />}
+            {!isPhoneDevice && game.componentFactory.notes()}
           </>
         }
       />

--- a/react_main/src/pages/Game/TexasHoldEmGame.jsx
+++ b/react_main/src/pages/Game/TexasHoldEmGame.jsx
@@ -11,6 +11,7 @@ import {
   Timer,
   Notes,
   SettingsMenu,
+  MobileLayout,
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
@@ -102,19 +103,33 @@ export default function TexasHoldEmGame(props) {
     });
   }, game.socket);
 
+  const playerList = (
+    <>
+      {history.currentState < 0 && <PlayerList />}
+      <LiarscardcardViewWrapper />
+    </>
+  );
+
+  const actionList = (
+    <ActionList
+      title="Make A Bid!"
+      style={{
+        color: history.states?.[stateViewing]?.extraInfo
+          ?.isTheFlyingDutchman
+          ? "#718E77"
+          : undefined,
+      }}
+    />
+  );
+
   return (
     <>
       <TopBar hideStateSwitcher />
       <ThreePanelLayout
         leftPanelContent={
           <>
-            {history.currentState == -1 && <PlayerList />}
-            <LiarscardcardViewWrapper
-              history={history}
-              stateViewing={stateViewing}
-              self={self}
-            />
-            {!isPhoneDevice && <SettingsMenu />}
+            {playerList}
+            <SettingsMenu />
           </>
         }
         centerPanelContent={
@@ -122,42 +137,23 @@ export default function TexasHoldEmGame(props) {
         }
         rightPanelContent={
           <>
-            {history.currentState == -1 && (
-              <OptionsList
-                players={players}
-                history={history}
-                gameType={gameType}
-                gameOptions={gameOptions}
-                stateViewing={stateViewing}
-                activity={game.activity}
-              />
-            )}
-            {history.currentState != -1 && (
-              <ThePot
-                players={players}
-                history={history}
-                gameType={gameType}
-                stateViewing={stateViewing}
-                activity={game.activity}
-              />
-            )}
-            {history.currentState != -1 && (
-              <CommunityCards
-                history={history}
-                stateViewing={stateViewing}
-                self={self}
-              />
-            )}
-            <ActionList
-              title="Make A Bid!"
-              style={{
-                color: history.states?.[stateViewing]?.extraInfo
-                  ?.isTheFlyingDutchman
-                  ? "#718E77"
-                  : undefined,
-              }}
-            />
-            {!isPhoneDevice && <Notes />}
+            <OptionsList />
+            <ThePot />
+            <CommunityCards />
+            {actionList}
+            <Notes />
+          </>
+        }
+      />
+      <MobileLayout
+        singleState 
+        outerLeftContent={playerList}
+        innerRightContent={
+          <>
+            <OptionsList />
+            <ThePot />
+            <CommunityCards />
+            {actionList}
           </>
         }
       />
@@ -165,10 +161,11 @@ export default function TexasHoldEmGame(props) {
   );
 }
 
-export function ThePot(props) {
-  const history = props.history;
-  const stateViewing = props.stateViewing;
-  const self = props.self;
+export function ThePot() {
+  const game = useContext(GameContext);
+
+  const history = game.history;
+  const stateViewing = game.stateViewing;
 
   if (stateViewing < 0) return <></>;
 
@@ -195,10 +192,11 @@ export function ThePot(props) {
   );
 }
 
-function CommunityCards(props) {
-  const history = props.history;
-  const stateViewing = props.stateViewing;
-  const self = props.self;
+function CommunityCards() {
+  const game = useContext(GameContext);
+
+  const history = game.history;
+  const stateViewing = game.stateViewing;
 
   if (stateViewing < 0) return <></>;
 
@@ -224,10 +222,12 @@ function CommunityCards(props) {
   );
 }
 
-function LiarscardcardViewWrapper(props) {
-  const history = props.history;
-  const stateViewing = props.stateViewing;
-  const self = props.self;
+function LiarscardcardViewWrapper() {
+  const game = useContext(GameContext);
+
+  const history = game.history;
+  const stateViewing = game.stateViewing;
+  const self = game.self;
 
   if (stateViewing < 0) return <></>;
 

--- a/react_main/src/pages/Game/TexasHoldEmGame.jsx
+++ b/react_main/src/pages/Game/TexasHoldEmGame.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useEffect, useContext, useState } from "react";
 import {
   useSocketListeners,
   ThreePanelLayout,
-  BotBar,
+  TopBar,
   TextMeetingLayout,
   ActionList,
   PlayerList,
@@ -102,7 +102,7 @@ export default function TexasHoldEmGame(props) {
 
   return (
     <>
-      <BotBar
+      <TopBar
         gameType={gameType}
         game={game}
         history={history}

--- a/react_main/src/pages/Game/TexasHoldEmGame.jsx
+++ b/react_main/src/pages/Game/TexasHoldEmGame.jsx
@@ -104,46 +104,21 @@ export default function TexasHoldEmGame(props) {
 
   return (
     <>
-      <TopBar
-        gameType={gameType}
-        game={game}
-        history={history}
-        stateViewing={stateViewing}
-        updateStateViewing={updateStateViewing}
-        players={players}
-        gameName={
-          <div className="game-name">
-            <span
-              style={{
-                color: history.states?.[stateViewing]?.extraInfo
-                  ?.isTheFlyingDutchman
-                  ? "#48654e"
-                  : "#8B0000",
-              }}
-            >
-              Texas Hold Em
-            </span>
-          </div>
-        }
-        hideStateSwitcher
-      />
+      <TopBar hideStateSwitcher />
       <ThreePanelLayout
-        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {history.currentState == -1 && game.componentFactory.playerList()}
+            {history.currentState == -1 && <PlayerList />}
             <LiarscardcardViewWrapper
               history={history}
               stateViewing={stateViewing}
               self={self}
             />
-            {!isPhoneDevice && game.componentFactory.settingsMenu()}
+            {!isPhoneDevice && <SettingsMenu />}
           </>
         }
         centerPanelContent={
-          <>
-            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
-          </>
+          <TextMeetingLayout combineMessagesFromAllMeetings />
         }
         rightPanelContent={
           <>
@@ -174,13 +149,6 @@ export default function TexasHoldEmGame(props) {
               />
             )}
             <ActionList
-              socket={game.socket}
-              isParticipant={game.isParticipant}
-              meetings={meetings}
-              players={players}
-              self={self}
-              history={history}
-              stateViewing={stateViewing}
               title="Make A Bid!"
               style={{
                 color: history.states?.[stateViewing]?.extraInfo
@@ -189,7 +157,7 @@ export default function TexasHoldEmGame(props) {
                   : undefined,
               }}
             />
-            {!isPhoneDevice && game.componentFactory.notes()}
+            {!isPhoneDevice && <Notes />}
           </>
         }
       />

--- a/react_main/src/pages/Game/WackyWordsGame.jsx
+++ b/react_main/src/pages/Game/WackyWordsGame.jsx
@@ -87,27 +87,14 @@ export default function WackyWordsGame(props) {
 
   return (
     <>
-      <TopBar
-        gameType={gameType}
-        game={game}
-        history={history}
-        stateViewing={stateViewing}
-        updateStateViewing={updateStateViewing}
-        players={players}
-        gameName={
-          <div className="game-name">
-            <span>Wacky Words</span>
-          </div>
-        }
-        hideStateSwitcher
-      />
+      <TopBar hideStateSwitcher />
       <ThreePanelLayout
         selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {game.componentFactory.playerList()}
-            {!isPhoneDevice && game.componentFactory.speechFilter()}
-            {!isPhoneDevice && game.componentFactory.settingsMenu()}
+            {<PlayerList />}
+            {!isPhoneDevice && <SpeechFilter />}
+            {!isPhoneDevice && <SettingsMenu />}
           </>
         }
         centerPanelContent={
@@ -127,7 +114,7 @@ export default function WackyWordsGame(props) {
               history={history}
               stateViewing={stateViewing}
             />
-            {!isPhoneDevice && game.componentFactory.notes()}
+            {!isPhoneDevice && <Notes />}
           </>
         }
       />

--- a/react_main/src/pages/Game/WackyWordsGame.jsx
+++ b/react_main/src/pages/Game/WackyWordsGame.jsx
@@ -14,11 +14,13 @@ import {
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
 import "css/gameAcrotopia.css";
 
 export default function WackyWordsGame(props) {
   const game = useContext(GameContext);
+  const isPhoneDevice = useIsPhoneDevice();
 
   const history = game.history;
   const updateHistory = game.updateHistory;
@@ -97,46 +99,20 @@ export default function WackyWordsGame(props) {
             <span>Wacky Words</span>
           </div>
         }
+        hideStateSwitcher
       />
       <ThreePanelLayout
+        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            <PlayerList
-              players={players}
-              history={history}
-              gameType={gameType}
-              stateViewing={stateViewing}
-              activity={game.activity}
-            />
-            <SpeechFilter
-              filters={game.speechFilters}
-              setFilters={game.setSpeechFilters}
-              stateViewing={stateViewing}
-            />
-            <SettingsMenu
-              settings={game.settings}
-              updateSettings={game.updateSettings}
-              showMenu={game.showMenu}
-              setShowMenu={game.setShowMenu}
-              stateViewing={stateViewing}
-            />
+            {game.componentFactory.playerList()}
+            {!isPhoneDevice && game.componentFactory.speechFilter()}
+            {!isPhoneDevice && game.componentFactory.settingsMenu()}
           </>
         }
         centerPanelContent={
           <>
-            <TextMeetingLayout
-              combineMessagesFromAllMeetings
-              socket={game.socket}
-              history={history}
-              updateHistory={updateHistory}
-              players={players}
-              stateViewing={stateViewing}
-              settings={game.settings}
-              filters={game.speechFilters}
-              options={game.options}
-              setup={game.setup}
-              localAudioTrack={game.localAudioTrack}
-            />
+            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
           </>
         }
         rightPanelContent={
@@ -151,7 +127,7 @@ export default function WackyWordsGame(props) {
               history={history}
               stateViewing={stateViewing}
             />
-            {!isSpectator && <Notes stateViewing={stateViewing} />}
+            {!isPhoneDevice && game.componentFactory.notes()}
           </>
         }
       />

--- a/react_main/src/pages/Game/WackyWordsGame.jsx
+++ b/react_main/src/pages/Game/WackyWordsGame.jsx
@@ -11,6 +11,7 @@ import {
   SpeechFilter,
   SettingsMenu,
   Notes,
+  MobileLayout,
 } from "./Game";
 import { GameContext } from "../../Contexts";
 import { SideMenu } from "./Game";
@@ -89,32 +90,32 @@ export default function WackyWordsGame(props) {
     <>
       <TopBar hideStateSwitcher />
       <ThreePanelLayout
-        selectedPanel={game.selectedPanel}
         leftPanelContent={
           <>
-            {<PlayerList />}
-            {!isPhoneDevice && <SpeechFilter />}
-            {!isPhoneDevice && <SettingsMenu />}
+            <PlayerList />
+            <SpeechFilter />
+            <SettingsMenu />
           </>
         }
         centerPanelContent={
           <>
-            {game.componentFactory.textMeetingLayout({combineMessagesFromAllMeetings: true})}
+            <TextMeetingLayout combineMessagesFromAllMeetings />
           </>
         }
         rightPanelContent={
           <>
             <HistoryKeeper history={history} stateViewing={stateViewing} />
-            <ActionList
-              socket={game.socket}
-              isParticipant={game.isParticipant}
-              meetings={meetings}
-              players={players}
-              self={self}
-              history={history}
-              stateViewing={stateViewing}
-            />
-            {!isPhoneDevice && <Notes />}
+            <ActionList />
+            <Notes />
+          </>
+        }
+      />
+      <MobileLayout
+        singleState
+        innerRightContent={
+          <>
+            <HistoryKeeper history={history} stateViewing={stateViewing} />
+            <ActionList />
           </>
         }
       />

--- a/react_main/src/pages/Game/WackyWordsGame.jsx
+++ b/react_main/src/pages/Game/WackyWordsGame.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useEffect, useContext } from "react";
 import {
   useSocketListeners,
   ThreePanelLayout,
-  BotBar,
+  TopBar,
   TextMeetingLayout,
   ActionList,
   PlayerList,
@@ -85,7 +85,7 @@ export default function WackyWordsGame(props) {
 
   return (
     <>
-      <BotBar
+      <TopBar
         gameType={gameType}
         game={game}
         history={history}

--- a/react_main/src/pages/Learn/Setup/SetupPage.jsx
+++ b/react_main/src/pages/Learn/Setup/SetupPage.jsx
@@ -122,8 +122,7 @@ function getEloPieStats(factionRatings) {
 export function SetupPage() {
   const user = useContext(UserContext);
   const siteInfo = useContext(SiteInfoContext);
-  const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const isPhoneDevice = useIsPhoneDevice();
   const navigate = useNavigate();
   const errorAlert = useErrorAlert();
   const { setupId } = useParams();
@@ -260,7 +259,7 @@ export function SetupPage() {
     }
   };
 
-  const iconSize = isSmallScreen ? 30 : 60;
+  const iconSize = isPhoneDevice ? 30 : 60;
 
   return (
     <Stack
@@ -304,7 +303,7 @@ export function SetupPage() {
               <IconButton
                 onClick={() => setIshostGameDialogueOpen(true)}
                 sx={{
-                  p: isSmallScreen ? 1 : 2,
+                  p: isPhoneDevice ? 1 : 2,
                   borderRadius: "50%",
                   backgroundColor: setupHeadingIconColor,
                 }}
@@ -314,7 +313,7 @@ export function SetupPage() {
               <Typography
                 variant="h2"
                 sx={{
-                  ml: isSmallScreen ? "auto !important" : undefined,
+                  ml: isPhoneDevice ? "auto !important" : undefined,
                 }}
               >
                 {setup.name}
@@ -343,7 +342,7 @@ export function SetupPage() {
           {setup.creator && (
             <Grid item xs={12} md={2}>
               <Stack
-                direction={isSmallScreen ? "row" : "column"}
+                direction={isPhoneDevice ? "row" : "column"}
                 sx={{
                   alignItems: "center",
                 }}
@@ -351,7 +350,7 @@ export function SetupPage() {
                 <Typography
                   variant="italicRelation"
                   sx={{
-                    ml: isSmallScreen ? "auto" : 1,
+                    ml: isPhoneDevice ? "auto" : 1,
                   }}
                 >
                   {"Created by"}

--- a/react_main/src/pages/Play/CreateSetup/CreateBrowser.jsx
+++ b/react_main/src/pages/Play/CreateSetup/CreateBrowser.jsx
@@ -35,6 +35,7 @@ import { useErrorAlert } from "components/Alerts";
 
 import "css/createSetup.css";
 import { NewLoading } from "pages/Welcome/NewLoading";
+import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 
 function StickyStateViewer(props) {
   const isSticky = props.isSticky;

--- a/react_main/src/pages/Play/CreateSetup/CreateBrowser.jsx
+++ b/react_main/src/pages/Play/CreateSetup/CreateBrowser.jsx
@@ -42,7 +42,7 @@ function StickyStateViewer(props) {
   const isVertical = props.isVertical;
 
   const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const isPhoneDevice = useIsPhoneDevice();
 
   return (
     <Stack
@@ -64,7 +64,7 @@ function StickyStateViewer(props) {
       >
         <Stack
           direction={isVertical ? "column" : "row"}
-          spacing={isSmallScreen ? 0.5 : 1}
+          spacing={isPhoneDevice ? 0.5 : 1}
           sx={{
             justifyContent: isVertical ? "stretch" : "center",
             alignItems: "stretch",
@@ -118,7 +118,7 @@ export default function CreateSetup(props) {
   const params = new URLSearchParams(location.search);
   const siteInfo = useContext(SiteInfoContext);
   const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const isPhoneDevice = useIsPhoneDevice();
 
   const gameTypeSettings = siteInfo.gamesettings[gameType];
 
@@ -555,7 +555,7 @@ export default function CreateSetup(props) {
                 <i
                   className="fa-times fas"
                   aria-hidden="true"
-                  style={{ fontSize: isSmallScreen ? "0.5em" : "1em" }}
+                  style={{ fontSize: isPhoneDevice ? "0.5em" : "1em" }}
                 />
               </Button>
             )}
@@ -602,16 +602,16 @@ export default function CreateSetup(props) {
   if (params.get("edit") && !editing) return <NewLoading small />;
 
   const innerContentHeight = "calc(1.2 * 2em)";
-  const iconLength = isSmallScreen ? "1em" : innerContentHeight;
+  const iconLength = isPhoneDevice ? "1em" : innerContentHeight;
 
   const selectedModifiers = [
-    ...Array(isSmallScreen ? modifiers.length : MaxModifiersPerRole).keys(),
+    ...Array(isPhoneDevice ? modifiers.length : MaxModifiersPerRole).keys(),
   ].map((i) => {
     const m = modifiers[i];
     return (
       <Grid2
         size={1}
-        sx={{ width: isSmallScreen ? "100%" : undefined }}
+        sx={{ width: isPhoneDevice ? "100%" : undefined }}
         key={i}
       >
         <RoleCell
@@ -653,12 +653,12 @@ export default function CreateSetup(props) {
         <StickyStateViewer
           isSticky={modifiers.length > 0}
           title="Selected Modifiers"
-          isVertical={isSmallScreen}
+          isVertical={isPhoneDevice}
         >
           <Grid2
             container
             columns={MaxModifiersPerRole}
-            direction={isSmallScreen ? "column" : "row"}
+            direction={isPhoneDevice ? "column" : "row"}
             spacing={1}
             sx={{ flexGrow: "1", width: "100%" }}
           >
@@ -777,7 +777,7 @@ export default function CreateSetup(props) {
       </Stack>
       <Paper sx={{ p: 1 }}>
         {user.loggedIn && (
-          <Stack direction={isSmallScreen ? "column" : "row"}>
+          <Stack direction={isPhoneDevice ? "column" : "row"}>
             <Form
               fields={formFields}
               onChange={updateFormFields}

--- a/react_main/src/pages/Play/LobbyBrowser/PlayerCount.jsx
+++ b/react_main/src/pages/Play/LobbyBrowser/PlayerCount.jsx
@@ -2,6 +2,8 @@ import React, { useContext, useRef } from "react";
 import { Box, Popover, Stack, Typography } from "@mui/material";
 import { usePopover } from "components/Popover";
 
+import "css/join.css";
+
 export const PlayerCount = (props) => {
   const game = props.game;
   const numSlotsTotal = game.setup.total;

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -94,14 +94,12 @@ export default function Profile() {
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
   const [currentUserLove, setCurrentUserLove] = useState({});
 
-  const theme = useTheme();
   const user = useContext(UserContext);
   const siteInfo = useContext(SiteInfoContext);
   const navigate = useNavigate();
   const errorAlert = useErrorAlert();
   const { userId } = useParams();
   const isPhoneDevice = useIsPhoneDevice();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md")); // This is for the mui breakpoint
 
   const isSelf = userId === user.id;
   const isBlocked = !isSelf && user.blockedUsers.indexOf(userId) !== -1;
@@ -709,12 +707,12 @@ export default function Profile() {
       />
     ));
 
-  const avatarUpliftPx = !banner ? 0 : isSmallScreen ? 38 : 58;
+  const avatarUpliftPx = !banner ? 0 : isPhoneDevice ? 38 : 58;
   const avatarPaddingPx = !banner
-    ? isSmallScreen
+    ? isPhoneDevice
       ? 60
       : 100
-    : isSmallScreen
+    : isPhoneDevice
     ? 22
     : 50;
 
@@ -736,8 +734,8 @@ export default function Profile() {
         >
           {!bustCache && (
             <Avatar
-              mediumlarge={isSmallScreen}
-              large={!isSmallScreen}
+              mediumlarge={isPhoneDevice}
+              large={!isPhoneDevice}
               id={userId}
               hasImage={avatar}
               bustCache={bustCache}
@@ -807,8 +805,8 @@ export default function Profile() {
             }}
           >
             <Stack
-              direction={isSmallScreen ? "row" : "column"}
-              spacing={isSmallScreen ? 1 : 0}
+              direction={isPhoneDevice ? "row" : "column"}
+              spacing={isPhoneDevice ? 1 : 0}
               sx={{
                 mb: 1,
                 height: "100%",
@@ -828,7 +826,7 @@ export default function Profile() {
     </Grid>
   );
 
-  const aviGridItems = isSmallScreen ? (
+  const aviGridItems = isPhoneDevice ? (
     <>
       {nameBox}
       {inLoveBox}
@@ -933,7 +931,7 @@ export default function Profile() {
                 )}
               </div>
             </div>
-            {!isSmallScreen && (
+            {!isPhoneDevice && (
               <Box
                 sx={{
                   mt: "16px !important",
@@ -1153,7 +1151,7 @@ export default function Profile() {
             )}
           </Stack>
         </Grid>
-        {isSmallScreen && (
+        {isPhoneDevice && (
           <Grid item xs={12} sx={{ mt: 1 }}>
             <Comments fullWidth location={userId} />
           </Grid>


### PR DESCRIPTION
- Refactors to how components are organized for various game type UIs
- Refactored many components to useContext(GameContext) because there was no performance hit to not doing that
- Added ghost, admiral game state icons
- Added state switcher that has "pagination"
- Added mobile bottom navigation bar
- Moved timer into chat panel
- Disabled ripples everywhere across MUI
- Tweaked top bar to be a flex container
- Fixed PlayerCount not rendering correctly
- Fixed rendered aspect ratio of halloween spider