### PR TITLE
fix: cursed modifier jinx persistence

### DIFF
--- a/Games/types/Mafia/roles/cards/RemoveEffectsAppliedOnDeath.js
+++ b/Games/types/Mafia/roles/cards/RemoveEffectsAppliedOnDeath.js
@@ -22,6 +22,29 @@ module.exports = class RemoveEffectsAppliedOnDeath extends Card {
           }
         }
       },
+      death: function (player) {
+        if (player != this.player) {
+          return;
+        }
+        for (let p of this.game.players) {
+          for (let effect of p.effects) {
+            if (effect.source && effect.source == this) {
+              effect.remove();
+            }
+          }
+        }
+      },
+      state: function () {
+        if (!this.player.alive) {
+          for (let p of this.game.players) {
+            for (let effect of p.effects) {
+              if (effect.source && effect.source == this) {
+                effect.remove();
+              }
+            }
+          }
+        }
+      },
       RoleBeingRemoved: function (role, player, isExtraRole) {
         if (role == this) {
           for (let player of this.game.players) {


### PR DESCRIPTION
Now the issue is: RemoveEffectsAppliedOnDeath's death listener fires before the Curse effect is applied (due to priority ordering).