### PR TITLE
chore: stamp exchange as part of live feed

### DIFF
--- a/react_main/src/pages/Play/LobbyBrowser/LobbyBrowser.jsx
+++ b/react_main/src/pages/Play/LobbyBrowser/LobbyBrowser.jsx
@@ -31,7 +31,6 @@ import { useIsPhoneDevice } from "../../../hooks/useIsPhoneDevice";
 import { RecentlyPlayedSetups } from "./RecentlyPlayedSetups";
 import { RecentForumReplies } from "components/RecentForumReplies";
 import { Poll } from "components/Poll";
-import RecentTradesFeed from "components/RecentTradesFeed";
 import Chat from "../../Chat/Chat";
 import { FeaturedSetup } from "./FeaturedSetup";
 import { DailyChallenges } from "./DailyChallengeDisplay";
@@ -283,7 +282,6 @@ export default function LobbyBrowser() {
             <RecentForumReplies />
             <Chat />
             <Poll lobby={lobbyName} />
-            <RecentTradesFeed />
           </Stack>
         </Grid2>
       </Grid2>

--- a/routes/siteActivity.js
+++ b/routes/siteActivity.js
@@ -441,15 +441,21 @@ async function fetchStampTrades(cutoff, limit) {
     .sort({ updatedAt: -1 })
     .limit(limit)
     .lean();
+  const normalizeStatus = (status) =>
+    String(status || "")
+      .toLowerCase()
+      .replace(/_/g, " ");
   return rows.map((r) => ({
     id: `stamptrade:${r._id}`,
     type: "stampTrade",
     category: "profile",
-    actorId: r.initiatorId,
+    actorId: r.updatedAt !== r.createdAt && r.recipientId ? r.recipientId : r.initiatorId,
     timestamp: r.updatedAt,
     targetType: "user",
-    targetLabel: String(r.status || "").toLowerCase().replace(/_/g, " "),
-    contentPreview: "",
+    targetLabel: r.recipientRole
+      ? `${r.initiatorRole || "Unknown"} ↔ ${r.recipientRole}`
+      : `${r.initiatorRole || "Unknown"} gifted`,
+    contentPreview: normalizeStatus(r.status),
     link: null,
   }));
 }


### PR DESCRIPTION
Live Feed's current Stamp Trade filter appears to have no data
<img width="1282" height="455" alt="image" src="https://github.com/user-attachments/assets/7ce75d0f-e319-4f3a-8462-6704bc8b83ef" />
Aiming to bring it into 1:1 with the existing Stamp Exchange feature on lobby wall