### PR TITLE
fix: bind mongo host port to 127.0.0.1 only

### DIFF
--- a/docker-compose-core.yml
+++ b/docker-compose-core.yml
@@ -11,7 +11,7 @@ services:
     expose:
       - 27017
     ports:
-      - "27017:27017"
+      - "127.0.0.1:27017:27017"
     volumes:
       - mongodb:/data/db
       - ./scripts/mongo:/scripts


### PR DESCRIPTION
- [ ] `ss -tlnp | grep 27017` on the host shows `127.0.0.1:27017` (not `0.0.0.0:27017`)
- [ ] From the host: `mongosh -u ... -p ... --authenticationDatabase admin` still connects
- [ ] From an external machine: `nc -zv <host> 27017` is refused/filtered
- [ ] Backend stays connected to mongo (no reconnect storms in logs)