### PR TITLE
fix: UI tweaks for Stock Market (mobile layout, desktop centering)

### DIFF
--- a/react_main/src/pages/Fame/Fame.jsx
+++ b/react_main/src/pages/Fame/Fame.jsx
@@ -15,8 +15,8 @@ export default function Fame(props) {
 
   return (
     <>
-      <Box maxWidth="1280px" sx={{ flexGrow: 1, margin: "auto" }}>
-        <Card sx={{ p: { xs: 1, sm: 2, md: 3 }, textAlign: "justify" }}>
+      <Box sx={{ width: '100%', flexGrow: 1 }}>
+        <Card sx={{ p: { xs: 1, sm: 2, md: 3 } }}>
           <Routes>
             <Route path="competitive" element={<Competitive />} />
             <Route path="competitive/faq" element={<CompetitiveFaq />} />

--- a/react_main/src/pages/Fame/Fame.jsx
+++ b/react_main/src/pages/Fame/Fame.jsx
@@ -15,7 +15,14 @@ export default function Fame(props) {
 
   return (
     <>
-      <Box sx={{ width: '100%', flexGrow: 1 }}>
+      <Box sx={{ 
+        width: { xs: '100%', md: '1280px' }, 
+        maxWidth: '100vw',
+        position: 'relative',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        flexGrow: 1 
+      }}>
         <Card sx={{ p: { xs: 1, sm: 2, md: 3 } }}>
           <Routes>
             <Route path="competitive" element={<Competitive />} />

--- a/react_main/src/pages/Fame/StockMarket.jsx
+++ b/react_main/src/pages/Fame/StockMarket.jsx
@@ -406,8 +406,8 @@ export default function StockMarket() {
             <Box sx={{ display: { xs: "none", sm: "block" } }}>
               <Icon icon="lucide:coins" style={{ color: "gold", fontSize: "28px" }} />
             </Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 2 }, flex: 1, justifyContent: { xs: 'space-between', sm: 'flex-start' } }}>
-              <Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 2 }, flex: 1, justifyContent: { xs: 'center', sm: 'flex-start' } }}>
+              <Box sx={{ flex: { xs: 1, sm: 'initial' }, textAlign: { xs: 'center', sm: 'left' } }}>
                 <Typography variant="caption" color="text.secondary" display="block">
                   Coins
                 </Typography>
@@ -416,7 +416,7 @@ export default function StockMarket() {
                 </Typography>
               </Box>
               <Box sx={{ height: 30, borderLeft: '1px solid rgba(255, 215, 0, 0.3)' }} />
-              <Box>
+              <Box sx={{ flex: { xs: 1, sm: 'initial' }, textAlign: { xs: 'center', sm: 'left' } }}>
                 <Typography variant="caption" color="text.secondary" display="block">
                   Stock Value
                 </Typography>
@@ -425,7 +425,7 @@ export default function StockMarket() {
                 </Typography>
               </Box>
               <Box sx={{ height: 30, borderLeft: '1px solid rgba(255, 215, 0, 0.3)' }} />
-              <Box>
+              <Box sx={{ flex: { xs: 1, sm: 'initial' }, textAlign: { xs: 'center', sm: 'left' } }}>
                 <Typography variant="caption" color="text.secondary" display="block">
                   Net Worth
                 </Typography>

--- a/react_main/src/pages/Fame/StockMarket.jsx
+++ b/react_main/src/pages/Fame/StockMarket.jsx
@@ -371,7 +371,7 @@ export default function StockMarket() {
   }
 
   return (
-    <Box sx={{ width: '100%', boxSizing: 'border-box', overflowX: 'hidden' }}>
+    <Box sx={{ width: '100%', boxSizing: 'border-box', overflowX: 'hidden', textAlign: 'left' }}>
       {/* Top Banner & Balance */}
       <Stack
         direction={{ xs: "column", sm: "row" }}
@@ -393,7 +393,7 @@ export default function StockMarket() {
           <Paper
             variant="outlined"
             sx={{
-              p: { xs: 1, sm: 2 },
+              p: { xs: 1.5, sm: 2 },
               display: "flex",
               alignItems: "center",
               gap: { xs: 1, sm: 2 },
@@ -403,8 +403,10 @@ export default function StockMarket() {
               maxWidth: "100%",
             }}
           >
-            <Icon icon="lucide:coins" style={{ color: "gold", fontSize: "28px" }} />
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <Box sx={{ display: { xs: "none", sm: "block" } }}>
+              <Icon icon="lucide:coins" style={{ color: "gold", fontSize: "28px" }} />
+            </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 2 }, flex: 1, justifyContent: { xs: 'space-between', sm: 'flex-start' } }}>
               <Box>
                 <Typography variant="caption" color="text.secondary" display="block">
                   Coins

--- a/react_main/src/pages/Fame/StockMarket.jsx
+++ b/react_main/src/pages/Fame/StockMarket.jsx
@@ -403,10 +403,10 @@ export default function StockMarket() {
               maxWidth: "100%",
             }}
           >
-            <Box sx={{ display: { xs: "none", sm: "block" } }}>
+            <Box sx={{ display: "flex", alignItems: "center", mr: { xs: 0.5, sm: 0 } }}>
               <Icon icon="lucide:coins" style={{ color: "gold", fontSize: "28px" }} />
             </Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 2 }, flex: 1, justifyContent: { xs: 'center', sm: 'flex-start' } }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 0.5, sm: 2 }, flex: 1, justifyContent: { xs: 'center', sm: 'flex-start' } }}>
               <Box sx={{ flex: { xs: 1, sm: 'initial' }, textAlign: { xs: 'center', sm: 'left' } }}>
                 <Typography variant="caption" color="text.secondary" display="block">
                   Coins


### PR DESCRIPTION
This PR fixes a few layout issues in the Stock Market:
    - Centers the 1280px oversized Fame container on desktop screens using a translation transform.
    - Adjusts the mobile balance box to use flex: 1 for equal horizontal distribution among stats.
    - Restores the gold coin icon on mobile.

<img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/8d777178-c1e3-4a6a-8a52-bcd7f42ba6c8" />
<img width="444" height="830" alt="image" src="https://github.com/user-attachments/assets/91c8bd55-a34c-49a7-a2a1-42d16a5b6795" />
