### PR TITLE
Remove prestige gloss mobile

### DIFF
--- a/react_main/src/css/user.css
+++ b/react_main/src/css/user.css
@@ -349,6 +349,12 @@ iframe {
   pointer-events: none;
 }
 
+@media (max-width: 768px) {
+  .profile .trophy-tile-prestige::before {
+    display: none;
+  }
+}
+
 .profile .trophy-tile-prestige:hover {
   box-shadow: 0 4px 12px rgba(184, 134, 11, 0.45),
     inset 0 1px 0 rgba(255, 255, 255, 0.6);


### PR DESCRIPTION
Removed the problematic gloss effect on the "prestige" card on profile pages, fixing long-standing AI-slop induced NUMEROUS problems.