### PR TITLE
fix: auto-grant ranked and competitive access when requirements are met

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -33,6 +33,9 @@ const mongo = require("mongodb");
 const ObjectID = mongo.ObjectID;
 const axios = require("axios");
 const fortunePoints = require("../../modules/fortunePoints");
+const {
+  syncRankedCompetitiveAccess,
+} = require("../../modules/userEligibility");
 
 module.exports = class Game {
   constructor(options) {
@@ -3779,6 +3782,10 @@ module.exports = class Game {
             },
           }
         ).exec();
+
+        if (!player.isBot) {
+          await syncRankedCompetitiveAccess(player.user.id);
+        }
 
         if (player.DailyTracker && player.DailyTracker.length >= 1) {
           await models.User.updateOne(

--- a/modules/userEligibility.js
+++ b/modules/userEligibility.js
@@ -1,0 +1,112 @@
+const models = require("../db/models");
+const constants = require("../data/constants");
+const redis = require("./redis");
+
+async function getGamesPlayed(userObjectId) {
+  const aggregation = await models.User.aggregate([
+    { $match: { _id: userObjectId } },
+    { $project: { count: { $size: "$games" } } },
+  ]);
+
+  return aggregation[0]?.count || 0;
+}
+
+async function ensureInGroup(user, group) {
+  const existing = await models.InGroup.findOne({
+    user: user._id,
+    group: group._id,
+  }).select("_id");
+
+  if (existing) return false;
+
+  await models.InGroup.create({
+    user: user._id,
+    group: group._id,
+  });
+  return true;
+}
+
+async function syncRankedCompetitiveAccess(userId, options = {}) {
+  const user = await models.User.findOne({
+    id: userId,
+    deleted: false,
+    banned: { $ne: true },
+    flagged: { $ne: true },
+  }).select("_id id games points");
+
+  if (!user) {
+    return {
+      changed: false,
+      rankedGranted: false,
+      competitiveGranted: false,
+      gamesPlayed: 0,
+      points: 0,
+    };
+  }
+
+  const minimumGames =
+    options.minimumGames != null
+      ? options.minimumGames
+      : await redis.getMinimumGamesForRanked();
+  const minimumPoints =
+    options.minimumPoints != null
+      ? options.minimumPoints
+      : constants.minimumPointsForCompetitive;
+  const gamesPlayed =
+    user.games != null ? user.games.length : await getGamesPlayed(user._id);
+  const points = Number(user.points || 0);
+
+  const qualifiesForRanked = gamesPlayed >= minimumGames;
+  const qualifiesForCompetitive =
+    qualifiesForRanked && points >= minimumPoints;
+
+  if (!qualifiesForRanked && !qualifiesForCompetitive) {
+    return {
+      changed: false,
+      rankedGranted: false,
+      competitiveGranted: false,
+      gamesPlayed,
+      points,
+    };
+  }
+
+  const groups = await models.Group.find({
+    name: { $in: ["Ranked Player", "Competitive Player"] },
+  }).select("_id name");
+  const rankedGroup = groups.find((group) => group.name === "Ranked Player");
+  const competitiveGroup = groups.find(
+    (group) => group.name === "Competitive Player"
+  );
+
+  let rankedGranted = false;
+  let competitiveGranted = false;
+
+  if (qualifiesForRanked && rankedGroup) {
+    rankedGranted = await ensureInGroup(user, rankedGroup);
+  }
+
+  if (qualifiesForCompetitive && competitiveGroup) {
+    competitiveGranted = await ensureInGroup(user, competitiveGroup);
+  }
+
+  const changed = rankedGranted || competitiveGranted;
+  if (changed) {
+    await redis.cacheUserInfo(userId, true);
+  }
+
+  if (changed || qualifiesForRanked || qualifiesForCompetitive) {
+    await redis.cacheUserPermissions(userId);
+  }
+
+  return {
+    changed,
+    rankedGranted,
+    competitiveGranted,
+    gamesPlayed,
+    points,
+  };
+}
+
+module.exports = {
+  syncRankedCompetitiveAccess,
+};

--- a/react_main/src/pages/Policy/Moderation/commands.js
+++ b/react_main/src/pages/Policy/Moderation/commands.js
@@ -1021,7 +1021,7 @@ export function useModCommands(argValues, commandRan, setResults) {
           .then((res) => {
             const status = res.data.autoApprovalEnabled ? "enabled" : "disabled";
             siteInfo.showAlert(
-              `Auto-approval for Ranked and Competitive is now ${status}. New users will${res.data.autoApprovalEnabled ? " " : " not "}be immediately approved upon account creation.`,
+              `Legacy auto-approval flag is now ${status}. Ranked and Competitive access is granted when users meet the configured requirements.`,
               "success"
             );
             commandRan();
@@ -1037,11 +1037,12 @@ export function useModCommands(argValues, commandRan, setResults) {
         axios
           .post("/api/mod/syncCompetitiveApprovals")
           .then((res) => {
-            const count = res.data.restored;
+            const rankedCount = res.data.rankedGranted || 0;
+            const competitiveCount = res.data.competitiveGranted || 0;
             siteInfo.showAlert(
-              count > 0
-                ? `Restored Competitive Player group to ${count} user(s) who had lost it.`
-                : "No users needed restoration; all qualifying users already have Competitive Player.",
+              rankedCount > 0 || competitiveCount > 0
+                ? `Granted Ranked Player to ${rankedCount} user(s) and Competitive Player to ${competitiveCount} user(s).`
+                : "No users needed restoration; all qualifying users already have the right access.",
               "success"
             );
             commandRan();

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -6,9 +6,11 @@ const crypto = require("crypto");
 const constants = require("../data/constants");
 const routeUtils = require("../routes/utils");
 const models = require("../db/models");
-const redis = require("../modules/redis");
 const fbServiceAccount = require("../" + process.env.FIREBASE_JSON_FILE);
 const logger = require("../modules/logging")(".");
+const {
+  syncRankedCompetitiveAccess,
+} = require("../modules/userEligibility");
 const { sendFlaggedUserDiscordAlert } = require("./report");
 const router = express.Router();
 const passport = require("passport");
@@ -423,25 +425,7 @@ async function authSuccess(req, uid, email, discordProfile) {
 
         sendFlaggedUserDiscordAlert(name, id, flagReason || "Suspicious IP");
       } else {
-        var rankedGroup = await models.Group.findOne({
-          name: "Ranked Player",
-        }).select("_id");
-        var inGroup = new models.InGroup({
-          user: user._id,
-          group: rankedGroup._id,
-        });
-        await inGroup.save();
-
-        if (await redis.getAutoApprovalEnabled()) {
-          var competitiveGroup = await models.Group.findOne({
-            name: "Competitive Player",
-          }).select("_id");
-          var inCompetitiveGroup = new models.InGroup({
-            user: user._id,
-            group: competitiveGroup._id,
-          });
-          await inCompetitiveGroup.save();
-        }
+        await syncRankedCompetitiveAccess(id);
       }
     } else if (!id && bannedUser) {
       //(8) (9)
@@ -515,33 +499,7 @@ async function authSuccess(req, uid, email, discordProfile) {
         );
       }
 
-      // When auto-approval is on, ensure returning users who qualify get Competitive Player.
-      // This heals users who may have lost it (e.g. from cache/DB issues) and keeps them in sync.
-      if (await redis.getAutoApprovalEnabled()) {
-        const fullUser = await models.User.findOne({ id, deleted: false }).select("_id flagged");
-        if (fullUser && !fullUser.flagged) {
-          const rankedGroup = await models.Group.findOne({ name: "Ranked Player" }).select("_id");
-          const competitiveGroup = await models.Group.findOne({ name: "Competitive Player" }).select("_id");
-          if (rankedGroup && competitiveGroup) {
-            const inRanked = await models.InGroup.findOne({
-              user: fullUser._id,
-              group: rankedGroup._id,
-            });
-            const inCompetitive = await models.InGroup.findOne({
-              user: fullUser._id,
-              group: competitiveGroup._id,
-            });
-            if (inRanked && !inCompetitive) {
-              const inCompetitiveGroup = new models.InGroup({
-                user: fullUser._id,
-                group: competitiveGroup._id,
-              });
-              await inCompetitiveGroup.save();
-              await redis.cacheUserPermissions(id);
-            }
-          }
-        }
-      }
+      await syncRankedCompetitiveAccess(id);
     }
 
     req.session.user = {

--- a/routes/game.js
+++ b/routes/game.js
@@ -6,6 +6,9 @@ const utils = require("../lib/Utils");
 const redis = require("../modules/redis");
 const gameLoadBalancer = require("../modules/gameLoadBalancer");
 const logger = require("../modules/logging")(".");
+const {
+  syncRankedCompetitiveAccess,
+} = require("../modules/userEligibility");
 const router = express.Router();
 const axios = require("axios");
 const errors = require("../lib/errors");
@@ -297,14 +300,13 @@ router.get("/:id/connect", async function (req, res) {
     if (!userInThisGame) {
       // Ranked checks
       if (userId && game.settings.ranked && !isSpectating) {
+        await syncRankedCompetitiveAccess(userId);
         const user = await redis.getUserInfo(userId);
         const hasPlayRanked = await routeUtils.verifyPermission(
           userId,
           "playRanked"
         );
-        const minGamesForRanked = (await redis.getAutoApprovalEnabled())
-          ? 0
-          : await redis.getMinimumGamesForRanked();
+        const minGamesForRanked = await redis.getMinimumGamesForRanked();
 
         // Approved ranked players bypass min-games check (e.g. returning users after long inactivity)
         if (
@@ -331,6 +333,7 @@ router.get("/:id/connect", async function (req, res) {
       if (userId && game.settings.competitive && !isSpectating) {
         const roundInfo = await redis.getCompRoundInfo();
         const minimumPoints = roundInfo?.round?.minimumPoints ?? constants.minimumPointsForCompetitive;
+        await syncRankedCompetitiveAccess(userId, { minimumPoints });
         const failureReason = await userCanPlayCompetitive(userId, minimumPoints);
         if (failureReason) {
           res.status(400);
@@ -747,6 +750,13 @@ router.post("/host", async function (req, res) {
       return;
     }
 
+    if (req.body.ranked || req.body.competitive) {
+      await syncRankedCompetitiveAccess(userId, {
+        minimumPoints:
+          roundInfo?.round?.minimumPoints ?? constants.minimumPointsForCompetitive,
+      });
+    }
+
     if (
       req.body.ranked &&
       !(await routeUtils.verifyPermission(userId, "playRanked"))
@@ -775,9 +785,7 @@ router.post("/host", async function (req, res) {
         userId,
         "playRanked"
       );
-      const minGamesForRanked = (await redis.getAutoApprovalEnabled())
-        ? 0
-        : await redis.getMinimumGamesForRanked();
+      const minGamesForRanked = await redis.getMinimumGamesForRanked();
       // Approved ranked players bypass min-games check (e.g. returning users after migrations)
       if (
         !hasPlayRanked &&

--- a/routes/mod.js
+++ b/routes/mod.js
@@ -17,6 +17,9 @@ const gameLoadBalancer = require("../modules/gameLoadBalancer");
 const logger = require("../modules/logging")(".");
 const fortunePoints = require("../modules/fortunePoints");
 const errors = require("../lib/errors");
+const {
+  syncRankedCompetitiveAccess,
+} = require("../modules/userEligibility");
 const router = express.Router();
 
 router.get("/groups", async function (req, res) {
@@ -4078,54 +4081,45 @@ router.post("/syncCompetitiveApprovals", async function (req, res) {
     if (!(await routeUtils.verifyPermission(res, userId, "adjustMinGames")))
       return;
 
-    if (!(await redis.getAutoApprovalEnabled())) {
-      res.status(400).send(
-        "Auto-approval must be enabled. This sync only adds Competitive Player to users who have Ranked Player and would have been auto-approved."
-      );
-      return;
+    const minimumGames = await redis.getMinimumGamesForRanked();
+    const minimumPoints = constants.minimumPointsForCompetitive;
+    const usersToSync = await models.User.aggregate([
+      {
+        $match: {
+          deleted: false,
+          banned: { $ne: true },
+          flagged: { $ne: true },
+        },
+      },
+      {
+        $project: {
+          id: 1,
+          gamesPlayed: { $size: "$games" },
+        },
+      },
+      {
+        $match: {
+          gamesPlayed: { $gte: minimumGames },
+        },
+      },
+    ]);
+
+    let rankedGranted = 0;
+    let competitiveGranted = 0;
+    for (const user of usersToSync) {
+      const result = await syncRankedCompetitiveAccess(user.id, {
+        minimumGames,
+        minimumPoints,
+      });
+      if (result.rankedGranted) rankedGranted++;
+      if (result.competitiveGranted) competitiveGranted++;
     }
 
-    const rankedGroup = await models.Group.findOne({ name: "Ranked Player" }).select("_id");
-    const competitiveGroup = await models.Group.findOne({ name: "Competitive Player" }).select("_id");
-    if (!rankedGroup || !competitiveGroup) {
-      errors.notFound(res, "Required groups not found.");
-      return;
-    }
-
-    const inRanked = await models.InGroup.find({ group: rankedGroup._id })
-      .select("user")
-      .lean();
-    const rankedUserIds = inRanked.map((r) => r.user);
-    const inCompetitive = await models.InGroup.find({
-      group: competitiveGroup._id,
-      user: { $in: rankedUserIds },
-    })
-      .select("user")
-      .lean();
-    const competitiveUserIds = new Set(inCompetitive.map((c) => String(c.user)));
-
-    const usersToAdd = await models.User.find({
-      _id: { $in: rankedUserIds },
-      deleted: false,
-      flagged: { $ne: true },
-    })
-      .select("_id id")
-      .lean();
-
-    let restored = 0;
-    for (const user of usersToAdd) {
-      if (!competitiveUserIds.has(String(user._id))) {
-        await models.InGroup.create({
-          user: user._id,
-          group: competitiveGroup._id,
-        });
-        await redis.cacheUserPermissions(user.id);
-        restored++;
-      }
-    }
-
-    routeUtils.createModAction(userId, "Sync Competitive Approvals", [restored]);
-    res.json({ restored });
+    routeUtils.createModAction(userId, "Sync Competitive Approvals", [
+      rankedGranted,
+      competitiveGranted,
+    ]);
+    res.json({ rankedGranted, competitiveGranted });
   } catch (e) {
     logger.error(e);
     errors.serverError(res, "Could not sync competitive approvals. Please try again.");


### PR DESCRIPTION
Adds a shared eligibility sync that grants Ranked Player / Competitive Player based on games played and fortune, refreshes permission cache, and runs on login, game completion, game join/host checks, and the mod sync command. Also updates the mod command messaging to match the new requirement-based behavior.