### PR TITLE
feat(scrapbook): add role pick boost with stamp implementation for unranked games

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -1125,7 +1125,7 @@ module.exports = class Game {
     }
 
     // Tell clients the game started, assign roles, and move to the next state
-    this.assignRoles();
+    await this.assignRoles();
     this.captureStartingFactions();
     this.started = true;
     this.broadcast("start");
@@ -1417,7 +1417,7 @@ module.exports = class Game {
     }
   }
 
-  assignRoles() {
+  async assignRoles() {
     var roleset = this.generateRoleset();
 
     var hasHost = Object.keys(roleset).some(
@@ -1509,24 +1509,92 @@ module.exports = class Game {
 
     this.numHostInGame = hostCount;
     let remainingToAssign = players.slice(hostCount);
-    var randomPlayers = Random.randomizeArray(remainingToAssign);
 
-    var i = 0;
+    // Load role boosts for unranked Mafia games
+    let playerBoosts = {};
+    if (this.type === "Mafia" && !this.ranked && !this.competitive) {
+      const nonBotPlayers = remainingToAssign.filter((p) => !p.isBot);
+      if (nonBotPlayers.length > 0) {
+        const userIds = nonBotPlayers.map((p) => p.userId || p.user.id);
+        const boostedUsers = await models.User.find({
+          id: { $in: userIds },
+          roleBoostRole: { $ne: null },
+          "itemsOwned.roleBoostCharge": { $gt: 0 },
+        })
+          .select("id roleBoostRole itemsOwned")
+          .lean();
+        if (boostedUsers.length > 0) {
+          const stampCounts = await models.Stamp.aggregate([
+            {
+              $match: {
+                userId: { $in: boostedUsers.map((u) => u.id) },
+                gameType: "Mafia",
+              },
+            },
+            { $group: { _id: { userId: "$userId", role: "$role" }, count: { $sum: 1 } } },
+          ]);
+          const countMap = {};
+          for (const s of stampCounts) {
+            if (!countMap[s._id.userId]) countMap[s._id.userId] = {};
+            countMap[s._id.userId][s._id.role] = s.count;
+          }
+          for (const u of boostedUsers) {
+            const stampCount = countMap[u.id]?.[u.roleBoostRole] || 0;
+            const charges = u.itemsOwned?.roleBoostCharge || 0;
+            const weight = 1 + charges * 0.02 + stampCount * 0.02;
+            playerBoosts[u.id] = { role: u.roleBoostRole, weight };
+            console.log(`[RoleBoost] user=${u.id} role=${u.roleBoostRole} stamps=${stampCount} charges=${charges} weight=${weight.toFixed(2)}`);
+          }
+        }
+      }
+    }
+
+    const hasBoostedPlayers = Object.keys(playerBoosts).length > 0;
 
     if (
       this.HaveHostingState &&
       this.type == "Mafia" &&
       this.advancedHosting == true
     ) {
+      var randomPlayers = Random.randomizeArray(remainingToAssign);
       for (let player of randomPlayers) {
         player.setRole("Contestant", undefined, false, true, true);
         this.originalRoles[player.id] = "Contestant";
       }
+    } else if (hasBoostedPlayers) {
+      // Weighted assignment: each boost charge adds +10% weight for the preferred role
+      let pool = [...remainingToAssign];
+      for (let roleName in roleset) {
+        const baseRole = roleName.split(":")[0];
+        for (let j = 0; j < roleset[roleName]; j++) {
+          if (pool.length === 0) continue;
+          const weights = pool.map((p) => {
+            const uid = p.userId || p.user.id;
+            const boost = playerBoosts[uid];
+            return boost && boost.role === baseRole ? boost.weight : 1;
+          });
+          const totalWeight = weights.reduce((a, b) => a + b, 0);
+          let rand = Math.random() * totalWeight;
+          let selectedIdx = 0;
+          for (let k = 0; k < weights.length; k++) {
+            rand -= weights[k];
+            if (rand <= 0) {
+              selectedIdx = k;
+              break;
+            }
+          }
+          const player = pool[selectedIdx];
+          pool.splice(selectedIdx, 1);
+          player.setRole(roleName, undefined, false, true, true);
+          this.originalRoles[player.id] = roleName;
+        }
+      }
     } else {
+      var randomPlayers = Random.randomizeArray(remainingToAssign);
+      var i = 0;
       for (let roleName in roleset) {
         for (let j = 0; j < roleset[roleName]; j++) {
           let player = randomPlayers[i];
-          //player.setRole(roleName);
           if (!player) continue;
           player.setRole(roleName, undefined, false, true, true);
           this.originalRoles[player.id] = roleName;

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -135,8 +135,8 @@ module.exports = class MafiaGame extends Game {
     }
   }
 
-  assignRoles() {
-    super.assignRoles();
+  async assignRoles() {
+    await super.assignRoles();
 
     this.rebroadcastSetup();
 

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -182,6 +182,7 @@ var schemas = {
       profileBackground: { type: Number, default: 0 },
       forumBanner: { type: Number, default: 0 },
       createFamily: { type: Number, default: 0 },
+      roleBoostCharge: { type: Number, default: 0 },
     },
     stats: {},
     winRate: { type: Number, default: 0 },
@@ -189,6 +190,7 @@ var schemas = {
     achievements: [],
     achievementCount: { type: Number, default: 0 },
     favoriteRoles: { type: [String], default: [] },
+    roleBoostRole: { type: String, default: null },
     roleIconCredits: { type: [String], default: [] },
     redHearts: { type: Number, default: 0 },
     goldHearts: { type: Number, default: 0 },
@@ -389,6 +391,7 @@ var schemas = {
     role: { type: String },
     borderType: { type: String, enum: ["u", "r", "c"], default: "u", index: true },
     hidden: { type: Boolean, default: false },
+    roleBoostEnabled: { type: Boolean, default: false },
     createdAt: { type: Number, default: Date.now },
   })
     .index({ userId: 1, gameId: 1 }, { unique: true })

--- a/react_main/src/components/Scrapbook.jsx
+++ b/react_main/src/components/Scrapbook.jsx
@@ -11,6 +11,10 @@ import {
   DialogActions,
   Button,
   Stack,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
 } from "@mui/material";
 import { SiteInfoContext, UserContext } from "Contexts";
 import { RoleCount } from "components/Roles";
@@ -30,7 +34,7 @@ const ITEMS_PER_PAGE = 20;
 const ITEMS_PER_SPREAD = ITEMS_PER_PAGE * 2;
 const FLIP_DURATION_MS = 550;
 
-export function StampItem({ gameType, role, count, hasLock, clickable, onClick, size, borderType }) {
+export function StampItem({ gameType, role, count, hasLock, clickable, onClick, size, borderType, boostEnabled, onBoostToggle }) {
   const label = gameType === "Mafia" ? role : `${gameType} - ${role}`;
   const classNames = ["stamp"];
   if (clickable) classNames.push("stamp--clickable");
@@ -38,7 +42,6 @@ export function StampItem({ gameType, role, count, hasLock, clickable, onClick, 
   if (size === "small") classNames.push("stamp--small");
   if (borderType === "r") classNames.push("stamp--border-ranked");
   else if (borderType === "c") classNames.push("stamp--border-competitive");
-  if (count > 99) classNames.push("stamp--shiny");
 
   return (
     <Tooltip title={label} arrow>
@@ -56,8 +59,8 @@ export function StampItem({ gameType, role, count, hasLock, clickable, onClick, 
           </div>
         )}
         {count > 1 && (
-          <div className={`stamp-badge${count > 99 ? " star" : ""}`}>
-            {count > 99 ? "\u2605" : count}
+          <div className="stamp-badge">
+            {count > 999 ? "999+" : count}
           </div>
         )}
         {hasLock && (
@@ -65,17 +68,31 @@ export function StampItem({ gameType, role, count, hasLock, clickable, onClick, 
             <i className="fas fa-lock" />
           </div>
         )}
+        {onBoostToggle && (
+          <div
+            className={`stamp-boost${boostEnabled ? " stamp-boost--active" : ""}`}
+            aria-label={boostEnabled ? "Remove role boost" : "Apply role boost"}
+            onClick={(e) => {
+              e.stopPropagation();
+              onBoostToggle();
+            }}
+          >
+            <i className="fas fa-bolt" />
+          </div>
+        )}
       </div>
     </Tooltip>
   );
 }
 
-function renderStamp(s, { lockedCountsByRoleKey, isSelf, onStampClick, onRequestTrade, keyPrefix = "" }) {
+function renderStamp(s, { lockedCountsByRoleKey, isSelf, onStampClick, onRequestTrade, onBoostToggle, activeBoostRole, keyPrefix = "" }) {
   const key = `${s.gameType}:${s.role}`;
   const lockedCount = lockedCountsByRoleKey?.[key] || 0;
   const selfClickable = isSelf && s.count >= 2;
   const requestable = !isSelf && !!onRequestTrade && s.count >= 2;
   const clickable = selfClickable || requestable;
+  const canBoost = isSelf && s.gameType === "Mafia";
+  const boostEnabled = canBoost && activeBoostRole === s.role;
   return (
     <StampItem
       key={`${keyPrefix}${key}`}
@@ -85,6 +102,8 @@ function renderStamp(s, { lockedCountsByRoleKey, isSelf, onStampClick, onRequest
       borderType={s.borderType}
       hasLock={lockedCount > 0}
       clickable={clickable}
+      boostEnabled={boostEnabled}
+      onBoostToggle={canBoost ? () => onBoostToggle(s) : undefined}
       onClick={
         selfClickable
           ? () => onStampClick(s)
@@ -383,23 +402,64 @@ export default function Scrapbook({
   profileUserName,
   panelStyle = {},
   headingStyle = {},
+  stampDetails = [],
+  roleBoostRole = null,
+  roleBoostCharges = 0,
+  onBoostChange,
 }) {
   const [showHidden, setShowHidden] = useState(false);
   const [spreadIndex, setSpreadIndex] = useState(0);
   const [page, setPage] = useState(1);
   const [tradeModalStamp, setTradeModalStamp] = useState(null);
   const [requestTradeStamp, setRequestTradeStamp] = useState(null);
+  const [localStamps, setLocalStamps] = useState(stamps);
+  const [activeBoostRole, setActiveBoostRole] = useState(roleBoostRole);
+  const [sortBy, setSortBy] = useState("default");
   const siteInfo = useContext(SiteInfoContext);
+  const errorAlert = useErrorAlert();
   const isPhoneDevice = useIsPhoneDevice();
-  const hasVisible = stamps.length > 0;
+
+  useEffect(() => {
+    setLocalStamps(stamps);
+  }, [stamps]);
+
+  useEffect(() => {
+    setActiveBoostRole(roleBoostRole);
+  }, [roleBoostRole]);
+
+  function handleBoostToggle(stamp) {
+    if (roleBoostCharges === 0) {
+      siteInfo.showAlert("You need Role Boost Charges. Buy them in the Shop.", "error");
+      return;
+    }
+    const newRole = activeBoostRole === stamp.role ? null : stamp.role;
+    axios
+      .post("/api/shop/set-role-boost", { role: newRole })
+      .then((res) => {
+        setActiveBoostRole(res.data.roleBoostRole);
+        if (onBoostChange) onBoostChange(res.data.roleBoostRole);
+      })
+      .catch(errorAlert);
+  }
   const hasHidden = hiddenStamps.length > 0;
+  const hasVisible = localStamps.length > 0;
 
   if (!hasVisible && !hasHidden) return null;
 
   const rolesRaw = siteInfo?.rolesRaw || {};
 
+  const TIER_ORDER = { c: 0, r: 1, u: 2 };
+  const sortedStamps = [...localStamps].sort((a, b) => {
+    if (sortBy === "az") return a.role.localeCompare(b.role);
+    if (sortBy === "za") return b.role.localeCompare(a.role);
+    if (sortBy === "most") return b.count - a.count;
+    if (sortBy === "least") return a.count - b.count;
+    if (sortBy === "tier") return (TIER_ORDER[a.borderType] ?? 2) - (TIER_ORDER[b.borderType] ?? 2);
+    return 0;
+  });
+
   const uniqueRoles = new Set();
-  for (const s of stamps)
+  for (const s of localStamps)
     if (isCountableScrapbookRole(rolesRaw, s.gameType, s.role))
       uniqueRoles.add(`${s.gameType}:${s.role}`);
   for (const s of hiddenStamps)
@@ -408,13 +468,13 @@ export default function Scrapbook({
   const uniqueCount = uniqueRoles.size;
   const totalRoles = getTotalObtainableStamps(rolesRaw);
 
-  const maxSpreads = Math.max(Math.ceil(stamps.length / ITEMS_PER_SPREAD), 1);
+  const maxSpreads = Math.max(Math.ceil(sortedStamps.length / ITEMS_PER_SPREAD), 1);
   const safeSpreadIndex = Math.min(spreadIndex, maxSpreads - 1);
   const maxPage = Math.max(
-    Math.ceil(stamps.length / STAMPS_PER_PAGE_MOBILE),
+    Math.ceil(sortedStamps.length / STAMPS_PER_PAGE_MOBILE),
     1
   );
-  const pageStamps = stamps.slice(
+  const pageStamps = sortedStamps.slice(
     (page - 1) * STAMPS_PER_PAGE_MOBILE,
     page * STAMPS_PER_PAGE_MOBILE
   );
@@ -424,13 +484,48 @@ export default function Scrapbook({
     isSelf,
     onStampClick: (s) => setTradeModalStamp(s),
     onRequestTrade: !isSelf && profileUserId ? (s) => setRequestTradeStamp(s) : null,
+    onBoostToggle: isSelf ? handleBoostToggle : null,
+    activeBoostRole,
   };
 
   return (
     <div className="box-panel scrapbook-panel" style={panelStyle}>
-      <Typography variant="h3" style={headingStyle}>
-        Scrapbook {totalRoles > 0 && `(${uniqueCount}/${totalRoles})`}
-      </Typography>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: 1 }}>
+        <Typography variant="h3" style={headingStyle}>
+          Scrapbook {totalRoles > 0 && `(${uniqueCount}/${totalRoles})`}
+        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+          {isSelf && activeBoostRole && (() => {
+            const boostedStamp = localStamps.find((s) => s.role === activeBoostRole && s.gameType === "Mafia");
+            const stampPct = boostedStamp ? boostedStamp.count * 2 : 0;
+            const chargePct = roleBoostCharges * 2;
+            const totalPct = chargePct + stampPct;
+            return (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, fontSize: "0.9rem", fontWeight: 600 }}>
+                <i className="fas fa-bolt" style={{ color: "#f5a623", fontSize: "1rem" }} />
+                <span style={{ color: "#f5a623" }}>{activeBoostRole}: +{totalPct}%</span>
+                <span style={{ fontSize: "0.75rem", opacity: 0.7, fontWeight: 400 }}>({chargePct}% charges + {stampPct}% stamps)</span>
+              </Box>
+            );
+          })()}
+          <FormControl size="small" sx={{ minWidth: 110 }}>
+            <InputLabel sx={{ fontSize: "0.8rem" }}>Sort</InputLabel>
+            <Select
+              value={sortBy}
+              label="Sort"
+              onChange={(e) => { setSortBy(e.target.value); setSpreadIndex(0); setPage(1); }}
+              sx={{ fontSize: "0.8rem" }}
+            >
+              <MenuItem value="default">Default</MenuItem>
+              <MenuItem value="az">A – Z</MenuItem>
+              <MenuItem value="za">Z – A</MenuItem>
+              <MenuItem value="most">Most</MenuItem>
+              <MenuItem value="least">Fewest</MenuItem>
+              <MenuItem value="tier">Tier</MenuItem>
+            </Select>
+          </FormControl>
+        </Box>
+      </Box>
       <div className="content">
         {hasVisible ? (
           isPhoneDevice ? (
@@ -450,7 +545,7 @@ export default function Scrapbook({
           ) : (
             <>
               <BookSpread
-                stamps={stamps}
+                stamps={sortedStamps}
                 spreadIndex={safeSpreadIndex}
                 maxSpreads={maxSpreads}
                 onFlip={setSpreadIndex}

--- a/react_main/src/css/scrapbook.css
+++ b/react_main/src/css/scrapbook.css
@@ -386,3 +386,49 @@
   z-index: 2;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
+
+.stamp-boost {
+  position: absolute;
+  bottom: -4px;
+  left: -4px;
+  width: 16px;
+  height: 16px;
+  background: #555;
+  color: #aaa;
+  border-radius: 50%;
+  font-size: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.stamp-boost:hover {
+  background: #888;
+  color: #fff;
+}
+
+.stamp-boost--active {
+  background: #f5a623;
+  color: #fff;
+  width: auto;
+  min-width: 16px;
+  padding: 0 3px;
+  border-radius: 8px;
+  gap: 2px;
+  flex-direction: row;
+}
+
+.stamp-boost--active:hover {
+  background: #e09010;
+}
+
+.stamp-boost-label {
+  font-size: 7px;
+  font-weight: bold;
+  white-space: nowrap;
+  line-height: 1;
+}

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -160,7 +160,10 @@ export default function Profile() {
   const [favoriteRoles, setFavoriteRoles] = useState([]);
   const [roleIconCredits, setRoleIconCredits] = useState([]);
   const [stamps, setStamps] = useState([]);
+  const [stampDetails, setStampDetails] = useState([]);
   const [hiddenStamps, setHiddenStamps] = useState([]);
+  const [roleBoostRole, setRoleBoostRole] = useState(null);
+  const [roleBoostCharges, setRoleBoostCharges] = useState(0);
   const [lockedCountsByRoleKey, setLockedCountsByRoleKey] = useState({});
   const [pendingConfirmationTrades, setPendingConfirmationTrades] = useState([]);
   const [profileRefetchKey, setProfileRefetchKey] = useState(0);
@@ -357,7 +360,10 @@ export default function Profile() {
           );
           setTrophies(res.data.trophies || []);
           setStamps(res.data.stamps || []);
+          setStampDetails(res.data.stampDetails || []);
           setHiddenStamps(res.data.hiddenStamps || []);
+          setRoleBoostRole(res.data.roleBoostRole || null);
+          setRoleBoostCharges(res.data.roleBoostCharges || 0);
           setLockedCountsByRoleKey(res.data.lockedCountsByRoleKey || {});
           setPendingConfirmationTrades(
             res.data.pendingConfirmationTrades || []
@@ -1519,6 +1525,7 @@ export default function Profile() {
             </div>
             <Scrapbook
               stamps={stamps}
+              stampDetails={stampDetails}
               hiddenStamps={hiddenStamps}
               isSelf={isSelf}
               lockedCountsByRoleKey={lockedCountsByRoleKey}
@@ -1527,6 +1534,9 @@ export default function Profile() {
               profileUserName={name}
               panelStyle={panelStyle}
               headingStyle={headingStyle}
+              roleBoostRole={roleBoostRole}
+              roleBoostCharges={roleBoostCharges}
+              onBoostChange={setRoleBoostRole}
             />
             {!isPhoneDevice && (
               <Box

--- a/routes/shop.js
+++ b/routes/shop.js
@@ -446,6 +446,15 @@ const shopItems = [
       }
     },
   },
+  {
+    name: "Role Pick Boost",
+    desc: "+2% per charge and +2% per stamp of that role in unranked games. Toggle which role in Scrapbook.",
+    key: "roleBoostCharge",
+    category: "game",
+    price: 10,
+    limit: 10,
+    onBuy: async function (userId) {},
+  },
 ];
 
 router.get("/info", async function (req, res) {
@@ -949,6 +958,32 @@ router.post("/stamp/toggle-hide", async function (req, res) {
   } catch (e) {
     logger.error(e);
     errors.serverError(res, "Error toggling stamp visibility. Please try again.");
+  }
+});
+
+router.post("/set-role-boost", async function (req, res) {
+  try {
+    var userId = await routeUtils.verifyLoggedIn(req);
+    const { role } = req.body;
+
+    if (role) {
+      // Validate user has a stamp for this role
+      const stamp = await models.Stamp.findOne({ userId, role, gameType: "Mafia" });
+      if (!stamp) {
+        return res.status(400).send("You don't have a stamp for this role.");
+      }
+      // Validate user has boost charges
+      const user = await models.User.findOne({ id: userId }).select("itemsOwned");
+      if (!user || !(user.itemsOwned?.roleBoostCharge > 0)) {
+        return res.status(400).send("You have no Role Boost Charges.");
+      }
+    }
+
+    await models.User.updateOne({ id: userId }, { $set: { roleBoostRole: role || null } });
+    res.send({ roleBoostRole: role || null });
+  } catch (e) {
+    logger.error(e);
+    errors.serverError(res, "Error setting role boost. Please try again.");
   }
 });
 

--- a/routes/user.js
+++ b/routes/user.js
@@ -389,7 +389,7 @@ router.get("/:id/profile", async function (req, res) {
     var isSelf = reqUserId == userId;
     var user = await models.User.findOne({ id: userId, deleted: false })
       .select(
-        "id name avatar profileBackground settings accounts wins losses kudos karma points pointsNegative championshipPoints achievements bio pronouns banner setups games numFriends stats lastActive joined favoriteRoles roleIconCredits _id"
+        "id name avatar profileBackground settings accounts wins losses kudos karma points pointsNegative championshipPoints achievements bio pronouns banner setups games numFriends stats lastActive joined favoriteRoles roleIconCredits itemsOwned roleBoostRole _id"
       )
       .populate({
         path: "setups",
@@ -536,7 +536,7 @@ router.get("/:id/profile", async function (req, res) {
     // Fetch stamps sorted by creation time to preserve acquisition order
     var stampQuery = isSelf ? { userId } : { userId, hidden: { $ne: true } };
     var stamps = await models.Stamp.find(stampQuery)
-      .select("gameType role borderType hidden _id createdAt")
+      .select("gameType role borderType hidden roleBoostEnabled _id createdAt")
       .sort("createdAt")
       .lean();
 
@@ -576,6 +576,7 @@ router.get("/:id/profile", async function (req, res) {
             role: s.role,
             count: 0,
             borderType: "u",
+            boostEnabled: false,
           };
           visibleOrder.push(stampKey);
         }
@@ -584,6 +585,9 @@ router.get("/:id/profile", async function (req, res) {
           visibleGroups[stampKey].borderType,
           bt
         );
+        if (s.roleBoostEnabled) {
+          visibleGroups[stampKey].boostEnabled = true;
+        }
       }
       if (isSelf) {
         stampDetails.push({
@@ -592,6 +596,7 @@ router.get("/:id/profile", async function (req, res) {
           role: s.role,
           borderType: bt,
           hidden: s.hidden,
+          roleBoostEnabled: !!s.roleBoostEnabled,
         });
       }
     }
@@ -600,6 +605,8 @@ router.get("/:id/profile", async function (req, res) {
     if (isSelf) {
       user.hiddenStamps = hiddenOrder.map((k) => hiddenGroups[k]);
       user.stampDetails = stampDetails;
+      user.roleBoostRole = user.roleBoostRole || null;
+      user.roleBoostCharges = user.itemsOwned?.roleBoostCharge || 0;
 
       // Locked stamp ids + per-roleKey locked counts from active trades.
       const activeTrades = await models.StampTrade.find({


### PR DESCRIPTION
- added shop item to add role probability boost
- Boost formula: +2% per shop item + 2% per stamp of boosted role
- added stamp sorting options
- added weighted role assignment in unranked