### PR TITLE
Fixed wacky win prediction for faction elo

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -3000,7 +3000,11 @@ module.exports = class Game {
           alignment === "Village" ||
           alignment === "Mafia" ||
           alignment === "Cult";
-        const factionName = alignmentIsFaction ? alignment : roleName;
+        let factionName = alignmentIsFaction ? alignment : roleName;
+        if (factionName === "Traitor") {
+          // I'm hardcoding this sorry not sorry
+          factionName = "Mafia";
+        }
         memberFactions[playerId] = factionName;
 
         if (factionWinnerFractions[factionName] === undefined) {
@@ -3037,18 +3041,21 @@ module.exports = class Game {
       // In edge cases, such as members of a faction being converted then losing to their starting faction, this number will be somewhere in between
       const factionScores = factionNames.map((factionName) => {
         const factionWinnerFraction = factionWinnerFractions[factionName];
-        return (
+        return Math.floor(1, 
           factionWinnerFraction.winnerCount /
           factionWinnerFraction.originalCount
         );
       });
 
       // library code time
-      const predictions = predictWin(factionsToBeRated);
-      const ratedFactions = rate(factionsToBeRated, {
+      const options = {
         model: bradleyTerryFull,
+        beta: constants.defaultSkillRatingSigma * 4,
+      };
+      const predictions = predictWin(factionsToBeRated, options);
+      const ratedFactions = rate(factionsToBeRated, {
         score: factionScores,
-        beta: constants.defaultSkillRatingSigma / 4,
+        ...options,
       });
 
       /* Notes:

--- a/data/constants.js
+++ b/data/constants.js
@@ -352,7 +352,8 @@ module.exports = {
   leavePenaltyDurationMillis: 259200000,
 
   minimumGamesForRanked: 5,
-  minimumPointsForCompetitive: 1000,
+  minimumPointsForCompetitive: 150,
+  //minimumPointsForCompetitive: 1000,
 
   // See: https://www.npmjs.com/package/openskill
   defaultSkillRatingMu: 750,

--- a/modules/redis.js
+++ b/modules/redis.js
@@ -704,7 +704,7 @@ async function _getCompRoundInfo(seasonNumber = null, roundNumber = null) {
       points: userStanding.points,
     };
   });
-  roundInfo.standings.sort((a, b) => b.ranking - a.ranking);
+  roundInfo.standings.sort((a, b) => a.ranking - b.ranking);
 
   // Help clients know when the next thing is going to happen
   if (roundInfo.round) {

--- a/react_main/src/pages/Fame/Competitive.jsx
+++ b/react_main/src/pages/Fame/Competitive.jsx
@@ -126,7 +126,7 @@ function Overview({ roundInfo }) {
           <Typography variant="h3" gutterBottom>
             Round {roundInfo.round.number} top 10 players
           </Typography>
-          {roundInfo.standings.map((roundStanding) => {
+          {roundInfo.standings.slice(0, 10).map((roundStanding) => {
             const userId = roundStanding.userId;
             const user = roundInfo.users[userId].user;
             const points = roundInfo.users[userId].points;

--- a/routes/game.js
+++ b/routes/game.js
@@ -20,13 +20,6 @@ async function userCanPlayCompetitive(userId) {
     return "You cannot play competitive games because your Gold Hearts are depleted.";
   }
 
-  if (
-    userId &&
-    !(await routeUtils.verifyPermission(userId, "playCompetitive"))
-  ) {
-    return "You have not been approved for competitive games. Please message an admin for assistance.";
-  }
-
   return null;
 }
 

--- a/test/openskill-playground.js
+++ b/test/openskill-playground.js
@@ -1,0 +1,136 @@
+const { ordinal, rating, rate, predictWin } = require("openskill");
+const { bradleyTerryFull, thurstoneMostellerFull, plackettLuce } = require("openskill/models");
+
+const toMap = (obj) => new Map(Object.entries(obj));
+
+const defaultScenario = {
+  name: "myScenario",
+  sequence: [],
+  pointsNominalAmount: 60,
+  defaultSkillRatingMu: 750,
+  defaultSkillRatingSigma: 250,
+  options: {
+    model: plackettLuce,
+    beta: 1000,
+  },
+}
+
+const fiveMafiaWins = [
+  toMap({ "Mafia": 1, "Village": 0, }),
+  toMap({ "Mafia": 1, "Village": 0, }),
+  toMap({ "Mafia": 1, "Village": 0, }),
+  toMap({ "Mafia": 1, "Village": 0, }),
+  toMap({ "Mafia": 1, "Village": 0, }),
+];
+
+const fiveVillageWins = [
+  toMap({ "Mafia": 0, "Village": 1, }),
+  toMap({ "Mafia": 0, "Village": 1, }),
+  toMap({ "Mafia": 0, "Village": 1, }),
+  toMap({ "Mafia": 0, "Village": 1, }),
+  toMap({ "Mafia": 0, "Village": 1, }),
+];
+
+const village33winrate = [
+  ...fiveMafiaWins,
+  ...fiveMafiaWins,
+  ...fiveVillageWins,
+];
+
+// Use a "true" winrate of 33% for village
+let scenario1 = {...defaultScenario};
+scenario1.sequence = [
+  ...village33winrate,
+  ...village33winrate,
+  ...village33winrate,
+  ...village33winrate,
+  ...village33winrate,
+  ...village33winrate,
+  ...village33winrate,
+  ...village33winrate,
+  ...village33winrate,
+  ...village33winrate,
+];
+
+runScenario(scenario1);
+
+function runScenario(scenario) {
+  let factionRatingsState = [];
+
+  for (let j = 0; j < scenario.sequence.length; j++) {
+    console.log(`====================================== GAME ${j}`);
+    const factionScores = scenario.sequence[j];
+
+    // default the group ratings to an empty array if not yet exists
+    const factionsToBeRated = new Map(
+      factionRatingsState.map((factionRating) => [
+        factionRating.factionName,
+        factionRating.skillRating,
+      ])
+    );
+
+    for (const factionName of factionScores.keys()) {
+      const factionRating = factionsToBeRated.get(factionName);
+
+      // Default initialize the faction rating for the setup if it doesn't yet exist
+      if (factionRating === undefined) {
+        factionsToBeRated.set(factionName, rating({
+          mu: scenario.defaultSkillRatingMu,
+          sigma: scenario.defaultSkillRatingSigma,
+        }));
+      }
+    }
+
+    const factionNames = [...factionsToBeRated.keys()];
+
+    const factionsToBeRatedRaw = factionNames.map(factionName => [factionsToBeRated.get(factionName)]);
+    const factionScoresRaw = factionNames.map(factionName => factionScores.get(factionName));
+
+    // library code time
+    const predictions = predictWin(factionsToBeRatedRaw, scenario.options);
+    const ratedFactions = rate(factionsToBeRatedRaw, {
+      score: factionScoresRaw,
+      ...scenario.options
+    });
+
+    // Transform the results from the rate and predictWin functions back into their usable forms
+    const pointsWonByFactions = {};
+    const pointsLostByFactions = {};
+    const newFactionSkillRatings = factionRatingsState.filter(
+      (factionRating) => !factionNames.includes(factionRating.factionName)
+    );
+
+    // numbers for approximating the "look" of elo
+    const alpha = 200 / scenario.defaultSkillRatingSigma;
+    const ordinalTarget = 1500;
+
+    for (var i = 0; i < factionNames.length; i++) {
+      const factionName = factionNames[i];
+      const winPredictionPercent = predictions[i]; // this adds up to 1 across all factions
+      const newSkillRating = ratedFactions[i];
+      console.log(`${factionName} win ${100*winPredictionPercent.toFixed(2)}%`);
+
+      pointsWonByFactions[factionName] = Math.round(
+        2 * scenario.pointsNominalAmount * (1 - winPredictionPercent)
+      );
+      pointsLostByFactions[factionName] = Math.round(
+        2 * scenario.pointsNominalAmount * winPredictionPercent
+      );
+
+      newFactionSkillRatings.push({
+        factionName: factionName,
+        skillRating: newSkillRating[0],
+        elo: alpha * (ordinal(newSkillRating[0]) + ordinalTarget / alpha),
+      });
+
+      factionRatingsState = newFactionSkillRatings;
+    }
+
+    for (const factionName of Object.keys(pointsWonByFactions)) {
+      console.log(`${factionName} would win ${pointsWonByFactions[factionName]} points`);
+    }
+    for (const factionSkillRating of newFactionSkillRatings) {
+      console.log(`${factionSkillRating.factionName}: ${factionSkillRating.skillRating.mu}μ / ${factionSkillRating.skillRating.sigma}σ`);
+    }
+  }
+}


### PR DESCRIPTION
- Traitor's faction is now considered mafia for the purposes of elo
- Fixed faction elo bug where win predictions and ratings were using different parameters, causing wacky win prediction percentages
- Lowered minimum points for comp entry to 150
- Fixed upside down comp standings
- Added openskill "playground" script to assist with tuning, run it via `node test/openskill-playground.js`