### PR TITLE
fix: change avatar cache-control to no-cache and disable expires

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,6 +70,11 @@ app.use(
   "/uploads",
   express.static(path.join(__dirname, process.env.UPLOAD_PATH), {
     maxAge: "1h",
+    setHeaders: (res, filePath) => {
+      if (filePath.endsWith("_avatar.webp")) {
+        res.setHeader("Cache-Control", "no-cache");
+      }
+    },
   })
 );
 

--- a/react_main/nginx.conf
+++ b/react_main/nginx.conf
@@ -21,6 +21,16 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+map $uri $uploads_expires {
+    default          30d;
+    "~*_avatar\.webp$" off;
+}
+
+map $uri $uploads_cache_control {
+    default          "public, no-transform";
+    "~*_avatar\.webp$" "no-cache";
+}
+
 server {
 	server_name ultimafia.com;
     root /usr/share/nginx/html;
@@ -37,8 +47,8 @@ server {
 	
 	location ^~ /uploads/ {
 		alias /uploads/;
-		expires 30d;
-		add_header Cache-Control "public, no-transform";
+		expires $uploads_expires;
+		add_header Cache-Control $uploads_cache_control;
 	}
 
 	location /chatSocket {


### PR DESCRIPTION
This PR removes the max-age from Cache-Control headers for user and family avatars served via express.static and Nginx, replacing it with no-cache and disabling expires.