### PR TITLE
feat(wacky): added speed up button

### DIFF
--- a/Games/types/WackyWords/Game.js
+++ b/Games/types/WackyWords/Game.js
@@ -9,6 +9,7 @@ const ArrayHash = require("../../core/ArrayHash");
 const questionList = require("./data/questions");
 const neighborQuestionList = require("./data/neighborQuestions");
 const decisionsList = require("./data/decisions");
+const SpeedUpMeeting = require("./SpeedUpMeeting");
 
 // Acronym letter weights use dictionary-weighted first-letter-of-word
 // frequency (how often each letter begins a unique English word), not
@@ -111,6 +112,7 @@ module.exports = class WackyWordsGame extends Game {
 
     this.currentRound = 0;
     this.currentResponse = "";
+    this.speedUpMeeting = undefined;
     this.shuffledQuestions = Random.randomizeArray(questionList);
     this.secondPromptBank = this.shuffledQuestions;
     this.promptMode = false;
@@ -125,6 +127,23 @@ module.exports = class WackyWordsGame extends Game {
 
     // hacky implementation
     this.playerHasVoted = {};
+
+    this.events.on("state", (stateInfo) => {
+      if (stateInfo.name !== "Night" && stateInfo.name !== "Day") return;
+
+      if (this.speedUpMeeting) {
+        this.speedUpMeeting.finished = true;
+      }
+
+      this.speedUpMeeting = this.createMeeting(SpeedUpMeeting);
+      for (let player of this.players) {
+        this.speedUpMeeting.join(player);
+      }
+      this.speedUpMeeting.init();
+      for (let player of this.players) {
+        player.sendMeeting(this.speedUpMeeting);
+      }
+    });
   }
 
   start() {
@@ -159,6 +178,11 @@ module.exports = class WackyWordsGame extends Game {
     if (this.getStateName() == "Night") {
       this.saveResponseHistory("name");
       this.emptyResponseHistory();
+
+      if (this.speedUpMeeting) {
+        this.speedUpMeeting.finished = true;
+      }
+
       if (this.shuffledQuestions.length > 0) {
         this.promptMode = false;
         this.hostChoosePrompts = false;
@@ -185,10 +209,13 @@ module.exports = class WackyWordsGame extends Game {
           this.generateNewQuestion();
         }
       }
+
       return;
     }
 
     if (this.getStateName() == "Day") {
+      this.clearTimer("speedUp");
+
       this.saveResponseHistory("anon");
       let action = new Action({
         actor: {
@@ -218,6 +245,15 @@ module.exports = class WackyWordsGame extends Game {
       }
       this.queueAction(action);
     }
+  }
+
+  async speedUp() {
+    for (const player of this.players) {
+      if (player.alive && !player.left && !this.playerHasVoted[player.name]) {
+        await this.vegPlayer(player);
+      }
+    }
+    this.gotoNextState();
   }
 
   generateNewQuestion() {

--- a/Games/types/WackyWords/Meeting.js
+++ b/Games/types/WackyWords/Meeting.js
@@ -6,14 +6,12 @@ module.exports = class WackyWordsMeeting extends Meeting {
   }
 
   vote(voter, selection) {
-    if (this.name != "Give Response") {
-      this.game.markVoted(voter);
-      super.vote(voter, selection);
-      return;
-    }
-
     this.game.markVoted(voter);
     super.vote(voter, selection);
+
+    if (this.game.speedUpMeeting && !this.game.speedUpMeeting.finished) {
+      this.game.speedUpMeeting.enableVote(voter);
+    }
   }
 
   rejectVote(voter, selection, msg) {

--- a/Games/types/WackyWords/SpeedUpMeeting.js
+++ b/Games/types/WackyWords/SpeedUpMeeting.js
@@ -1,0 +1,70 @@
+const Meeting = require("../../core/Meeting");
+
+module.exports = class SpeedUpMeeting extends Meeting {
+  constructor(game) {
+    super(game, "Speed Up");
+
+    this.group = true;
+    this.voting = true;
+    this.noVeg = true;
+    this.inputType = "button";
+    this.targets = ["Speed Up"];
+    this.votesInvisible = false;
+    this.repeatable = false;
+  }
+
+  generateTargets() {
+    this.targets = ["Speed Up"];
+  }
+
+  getMeetingInfo(player) {
+    let info = super.getMeetingInfo(player);
+    info.canUnvote = false;
+    return info;
+  }
+
+  join(player) {
+    super.join(player, {
+      canVote: false,
+    });
+  }
+
+  enableVote(player) {
+    if (!this.members[player.id]) return;
+    this.members[player.id].canVote = true;
+    player.sendMeeting(this);
+  }
+
+  vote(voter) {
+    if (this.votes[voter.id]) return;
+    super.vote(voter, "Speed Up");
+    this.checkEnoughVoted();
+  }
+
+  checkEnoughVoted() {
+    if (this.finished) return;
+
+    const numAlive = Object.values(this.game.players).filter(
+      (p) => p.alive && !p.left
+    ).length;
+    const threshold = Math.ceil(numAlive / 2);
+    const numVoted = Object.keys(this.votes).length;
+
+    this.game.sendAlert(
+      `Speed up: ${numVoted} / ${threshold}`,
+      undefined,
+      undefined,
+      ["info"]
+    );
+
+    if (numVoted >= threshold) {
+      this.finished = true;
+      this.game.sendAlert("Speeding up in 5 seconds!");
+      this.game.createTimer("speedUp", 5000, () => this.game.speedUp());
+    }
+  }
+
+  checkReady() {}
+
+  finish() {}
+};

--- a/Games/types/WackyWords/roles/cards/TownCore.js
+++ b/Games/types/WackyWords/roles/cards/TownCore.js
@@ -14,7 +14,7 @@ module.exports = class TownCore extends Card {
       "Pick Favorite Response": {
         actionName: "Pick Favorite Response",
         states: ["Day"],
-        flags: ["voting"],
+        flags: ["voting", "noVeg"],
         inputType: "showAllOptions",
         targets: [],
         action: {

--- a/react_main/src/components/Setup.jsx
+++ b/react_main/src/components/Setup.jsx
@@ -632,6 +632,8 @@ function getRolesByAlignment(siteInfo, gameType, roles) {
 
   for (let i in roles) {
     eventsPerRoleset[i] = {};
+    rolesDividedByAlignment[i] = {};
+    rolesDividedByRoleset[i] = {};
     for (let role in roles[i]) {
       let roleName = role.split(":")[0];
       const modifiers = role.split(":")[1];
@@ -643,7 +645,7 @@ function getRolesByAlignment(siteInfo, gameType, roles) {
         continue;
       }
 
-      for (let roleObj of siteInfo.roles[gameType]) {
+      for (let roleObj of (siteInfo.roles?.[gameType] ?? [])) {
         if (roleObj.name === roleName) {
           const alignment = roleObj.alignment;
 
@@ -662,11 +664,8 @@ function getRolesByAlignment(siteInfo, gameType, roles) {
             continue;
           }
 
-          if (!rolesDividedByAlignment[i]) rolesDividedByAlignment[i] = {};
           if (!rolesDividedByAlignment[i][alignment])
             rolesDividedByAlignment[i][alignment] = {};
-          if (!rolesDividedByRoleset[i])
-            rolesDividedByRoleset[i] = {};
 
           rolesDividedByAlignment[i][alignment][role] = roles[i][role];
           rolesDividedByRoleset[i][role] = roles[i][role];

--- a/react_main/src/pages/Game/WackyWordsGame.jsx
+++ b/react_main/src/pages/Game/WackyWordsGame.jsx
@@ -50,7 +50,7 @@ export default function WackyWordsGame() {
   const isSpectator = game.isSpectator;
 
   const spectatorMeetingFilter = (m) => {
-    if (m.name === "Vote Kick") return false;
+    if (m.name === "Vote Kick" || m.name === "Speed Up") return false;
     if (m.inputType === "text") return false;
     if (m.inputType === "showAllOptions") return false;
     return true;
@@ -80,6 +80,7 @@ export default function WackyWordsGame() {
     (m) =>
       m &&
       m.name !== "Vote Kick" &&
+      m.name !== "Speed Up" &&
       !m.finished &&
       m.amMember &&
       !(m.votes && m.votes[self])
@@ -128,7 +129,7 @@ export default function WackyWordsGame() {
               renderRowEnd={extraInfo ? renderPlayerRowEnd : undefined}
             />
             <ActionList
-              meetingFilter={(m) => m.name === "Vote Kick"}
+              meetingFilter={(m) => m.name === "Vote Kick" || m.name === "Speed Up"}
               hideIfEmpty
               scrollable={false}
             />
@@ -190,7 +191,7 @@ export default function WackyWordsGame() {
               renderRowEnd={extraInfo ? renderPlayerRowEnd : undefined}
             />
             <ActionList
-              meetingFilter={(m) => m.name === "Vote Kick"}
+              meetingFilter={(m) => m.name === "Vote Kick" || m.name === "Speed Up"}
               hideIfEmpty
               scrollable={false}
             />
@@ -369,7 +370,7 @@ function AcrotopiaActionArea({ hasPending, meetingFilter }) {
     >
       <ActionList
         bare
-        meetingFilter={meetingFilter || ((m) => m.name !== "Vote Kick")}
+        meetingFilter={meetingFilter || ((m) => m.name !== "Vote Kick" && m.name !== "Speed Up")}
         hideIfEmpty
         className="acrotopia-action-list"
       />


### PR DESCRIPTION
was playing a game where a player afked and we were stuck in the game for like 5 minutes and we ended up suiing because it took so long so inspired to make this feature:

added a speed up button for wacky words (can port to other games too)
- can be used in a round after the player has done their action
- if half the lobby or more uses the button it speeds the round up 5 seconds after pressed
- can prevent players being held hostage for a long time by an afk player, and for speeding up games if desired

note: i get it can be abused but maybe the threshold can be made larger but it's better than keeping people hostage in a game so it can continue