### PR TITLE
fix: stop profile stats from being overwritten by stale game snapshots

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -3610,6 +3610,62 @@ module.exports = class Game {
     }
   }
 
+  static buildNumericIncrements(before, after, prefix) {
+    const increments = {};
+    const keys = new Set([
+      ...Object.keys(before || {}),
+      ...Object.keys(after || {}),
+    ]);
+
+    for (const key of keys) {
+      if (key.includes(".") || key.startsWith("$")) continue;
+
+      const beforeValue = before ? before[key] : undefined;
+      const afterValue = after ? after[key] : undefined;
+      const path = prefix ? `${prefix}.${key}` : key;
+
+      if (typeof afterValue === "number") {
+        const diff = afterValue - (Number(beforeValue) || 0);
+        if (diff) increments[path] = diff;
+      } else if (
+        afterValue &&
+        typeof afterValue === "object" &&
+        !Array.isArray(afterValue)
+      ) {
+        Object.assign(
+          increments,
+          Game.buildNumericIncrements(beforeValue || {}, afterValue, path)
+        );
+      }
+    }
+
+    return increments;
+  }
+
+  buildStatsIncrements(player) {
+    return Game.buildNumericIncrements(
+      player.user.initialStats || {},
+      player.user.stats || {},
+      "stats"
+    );
+  }
+
+  getUserStatsRateUpdates(stats) {
+    const updates = {};
+    const mafiaStats = stats && stats["Mafia"];
+    if (mafiaStats) {
+      updates.winRate =
+        (mafiaStats.all?.wins?.count || 0) /
+        (mafiaStats.all?.wins?.total || 1);
+      if (mafiaStats.unranked) {
+        updates.unrankedWinRate =
+          (mafiaStats.unranked.wins.count || 0) /
+          (mafiaStats.unranked.wins.total || 1);
+      }
+    }
+    return updates;
+  }
+
   async endPostgame() {
     try {
       if (this.postgameOver) return;
@@ -3773,39 +3829,43 @@ module.exports = class Game {
         }
 
         const skipStatsSave = this.type === "Mafia" && this.hadVegKill;
+        const statIncrements = skipStatsSave
+          ? {}
+          : this.buildStatsIncrements(player);
         const userSet = {
           playedGame: true,
           achievementCount: player.user.achievements.length,
         };
-        if (!skipStatsSave) {
-          userSet.stats = player.user.stats;
-          const mafiaStats = player.user.stats["Mafia"];
-          if (mafiaStats) {
-            userSet.winRate =
-              (mafiaStats.all?.wins?.count || 0) /
-              (mafiaStats.all?.wins?.total || 1);
-            if (mafiaStats.unranked) {
-              userSet.unrankedWinRate =
-                (mafiaStats.unranked.wins.count || 0) /
-                (mafiaStats.unranked.wins.total || 1);
-            }
-          }
-        }
+        const incOps = {
+          coins: coinsEarned,
+          kudos:
+            kudosTarget && kudosTarget.user.id == player.user.id ? 1 : 0,
+          points: pointsWon > 0 ? pointsWon : 0,
+          pointsNegative: pointsWon < 0 ? -pointsWon : 0,
+          ...statIncrements,
+        };
         await models.User.updateOne(
           { id: player.user.id },
           {
             $push: { games: game._id },
             $addToSet: { achievements: { $each: player.EarnedAchievements } },
             $set: userSet,
-            $inc: {
-              coins: coinsEarned,
-              kudos:
-                kudosTarget && kudosTarget.user.id == player.user.id ? 1 : 0,
-              points: pointsWon > 0 ? pointsWon : 0,
-              pointsNegative: pointsWon < 0 ? -pointsWon : 0,
-            },
+            $inc: incOps,
           }
         ).exec();
+
+        if (Object.keys(statIncrements).length > 0) {
+          const freshUser = await models.User.findOne({ id: player.user.id })
+            .select("stats")
+            .lean();
+          const rateUpdates = this.getUserStatsRateUpdates(freshUser?.stats);
+          if (Object.keys(rateUpdates).length > 0) {
+            await models.User.updateOne(
+              { id: player.user.id },
+              { $set: rateUpdates }
+            ).exec();
+          }
+        }
 
         if (!player.isBot) {
           await syncRankedCompetitiveAccess(player.user.id);

--- a/Games/core/User.js
+++ b/Games/core/User.js
@@ -15,6 +15,7 @@ module.exports = class User {
     this.rankedCount = props.rankedCount;
     this.competitiveCount = props.competitiveCount;
     this.stats = props.stats || dbStats.allStats();
+    this.initialStats = JSON.parse(JSON.stringify(this.stats));
     this.achievements = props.achievements || [];
     if (props.dailyChallenges) {
       this.dailyChallenges =

--- a/test/Games/Stats.test.js
+++ b/test/Games/Stats.test.js
@@ -206,6 +206,65 @@ describe("Stats recording", function () {
   });
 
   describe("Player stats — completed games", function () {
+    it("persists stat deltas without overwriting newer game results", async function () {
+      const user = makeUser();
+      await seedUserDoc(user);
+
+      const firstSnapshot = new User({
+        id: user.id,
+        socket: new Socket(),
+        name: user.name,
+        settings: {},
+        stats: {},
+      });
+      const secondSnapshot = new User({
+        id: user.id,
+        socket: new Socket(),
+        name: user.name,
+        settings: {},
+        stats: {},
+      });
+
+      firstSnapshot.stats.Mafia = {
+        all: {
+          totalGames: 1,
+          wins: { count: 0, total: 1 },
+        },
+      };
+      secondSnapshot.stats.Mafia = {
+        all: {
+          totalGames: 1,
+          wins: { count: 1, total: 1 },
+        },
+      };
+
+      await models.User.updateOne(
+        { id: user.id },
+        {
+          $inc: Game.buildNumericIncrements(
+            firstSnapshot.initialStats,
+            firstSnapshot.stats,
+            "stats"
+          ),
+        }
+      ).exec();
+      await models.User.updateOne(
+        { id: user.id },
+        {
+          $inc: Game.buildNumericIncrements(
+            secondSnapshot.initialStats,
+            secondSnapshot.stats,
+            "stats"
+          ),
+        }
+      ).exec();
+
+      const doc = await getUserDoc(user);
+      doc.stats.Mafia.all.totalGames.should.equal(2);
+      doc.stats.Mafia.all.wins.total.should.equal(2);
+      doc.stats.Mafia.all.wins.count.should.equal(1);
+    });
+
     it("unranked game: records Mafia.unranked only", async function () {
       const { game } = await makeGame(mafiaSetup(), {
         preJoinHook: autoVillageWin(),


### PR DESCRIPTION
Previously, postgame saved the entire in-memory user.stats object back to Mongo. If two games finished close together, the later save could overwrite stats from the earlier one with an older snapshot, causing wins/losses to disappear from the profile pie. User stats now persist as atomic numeric deltas, so each game contributes only its own stat changes. 

Also stores the initial stats snapshot when a game user is created and adds regression coverage for preserving multiple stat deltas.