### PR TITLE
fix(liarsdice): row alignment + simplified alert wording

### DIFF
--- a/Games/types/LiarsDice/Game.js
+++ b/Games/types/LiarsDice/Game.js
@@ -180,7 +180,7 @@ module.exports = class LiarsDiceGame extends Game {
           );
         } else {
           this.sendAlert(
-            `${player.name} called a lie. Bid was at least ${this.lastAmountBid}x  ${dieIcon} 's by ${bidderName} — and there were ${diceCount}x. ${player.name} loses a die.`
+            `${player.name} called a bluff on ${this.lastAmountBid}x ${dieIcon} but there were ${diceCount}x. ${player.name} loses a die.`
           );
         }
         this.removeDice(player);
@@ -192,7 +192,7 @@ module.exports = class LiarsDiceGame extends Game {
           );
         } else {
           this.sendAlert(
-            `${player.name} called a lie. Bid was at least ${this.lastAmountBid}x  ${dieIcon} 's by ${bidderName} — but there were only ${diceCount}x. ${bidderName} loses a die.`
+            `${player.name} called a bluff on ${this.lastAmountBid}x ${dieIcon} and there were only ${diceCount}x. ${bidderName} loses a die.`
           );
         }
         this.removeDice(this.lastBidder);
@@ -398,7 +398,7 @@ module.exports = class LiarsDiceGame extends Game {
       const dieIcon = `:dice${this.lastFaceBid}:`;
       if (diceCount == this.lastAmountBid) {
         this.sendAlert(
-          `${player.name} called spot on. Bid was ${this.lastAmountBid}x  ${dieIcon} 's by ${bidderName} — exactly ${diceCount}x. Everyone except ${player.name} loses a die.`
+          `SPOT ON! Everyone except ${player.name} loses a die.`
         );
 
         if (player.correctSpotOnsInARow >= 2) {
@@ -551,7 +551,7 @@ module.exports = class LiarsDiceGame extends Game {
         });
       } else {
         this.sendAlert(
-          `${player.name} called spot on. Bid was ${this.lastAmountBid}x  ${dieIcon} 's by ${bidderName} — but there were ${diceCount}x. ${player.name} loses a die.`
+          `${player.name} called SPOT ON on ${this.lastAmountBid}x ${dieIcon} but there were ${diceCount}x. ${player.name} loses a die.`
         );
         player.correctSpotOnsInARow = 0;
 

--- a/react_main/src/css/gameLiarsDice.css
+++ b/react_main/src/css/gameLiarsDice.css
@@ -45,6 +45,8 @@
   flex-shrink: 0;
   cursor: pointer;
   padding: 6px 4px;
+  width: 120px;
+  box-sizing: border-box;
 }
 
 .ld-player-name-small {
@@ -286,6 +288,7 @@
   .ld-player-avatar {
     padding: 4px 2px;
     gap: 4px;
+    width: 72px;
   }
 
   .ld-player-avatar .avatar {


### PR DESCRIPTION
Notes the starting-player rotation: see body for explanation.

**Starting player rotation** — `currentIndex` is initialized to 0 at game start and advanced by `incrementCurrentIndex()` modulo player count. After `callALie()` or `callASpotOn()`, `rollDice()` is called but `currentIndex` is never reset. So the next round continues the rotation from where the previous round's bidder was — it is **not** random, and **not** "the caller starts next". It is "next player after the previous bidder in turn order".