### PR TITLE
Changed self deletion to not get rid of as many fields

### DIFF
--- a/react_main/src/hooks/useSnackbar.jsx
+++ b/react_main/src/hooks/useSnackbar.jsx
@@ -44,6 +44,12 @@ export const useSnackbar = () => {
       "error"
     );
   };
+  const popUserDeleted = () => {
+    popSnackbar(
+      "Your user is deleted. To restore your account, contact a site administrator.",
+      "error"
+    );
+  };
 
   const SnackbarWrapped = (
     <Snackbar
@@ -69,6 +75,7 @@ export const useSnackbar = () => {
     popTooManyLoginAttempts,
     popLoginFailed,
     popSiteBanned,
+    popUserDeleted,
     SnackbarWrapped,
   };
 };

--- a/react_main/src/pages/Welcome/LoginDialog.jsx
+++ b/react_main/src/pages/Welcome/LoginDialog.jsx
@@ -87,6 +87,11 @@ export const LoginDialog = ({ open, setOpen }) => {
               setLoading(false);
               return;
             }
+            if (data.deleted) {
+              snackbarHook.popUserDeleted();
+              setLoading(false);
+              return;
+            }
           } catch (parseErr) {
             // Not a site-ban error, continue with regular error handling
           }
@@ -138,6 +143,11 @@ export const LoginDialog = ({ open, setOpen }) => {
                 : err.response.data;
             if (data.siteBanned) {
               snackbarHook.popSiteBanned(data.banExpires);
+              setLoading(false);
+              return;
+            }
+            if (data.deleted) {
+              snackbarHook.popUserDeleted();
               setLoading(false);
               return;
             }

--- a/react_main/src/pages/Welcome/Welcome.jsx
+++ b/react_main/src/pages/Welcome/Welcome.jsx
@@ -66,6 +66,11 @@ export const Welcome = () => {
                   setIsLoading(false);
                   return;
                 }
+                if (data.deleted) {
+                  snackbarHook.popUserDeleted();
+                  setLoading(false);
+                  return;
+                }
               } catch (parseErr) {
                 // Not a site-ban error, continue with regular error handling
               }


### PR DESCRIPTION
- Self deletion no longer unsets a ton of fields from the user's record. Friends, lovers, vanity urls, notifications, and group memberships are still deleted.
- Friends and lovers are now properly fully deleted for self-deleted users, this should prevent new [deleted] users from appearing in friends list (old occurrences of this will still be visible)
- Added error notification if you try to sign into your deleted account