### PR TITLE
fix: new watcher handling for mafia kill voters

### DIFF
--- a/Games/core/Meeting.js
+++ b/Games/core/Meeting.js
@@ -1292,16 +1292,34 @@ module.exports = class Meeting {
 
   // only people who voted for the final target are actors
   actors = () => {
+    const targets = Array.isArray(this.finalTarget)
+      ? this.finalTarget
+      : [this.finalTarget];
+    const voterOrder = {};
+
+    if (this.name.endsWith(" Kill")) {
+      for (let i = 0; i < this.voteRecord.length; i++) {
+        const vote = this.voteRecord[i];
+
+        if (vote.type !== "vote" || voterOrder[vote.voterId] != null) {
+          continue;
+        }
+
+        for (const target of targets) {
+          if (target instanceof Player && vote.target === target.id) {
+            voterOrder[vote.voterId] = i;
+            break;
+          }
+        }
+      }
+    }
+
     var actors = Object.keys(this.votes)
       .filter((pId) => {
         if (!this.votes[pId] || this.votes[pId] === "*") {
           return false;
         }
-        let targets = this.finalTarget;
         let votes = this.votes[pId];
-        if (!Array.isArray(targets)) {
-          targets = [targets];
-        }
         if (!Array.isArray(votes)) {
           votes = [votes];
         }
@@ -1316,7 +1334,18 @@ module.exports = class Meeting {
         }
         return false;
       })
-      .sort((a, b) => this.members[b].leader - this.members[a].leader)
+      .sort((a, b) => {
+        if (this.name.endsWith(" Kill")) {
+          const aOrder = voterOrder[a] ?? Number.MAX_SAFE_INTEGER;
+          const bOrder = voterOrder[b] ?? Number.MAX_SAFE_INTEGER;
+
+          if (aOrder !== bOrder) {
+            return aOrder - bOrder;
+          }
+        }
+
+        return this.members[b].leader - this.members[a].leader;
+      })
       .map((pId) => this.game.getPlayer(pId));
     return actors;
   };

--- a/Games/types/Mafia/information/WatcherInfo.js
+++ b/Games/types/Mafia/information/WatcherInfo.js
@@ -36,18 +36,9 @@ module.exports = class WatcherInfo extends Information {
     } else {
       visitors = this.getVisitorsAppearance(this.target);
     }
-    let MafiaKill = this.getVisitors(this.target, "mafia");
+    let MafiaKill = this.getMafiaKillVisitors(this.target);
 
-    if (
-      MafiaKill &&
-      MafiaKill.length > 1 &&
-      this.limtMafia == true &&
-      this.forceCount == false
-    ) {
-      for (let x = 1; x < MafiaKill.length; x++) {
-        visitors.splice(visitors.indexOf(MafiaKill[x]), 1);
-      }
-    }
+    visitors = this.limitMafiaVisitors(visitors, MafiaKill);
 
     if (visitors.includes(this.creator)) {
       while (visitors.includes(this.creator)) {
@@ -61,6 +52,50 @@ module.exports = class WatcherInfo extends Information {
   getInfoRaw() {
     super.getInfoRaw();
     return this.mainInfo;
+  }
+
+  getMafiaKillVisitors(target) {
+    let visitors = [];
+
+    for (let action of this.game.actions[0]) {
+      if (!action.hasLabel("mafia")) {
+        continue;
+      }
+
+      let toCheck = action.target;
+      if (!Array.isArray(action.target)) {
+        toCheck = [action.target];
+      }
+
+      if (
+        toCheck.includes(target) &&
+        !action.hasLabel("hidden") &&
+        action.actors.length > 0
+      ) {
+        visitors.push(...action.actors);
+      }
+    }
+
+    return visitors;
+  }
+
+  limitMafiaVisitors(visitors, MafiaKill) {
+    if (MafiaKill == null) {
+      MafiaKill = this.getMafiaKillVisitors(this.target);
+    }
+
+    if (
+      MafiaKill &&
+      MafiaKill.length > 1 &&
+      this.limtMafia == true &&
+      this.forceCount == false
+    ) {
+      visitors = visitors.filter(
+        (visitor) => visitor === MafiaKill[0] || !MafiaKill.includes(visitor)
+      );
+    }
+
+    return visitors;
   }
 
   getInfoFormated() {
@@ -84,7 +119,7 @@ module.exports = class WatcherInfo extends Information {
   }
 
   isTrue() {
-    let visitors = this.getVisitors(this.target);
+    let visitors = this.limitMafiaVisitors(this.getVisitors(this.target));
     if (visitors.includes(this.creator)) {
       while (visitors.includes(this.creator)) {
         visitors.splice(visitors.indexOf(this.creator), 1);
@@ -133,7 +168,7 @@ module.exports = class WatcherInfo extends Information {
   }
 
   makeTrue() {
-    let visitors = this.getVisitors(this.target);
+    let visitors = this.limitMafiaVisitors(this.getVisitors(this.target));
     if (visitors.includes(this.creator)) {
       while (visitors.includes(this.creator)) {
         visitors.splice(visitors.indexOf(this.creator), 1);
@@ -142,7 +177,7 @@ module.exports = class WatcherInfo extends Information {
     this.mainInfo = visitors;
   }
   makeFalse() {
-    let visitors = this.getVisitors(this.target);
+    let visitors = this.limitMafiaVisitors(this.getVisitors(this.target));
     if (visitors.includes(this.creator)) {
       while (visitors.includes(this.creator)) {
         visitors.splice(visitors.indexOf(this.creator), 1);
@@ -177,7 +212,7 @@ module.exports = class WatcherInfo extends Information {
     }
   }
   makeFavorable() {
-    let visitors = this.getVisitors(this.target);
+    let visitors = this.limitMafiaVisitors(this.getVisitors(this.target));
     if (visitors.includes(this.creator)) {
       while (visitors.includes(this.creator)) {
         visitors.splice(visitors.indexOf(this.creator), 1);
@@ -202,7 +237,7 @@ module.exports = class WatcherInfo extends Information {
     }
   }
   makeUnfavorable() {
-    let visitors = this.getVisitors(this.target);
+    let visitors = this.limitMafiaVisitors(this.getVisitors(this.target));
     if (visitors.includes(this.creator)) {
       while (visitors.includes(this.creator)) {
         visitors.splice(visitors.indexOf(this.creator), 1);

--- a/Games/types/Mafia/roles/cards/WatchPlayer.js
+++ b/Games/types/Mafia/roles/cards/WatchPlayer.js
@@ -22,7 +22,8 @@ module.exports = class WatchPlayer extends Card {
               "WatcherInfo",
               this.actor,
               this.game,
-              this.target
+              this.target,
+              true
             );
             info.processInfo();
 

--- a/test/Games/Mafia.test.js
+++ b/test/Games/Mafia.test.js
@@ -186,6 +186,73 @@ describe("Games/Mafia", function () {
       game.winners.groups["Mafia"].should.have.lengthOf(1);
     });
 
+    it("should show the first unblocked mafia kill voter to watchers", async function () {
+      this.timeout(10000);
+
+      await db.promise;
+      await redis.client.flushdbAsync();
+
+      const setup = {
+        total: 6,
+        roles: [{ Watcher: 1, Drunk: 1, Villager: 1, Mafioso: 3 }],
+      };
+      const game = await makeGame(setup);
+      const roles = getRoles(game);
+      const mafiosi = roles["Mafioso"];
+      const target = roles["Villager"];
+
+      addListenerToPlayer(roles["Watcher"], "meeting", function (meeting) {
+        if (meeting.name == "Watch") {
+          this.sendToServer("vote", {
+            selection: target.id,
+            meetingId: meeting.id,
+          });
+        }
+      });
+
+      addListenerToPlayer(roles["Drunk"], "meeting", function (meeting) {
+        if (meeting.name == "Block") {
+          this.sendToServer("vote", {
+            selection: mafiosi[0].id,
+            meetingId: meeting.id,
+          });
+        }
+      });
+
+      for (let mafioso of mafiosi) {
+        addListenerToPlayer(mafioso, "meeting", function (meeting) {
+          if (meeting.name == "Mafia Kill") {
+            this.sendToServer("vote", {
+              selection: target.id,
+              meetingId: meeting.id,
+            });
+          }
+        });
+      }
+
+      addListenerToPlayers(game.players, "meeting", function (meeting) {
+        if (meeting.name == "Village") {
+          this.sendToServer("vote", {
+            selection: mafiosi[0].id,
+            meetingId: meeting.id,
+          });
+        }
+      });
+
+      await waitForGameEnd(game);
+
+      gameHasAlert(
+        game,
+        `${target.name} was visited by ${mafiosi[1].name}`,
+        "Watcher"
+      ).should.be.true;
+      gameHasAlert(
+        game,
+        `${target.name} was visited by ${mafiosi[0].name}`,
+        "Watcher"
+      ).should.be.false;
+    });
+
     it("should allow the game to continue after a death", async function () {
       await db.promise;
       await redis.client.flushdbAsync();


### PR DESCRIPTION


Old behavior:
- Watcher could show multiple mafia kill voters as visitors.
- if the first mafia voter was roleblocked, the visible kill actor handling did not cleanly fall through to the next voter.
- `Leading` : a leading mafia member in the majority vote became the only mafia kill actor.
- multiple-`Leading`: if multiple majority voters had Leading, the winner was the first queued/resolved Leading passive, not necessarily the first mafia to vote.

New behavior:
- Mafia kill actors keep vote order.
- Watcher only sees the first unblocked majority voter.
- If the first mafia voter is blocked, the kill still uses the next unblocked majority voter as the visible visitor.
- `Leading`: same core behavior, but Watcher now reports that final leading actor instead of potentially showing multiple mafia voters.
- if the leading mafia is roleblocked, they are removed before `Leading` applies, so the kill can fall through to the next unblocked majority voter.

UNCHANGED:
- Tracker-style visit info can still see all majority voters.
- If all majority-voting mafia are blocked, the kill action has no actors and should not resolve.
- a leading mafia who does not vote with the majority does not affect the kill.

etc:
- Added a regression test for the blocked-first-voter case.