### PR TITLE
fix: use wins+abandons total for per-setup games count

### DIFF
--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -2240,7 +2240,7 @@ function StatsQueryView({ stats }) {
               <div className="query-stat">
                 <span className="query-stat-label">Games</span>
                 <span className="query-stat-value">
-                  {selectedStats.totalGames || totalUnabandoned}
+                  {totalUnabandoned}
                 </span>
               </div>
               <div className="query-stat">


### PR DESCRIPTION
recordStat("wins") has existed since the initial commit, but recordStat("totalGames") was added later.