### PR TITLE
Fix stock market mobile UI, trading dialog avatar, and dividend distribution exclusions

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -3842,6 +3842,13 @@ module.exports = class Game {
         await this.recordCompetitiveCompletions(gameDocument._id);
       }
 
+      const allParticipantIds = Array.from(
+        new Set([
+          ...this.players.filter((p) => !p.isBot).map((p) => p.userId || p.user.id),
+          ...Object.keys(this.playersGone || {}),
+        ])
+      );
+
       for (let player of this.players) {
         let coinsEarned = 0;
         if (this.ranked && player.won) {
@@ -3929,7 +3936,7 @@ module.exports = class Game {
           if ((this.ranked || this.competitive) && coinsEarned > 0) {
             if (this.shareholderSnapshots && this.shareholderSnapshots[player.user.id]) {
               try {
-                await stockMarket.distributeDividends(player.user.id, coinsEarned, this.shareholderSnapshots[player.user.id]);
+                await stockMarket.distributeDividends(player.user.id, coinsEarned, this.shareholderSnapshots[player.user.id], allParticipantIds);
               } catch (err) {
                 logger.error(`Failed to distribute dividends for ${player.user.id} in game ${this.id}: ${err.message}`);
               }
@@ -3938,7 +3945,7 @@ module.exports = class Game {
             const familyId = this.playerToFamilyMap && this.playerToFamilyMap[player.user.id];
             if (familyId && this.familyShareholderSnapshots && this.familyShareholderSnapshots[familyId]) {
               try {
-                await stockMarket.distributeFamilyDividends(familyId, coinsEarned, this.familyShareholderSnapshots[familyId]);
+                await stockMarket.distributeFamilyDividends(familyId, coinsEarned, this.familyShareholderSnapshots[familyId], allParticipantIds, player.user.id);
               } catch (err) {
                 logger.error(`Failed to distribute family dividends for ${familyId} from player ${player.user.id} in game ${this.id}: ${err.message}`);
               }

--- a/lib/StockMarket.js
+++ b/lib/StockMarket.js
@@ -66,7 +66,7 @@ function getSellPrice(currentSupply, sharesToSell) {
  * Distributes dividends based on game completion coin earnings.
  * Uses a snapshot taken at game start.
  */
-async function distributeDividends(subjectId, coinsEarned, snapshot) {
+async function distributeDividends(subjectId, coinsEarned, snapshot, participantIds = []) {
   if (!snapshot || !snapshot.holders || snapshot.holders.length === 0 || snapshot.shareSupply <= 0) {
     return [];
   }
@@ -74,11 +74,13 @@ async function distributeDividends(subjectId, coinsEarned, snapshot) {
   const dividendPool = coinsEarned * DIVIDEND_RATE;
   if (dividendPool <= 0) return [];
 
+  const participantSet = new Set(participantIds);
   const payouts = [];
   let totalDistributed = 0;
 
   for (const holder of snapshot.holders) {
     if (holder.sharesOwned <= 0) continue;
+    if (participantSet.has(holder.holderId) && holder.holderId !== subjectId) continue;
 
     const shareFraction = holder.sharesOwned / snapshot.shareSupply;
     // Round to 2 decimals for precision
@@ -135,7 +137,7 @@ async function distributeDividends(subjectId, coinsEarned, snapshot) {
  * Distributes dividends for Family ETFs based on game completion coin earnings.
  * Uses a snapshot taken at game start.
  */
-async function distributeFamilyDividends(familyId, coinsEarned, snapshot) {
+async function distributeFamilyDividends(familyId, coinsEarned, snapshot, participantIds = [], winnerId) {
   if (!snapshot || !snapshot.holders || snapshot.holders.length === 0 || snapshot.shareSupply <= 0) {
     return [];
   }
@@ -144,11 +146,13 @@ async function distributeFamilyDividends(familyId, coinsEarned, snapshot) {
   const dividendPool = coinsEarned * FAMILY_DIVIDEND_RATE;
   if (dividendPool <= 0) return [];
 
+  const participantSet = new Set(participantIds);
   const payouts = [];
   let totalDistributed = 0;
 
   for (const holder of snapshot.holders) {
     if (holder.sharesOwned <= 0) continue;
+    if (participantSet.has(holder.holderId) && holder.holderId !== winnerId) continue;
 
     const shareFraction = holder.sharesOwned / snapshot.shareSupply;
     const rawPayout = dividendPool * shareFraction;

--- a/react_main/src/components/TradeDialog.jsx
+++ b/react_main/src/components/TradeDialog.jsx
@@ -12,7 +12,8 @@ import {
   ToggleButtonGroup,
   Button,
   TextField,
-  Paper
+  Paper,
+  useTheme
 } from "@mui/material";
 import { UserContext, SiteInfoContext } from "Contexts";
 import { useErrorAlert } from "components/Alerts";
@@ -23,6 +24,9 @@ export default function TradeDialog({ open, onClose, stock, initialType = "buy",
   const user = useContext(UserContext);
   const siteInfo = useContext(SiteInfoContext);
   const errorAlert = useErrorAlert();
+  const theme = useTheme();
+
+  const goldColor = theme.palette.mode === "light" ? "#b8860b" : "gold";
 
   const [tradeType, setTradeType] = useState(initialType);
   const [shareCount, setShareCount] = useState(1);
@@ -111,7 +115,7 @@ export default function TradeDialog({ open, onClose, stock, initialType = "buy",
       <DialogTitle sx={{ fontWeight: "bold", borderBottom: 1, borderColor: "divider", pb: 2 }}>
         <Stack direction="row" spacing={1.5} alignItems="center">
           {stock.targetType === "player" ? (
-            <Avatar id={stock.id} name={stock.name} avatar={stock.avatar} size={40} />
+            <Avatar id={stock.id} name={stock.name} hasImage={stock.avatar} size={40} />
           ) : (
             <Box
               sx={{
@@ -206,7 +210,7 @@ export default function TradeDialog({ open, onClose, stock, initialType = "buy",
             )}
           </Box>
 
-          <Paper variant="outlined" sx={{ p: 2, background: "rgba(255,255,255,0.01)" }}>
+          <Paper variant="outlined" sx={{ p: 2, backgroundColor: theme.palette.mode === "light" ? "rgba(0, 0, 0, 0.02)" : "rgba(255, 255, 255, 0.02)" }}>
             <Stack spacing={1}>
               <Stack direction="row" justifyContent="space-between">
                 <Typography variant="body2">Base Price:</Typography>
@@ -233,7 +237,7 @@ export default function TradeDialog({ open, onClose, stock, initialType = "buy",
                 <Typography sx={{ fontWeight: "bold" }}>
                   {tradeType === "buy" ? "Total Cost:" : "Total Payout:"}
                 </Typography>
-                <Typography variant="h6" sx={{ fontWeight: "bold", color: "gold" }}>
+                <Typography variant="h6" sx={{ fontWeight: "bold", color: goldColor }}>
                   {tradePreview.total.toFixed(2)} Coins
                 </Typography>
               </Stack>

--- a/react_main/src/pages/Fame/StockMarket.jsx
+++ b/react_main/src/pages/Fame/StockMarket.jsx
@@ -91,6 +91,8 @@ export default function StockMarket() {
   const theme = useTheme();
   const isMobile = useIsPhoneDevice();
 
+  const goldColor = theme.palette.mode === "light" ? "#b8860b" : "gold";
+
   const [activeTab, setActiveTab] = useState(0);
   const [marketMode, setMarketMode] = useState("player"); // "player" | "family"
   
@@ -341,7 +343,7 @@ export default function StockMarket() {
           userSelect: "none",
           whiteSpace: "nowrap",
           "&:hover": {
-            backgroundColor: "rgba(255, 255, 255, 0.05)",
+            backgroundColor: "action.hover",
           },
           ...extraSx
         }}
@@ -354,7 +356,7 @@ export default function StockMarket() {
         >
           <span>{label}</span>
           {isActive ? (
-            <Icon icon={isAsc ? "lucide:chevron-up" : "lucide:chevron-down"} style={{ fontSize: "16px", color: "gold" }} />
+            <Icon icon={isAsc ? "lucide:chevron-up" : "lucide:chevron-down"} style={{ fontSize: "16px", color: goldColor }} />
           ) : (
             <Icon icon="lucide:chevrons-up-down" style={{ fontSize: "16px", color: "gray", opacity: 0.5 }} />
           )}
@@ -400,21 +402,21 @@ export default function StockMarket() {
               display: "flex",
               alignItems: "center",
               gap: { xs: 1, sm: 2 },
-              background: "rgba(255, 215, 0, 0.05)",
-              borderColor: "gold",
+              background: theme.palette.mode === "light" ? "rgba(184, 134, 11, 0.05)" : "rgba(255, 215, 0, 0.05)",
+              borderColor: goldColor,
               overflowX: "auto",
               maxWidth: "100%",
             }}
           >
             <Box sx={{ display: "flex", alignItems: "center", mr: { xs: 0.5, sm: 0 } }}>
-              <Icon icon="lucide:coins" style={{ color: "gold", fontSize: "28px" }} />
+              <Icon icon="lucide:coins" style={{ color: goldColor, fontSize: "28px" }} />
             </Box>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 0.5, sm: 2 }, flex: 1, justifyContent: { xs: 'center', sm: 'flex-start' } }}>
               <Box sx={{ flex: { xs: 1, sm: 'initial' }, textAlign: { xs: 'center', sm: 'left' } }}>
                 <Typography variant="caption" color="text.secondary" display="block">
                   Coins
                 </Typography>
-                <Typography variant="h6" sx={{ fontWeight: "bold", color: "gold", lineHeight: 1 }}>
+                <Typography variant="h6" sx={{ fontWeight: "bold", color: goldColor, lineHeight: 1 }}>
                   {user.coins.toFixed(2)}
                 </Typography>
               </Box>
@@ -423,7 +425,7 @@ export default function StockMarket() {
                 <Typography variant="caption" color="text.secondary" display="block">
                   Stock Value
                 </Typography>
-                <Typography variant="h6" sx={{ fontWeight: "bold", color: "gold", lineHeight: 1 }}>
+                <Typography variant="h6" sx={{ fontWeight: "bold", color: goldColor, lineHeight: 1 }}>
                   {totalStockValue.toFixed(2)}
                 </Typography>
               </Box>
@@ -432,7 +434,7 @@ export default function StockMarket() {
                 <Typography variant="caption" color="text.secondary" display="block">
                   Net Worth
                 </Typography>
-                <Typography variant="h6" sx={{ fontWeight: "bold", color: "gold", lineHeight: 1 }}>
+                <Typography variant="h6" sx={{ fontWeight: "bold", color: goldColor, lineHeight: 1 }}>
                   {(user.coins + totalStockValue).toFixed(2)}
                 </Typography>
               </Box>
@@ -526,7 +528,7 @@ export default function StockMarket() {
                 const isSelf = user.loggedIn && marketMode === "player" && stock.userId === user.id;
                 const name = marketMode === "player" ? stock.username : stock.familyName;
                 return (
-                  <Card key={stock._id || stock.familyId} variant="outlined" sx={{ background: "rgba(0,0,0,0.2)" }}>
+                  <Card key={stock._id || stock.familyId} variant="outlined" sx={{ backgroundColor: theme.palette.mode === "light" ? "rgba(0, 0, 0, 0.02)" : "rgba(0, 0, 0, 0.2)" }}>
                     <CardContent sx={{ p: 2, "&:last-child": { pb: 2 } }}>
                       <Stack direction="row" justifyContent="space-between" alignItems="center" mb={1.5}>
                         <Stack direction="row" spacing={1.5} alignItems="center">
@@ -556,17 +558,23 @@ export default function StockMarket() {
                           <Sparkline history={stock.priceHistory} width={60} height={20} />
                         </Box>
                       </Stack>
-                      <Grid container spacing={1} mb={2}>
-                        <Grid item xs={6}>
+                       <Grid container spacing={1} mb={2}>
+                        <Grid item xs={4}>
                           <Typography variant="caption" color="text.secondary" display="block">Buy Price</Typography>
                           <Typography variant="body2" color="success.main" fontWeight="bold">
                             {stock.buyPrice.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} />
                           </Typography>
                         </Grid>
-                        <Grid item xs={6}>
+                        <Grid item xs={4}>
                           <Typography variant="caption" color="text.secondary" display="block">Sell Price</Typography>
                           <Typography variant="body2" color="error.main" fontWeight="bold">
                             {stock.sellPrice.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} />
+                          </Typography>
+                        </Grid>
+                        <Grid item xs={4}>
+                          <Typography variant="caption" color="text.secondary" display="block">Supply</Typography>
+                          <Typography variant="body2" color="text.primary" fontWeight="bold">
+                            {stock.shareSupply}
                           </Typography>
                         </Grid>
                         <Grid item xs={6}>
@@ -577,7 +585,7 @@ export default function StockMarket() {
                         </Grid>
                         <Grid item xs={6}>
                           <Typography variant="caption" color="text.secondary" display="block">{marketMode === "player" ? "Dividends" : "Treasury"}</Typography>
-                          <Typography variant="body2" color="gold" fontWeight="bold">
+                          <Typography variant="body2" color={goldColor} fontWeight="bold">
                             {marketMode === "player" ? stock.dividendsPaidOut.toFixed(2) : stock.treasuryCoins.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} />
                           </Typography>
                         </Grid>
@@ -593,7 +601,15 @@ export default function StockMarket() {
               {filteredStocks.length === 0 && <Typography color="text.secondary" align="center">No markets found.</Typography>}
             </Stack>
           ) : (
-          <TableContainer component={Paper} variant="outlined" sx={{ width: '100%', overflowX: 'auto' }}>
+          <TableContainer
+            component={Paper}
+            variant="outlined"
+            sx={{
+              width: '100%',
+              overflowX: 'auto',
+              backgroundColor: "background.paper",
+            }}
+          >
             <Table>
               <TableHead>
                 <TableRow>
@@ -668,7 +684,7 @@ export default function StockMarket() {
                         </TableCell>
                         <TableCell align="right" sx={{ display: { xs: 'none', md: 'table-cell' } }}>{stock.shareSupply}</TableCell>
                         {marketMode === "family" && (
-                          <TableCell align="right" sx={{ fontWeight: "bold", color: "gold", display: { xs: 'none', md: 'table-cell' } }}>
+                          <TableCell align="right" sx={{ fontWeight: "bold", color: goldColor, display: { xs: 'none', md: 'table-cell' } }}>
                             {stock.treasuryCoins.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
                           </TableCell>
                         )}
@@ -684,7 +700,7 @@ export default function StockMarket() {
                         <TableCell align="right" sx={{ fontWeight: "bold", color: "error.main", whiteSpace: "nowrap", display: { xs: 'none', sm: 'table-cell' } }}>
                           {stock.sellPrice.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
                         </TableCell>
-                        <TableCell align="right" sx={{ color: "gold", whiteSpace: "nowrap", display: { xs: 'none', sm: 'table-cell' } }}>
+                        <TableCell align="right" sx={{ color: goldColor, whiteSpace: "nowrap", display: { xs: 'none', sm: 'table-cell' } }}>
                           {stock.dividendsPaidOut.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
                         </TableCell>
                         <TableCell align="center">
@@ -731,7 +747,7 @@ export default function StockMarket() {
                   portfolio.map((holding) => {
                     const matchingStock = stocks.find((s) => s.userId === holding.subjectId) || { shareSupply: 0 };
                     return (
-                      <Card key={holding.subjectId} variant="outlined" sx={{ background: "rgba(0,0,0,0.2)" }}>
+                      <Card key={holding.subjectId} variant="outlined" sx={{ backgroundColor: theme.palette.mode === "light" ? "rgba(0, 0, 0, 0.02)" : "rgba(0, 0, 0, 0.2)" }}>
                         <CardContent sx={{ p: 2, "&:last-child": { pb: 2 } }}>
                           <Stack direction="row" spacing={1.5} alignItems="center" mb={1.5}>
                             <StockAvatar targetType="player" id={holding.subjectId} name={holding.username} avatar={holding.avatar} siteInfo={siteInfo} />
@@ -746,12 +762,24 @@ export default function StockMarket() {
                             </Grid>
                             <Grid item xs={4}>
                               <Typography variant="caption" color="text.secondary" display="block">Liquid Value</Typography>
-                              <Typography variant="body2" color="gold" fontWeight="bold">{holding.averageSellValue.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} /></Typography>
+                              <Typography variant="body2" color={goldColor} fontWeight="bold">{holding.averageSellValue.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} /></Typography>
                             </Grid>
                             <Grid item xs={4}>
                               <Typography variant="caption" color="text.secondary" display="block">P&L</Typography>
                               <Typography variant="body2" color={holding.totalPnL >= 0 ? "success.main" : "error.main"} fontWeight="bold">
                                 {holding.totalPnL >= 0 ? "+" : ""}{holding.totalPnL.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} />
+                              </Typography>
+                            </Grid>
+                            <Grid item xs={6}>
+                              <Typography variant="caption" color="text.secondary" display="block">Net Investment</Typography>
+                              <Typography variant="body2" color="text.primary" fontWeight="bold">
+                                {holding.netInvestment.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} />
+                              </Typography>
+                            </Grid>
+                            <Grid item xs={6}>
+                              <Typography variant="caption" color="text.secondary" display="block">Dividends Earned</Typography>
+                              <Typography variant="body2" color={goldColor} fontWeight="bold">
+                                {holding.dividendsReceived.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} />
                               </Typography>
                             </Grid>
                           </Grid>
@@ -771,7 +799,7 @@ export default function StockMarket() {
                   familyPortfolio.map((holding) => {
                     const matchingStock = familyStocks.find((s) => s.familyId === holding.subjectId) || { shareSupply: 0 };
                     return (
-                      <Card key={holding.subjectId} variant="outlined" sx={{ background: "rgba(0,0,0,0.2)" }}>
+                      <Card key={holding.subjectId} variant="outlined" sx={{ backgroundColor: theme.palette.mode === "light" ? "rgba(0, 0, 0, 0.02)" : "rgba(0, 0, 0, 0.2)" }}>
                         <CardContent sx={{ p: 2, "&:last-child": { pb: 2 } }}>
                           <Stack direction="row" spacing={1.5} alignItems="center" mb={1.5}>
                             <StockAvatar targetType="family" id={holding.subjectId} name={holding.familyName} avatar={holding.avatar} siteInfo={siteInfo} />
@@ -786,12 +814,24 @@ export default function StockMarket() {
                             </Grid>
                             <Grid item xs={4}>
                               <Typography variant="caption" color="text.secondary" display="block">Liquid Value</Typography>
-                              <Typography variant="body2" color="gold" fontWeight="bold">{holding.averageSellValue.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} /></Typography>
+                              <Typography variant="body2" color={goldColor} fontWeight="bold">{holding.averageSellValue.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} /></Typography>
                             </Grid>
                             <Grid item xs={4}>
                               <Typography variant="caption" color="text.secondary" display="block">P&L</Typography>
                               <Typography variant="body2" color={holding.totalPnL >= 0 ? "success.main" : "error.main"} fontWeight="bold">
                                 {holding.totalPnL >= 0 ? "+" : ""}{holding.totalPnL.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} />
+                              </Typography>
+                            </Grid>
+                            <Grid item xs={6}>
+                              <Typography variant="caption" color="text.secondary" display="block">Net Investment</Typography>
+                              <Typography variant="body2" color="text.primary" fontWeight="bold">
+                                {holding.netInvestment.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} />
+                              </Typography>
+                            </Grid>
+                            <Grid item xs={6}>
+                              <Typography variant="caption" color="text.secondary" display="block">Dividends Earned</Typography>
+                              <Typography variant="body2" color={goldColor} fontWeight="bold">
+                                {holding.dividendsReceived.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} />
                               </Typography>
                             </Grid>
                           </Grid>
@@ -807,7 +847,15 @@ export default function StockMarket() {
               )}
             </Stack>
         ) : (
-        <TableContainer component={Paper} variant="outlined" sx={{ width: '100%', overflowX: 'auto' }}>
+        <TableContainer
+          component={Paper}
+          variant="outlined"
+          sx={{
+            width: '100%',
+            overflowX: 'auto',
+            backgroundColor: "background.paper",
+          }}
+        >
           <Table>
             <TableHead>
               <TableRow>
@@ -862,13 +910,13 @@ export default function StockMarket() {
                         <TableCell align="right" sx={{ display: { xs: 'none', md: 'table-cell' } }}>
                           {holding.netInvestment.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
                         </TableCell>
-                        <TableCell align="right" sx={{ fontWeight: "bold", color: "gold", display: { xs: 'none', sm: 'table-cell' } }}>
+                        <TableCell align="right" sx={{ fontWeight: "bold", color: goldColor, display: { xs: 'none', sm: 'table-cell' } }}>
                           {holding.averageSellValue.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
                         </TableCell>
                         <TableCell align="right" sx={{ fontWeight: "bold", color: holding.totalPnL >= 0 ? "success.main" : "error.main" }}>
                           {holding.totalPnL >= 0 ? "+" : ""}{holding.totalPnL.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
                         </TableCell>
-                        <TableCell align="right" sx={{ color: "gold", display: { xs: 'none', sm: 'table-cell' } }}>
+                        <TableCell align="right" sx={{ color: goldColor, display: { xs: 'none', sm: 'table-cell' } }}>
                           {holding.dividendsReceived.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
                         </TableCell>
                         <TableCell align="center">
@@ -938,13 +986,13 @@ export default function StockMarket() {
                         <TableCell align="right" sx={{ display: { xs: 'none', md: 'table-cell' } }}>
                           {holding.netInvestment.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
                         </TableCell>
-                        <TableCell align="right" sx={{ fontWeight: "bold", color: "gold", display: { xs: 'none', sm: 'table-cell' } }}>
+                        <TableCell align="right" sx={{ fontWeight: "bold", color: goldColor, display: { xs: 'none', sm: 'table-cell' } }}>
                           {holding.averageSellValue.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
                         </TableCell>
                         <TableCell align="right" sx={{ fontWeight: "bold", color: holding.totalPnL >= 0 ? "success.main" : "error.main" }}>
                           {holding.totalPnL >= 0 ? "+" : ""}{holding.totalPnL.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
                         </TableCell>
-                        <TableCell align="right" sx={{ color: "gold", display: { xs: 'none', sm: 'table-cell' } }}>
+                        <TableCell align="right" sx={{ color: goldColor, display: { xs: 'none', sm: 'table-cell' } }}>
                           {holding.dividendsReceived.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
                         </TableCell>
                         <TableCell align="center">
@@ -984,10 +1032,10 @@ export default function StockMarket() {
           {/* Card 1: Player IPO */}
           {!hasIpoed && (
             <Grid item xs={12} md={eligibleFamilies.length > 0 ? 6 : 12}>
-              <Card variant="outlined" sx={{ p: 2, textAlign: "center", height: "100%" }}>
+              <Card variant="outlined" sx={{ p: 2, textAlign: "center", height: "100%", backgroundColor: "background.paper" }}>
                 <CardContent sx={{ display: "flex", flexDirection: "column", height: "100%", justifyContent: "space-between" }}>
                   <Box>
-                    <Box sx={{ color: "gold", mb: 2 }}>
+                    <Box sx={{ color: goldColor, mb: 2 }}>
                       <Icon icon="lucide:rocket" style={{ fontSize: "64px" }} />
                     </Box>
                     <Typography variant="h5" sx={{ fontWeight: "bold", mb: 1 }}>
@@ -1000,7 +1048,7 @@ export default function StockMarket() {
                   </Box>
 
                   <Stack spacing={2} alignItems="center">
-                    <Paper variant="outlined" sx={{ p: 2, display: "flex", gap: 3, background: "rgba(255,255,255,0.02)" }}>
+                    <Paper variant="outlined" sx={{ p: 2, display: "flex", gap: 3, backgroundColor: theme.palette.mode === "light" ? "rgba(0, 0, 0, 0.02)" : "rgba(255, 255, 255, 0.02)" }}>
                       <Box>
                         <Typography variant="caption" display="block">IPO Fee</Typography>
                         <Typography variant="h6" sx={{ fontWeight: "bold", color: "error.main" }}>-100 Coins</Typography>
@@ -1038,7 +1086,7 @@ export default function StockMarket() {
           {/* Card 2: Family ETF IPO */}
           {eligibleFamilies.length > 0 && (
             <Grid item xs={12} md={!hasIpoed ? 6 : 12}>
-              <Card variant="outlined" sx={{ p: 2, textAlign: "center", height: "100%" }}>
+              <Card variant="outlined" sx={{ p: 2, textAlign: "center", height: "100%", backgroundColor: "background.paper" }}>
                 <CardContent sx={{ display: "flex", flexDirection: "column", height: "100%", justifyContent: "space-between" }}>
                   <Box>
                     <Box sx={{ color: "info.main", mb: 2 }}>
@@ -1070,7 +1118,7 @@ export default function StockMarket() {
                       </Select>
                     </FormControl>
 
-                    <Paper variant="outlined" sx={{ p: 2, display: "flex", gap: 3, background: "rgba(255,255,255,0.02)" }}>
+                    <Paper variant="outlined" sx={{ p: 2, display: "flex", gap: 3, backgroundColor: theme.palette.mode === "light" ? "rgba(0, 0, 0, 0.02)" : "rgba(255, 255, 255, 0.02)" }}>
                       <Box>
                         <Typography variant="caption" display="block">IPO Fee</Typography>
                         <Typography variant="h6" sx={{ fontWeight: "bold", color: "error.main" }}>-200 Coins</Typography>

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -148,6 +148,9 @@ function RoleIconCreditsPanel({
 }
 
 export default function Profile() {
+  const theme = useTheme();
+  const goldColor = theme.palette.mode === "light" ? "#b8860b" : "gold";
+
   const [profileLoaded, setProfileLoaded] = useState(false);
   const [name, setName] = useState();
   const [avatar, setAvatar] = useState();
@@ -1704,7 +1707,7 @@ export default function Profile() {
                       <Typography variant="caption" color="text.secondary" display="block">
                         Current Price
                       </Typography>
-                      <Typography variant="h6" sx={{ fontWeight: "bold", color: "gold" }}>
+                      <Typography variant="h6" sx={{ fontWeight: "bold", color: goldColor }}>
                         {stockInfo.buyPrice.toFixed(2)} Coins
                       </Typography>
                     </Box>
@@ -1726,7 +1729,7 @@ export default function Profile() {
                       <Typography variant="caption" color="text.secondary" display="block">
                         Market Cap
                       </Typography>
-                      <Typography variant="body2" sx={{ fontWeight: "bold", color: "gold" }}>
+                      <Typography variant="body2" sx={{ fontWeight: "bold", color: goldColor }}>
                         {(stockInfo.marketCap).toFixed(2)}
                       </Typography>
                     </Grid>

--- a/routes/stockMarket.js
+++ b/routes/stockMarket.js
@@ -667,9 +667,9 @@ router.get("/families/eligible", async function (req, res) {
 
     const familyIds = families.map(f => f.id);
     const ipoedStocks = await models.FamilyStock.find({ familyId: { $in: familyIds }, isIpoed: true }).select("familyId").lean().exec();
-    const ipoedIds = ipoedStocks.map(s => s.familyId);
+    const ipoedIdsSet = new Set(ipoedStocks.map(s => s.familyId));
 
-    const eligible = families.filter(f => !ipoedIds.includes(f.id));
+    const eligible = families.filter(f => !ipoedIdsSet.has(f.id));
     res.send(eligible);
   } catch (e) {
     if (e.message === "Not logged in") {

--- a/test/stockMarket.test.js
+++ b/test/stockMarket.test.js
@@ -189,6 +189,35 @@ describe("lib/StockMarket", function () {
         updateOneCalls[0].filter.userId.should.equal("subject1");
         updateOneCalls[0].update.$inc.dividendsPaidOut.should.equal(10);
       });
+
+      it("does not distribute dividends to game participants, except the subject user themselves", async function () {
+        const snapshot = {
+          shareSupply: 10,
+          holders: [
+            { holderId: "h1", sharesOwned: 6 },
+            { holderId: "subject1", sharesOwned: 4 }
+          ]
+        };
+
+        // coinsEarned = 20. Dividend pool = 20 * 0.5 = 10.
+        // Participants are ["h1", "subject1"].
+        // h1 (6 shares) is excluded.
+        // subject1 (4 shares) is NOT excluded because they are the subject! -> gets 4 coins
+        const res = await stockMarket.distributeDividends("subject1", 20, snapshot, ["h1", "subject1"]);
+        res.length.should.equal(1);
+
+        res[0].holderId.should.equal("subject1");
+        res[0].payout.should.equal(4);
+
+        bulkWriteCalls.length.should.equal(1);
+        bulkWriteCalls[0].length.should.equal(1);
+        bulkWriteCalls[0][0].updateOne.filter.id.should.equal("subject1");
+        bulkWriteCalls[0][0].updateOne.update.$inc.coins.should.equal(4);
+
+        updateOneCalls.length.should.equal(1);
+        updateOneCalls[0].filter.userId.should.equal("subject1");
+        updateOneCalls[0].update.$inc.dividendsPaidOut.should.equal(4);
+      });
     });
 
     describe("distributeFamilyDividends", function () {
@@ -230,6 +259,34 @@ describe("lib/StockMarket", function () {
         familyUpdateOneCalls.length.should.equal(1);
         familyUpdateOneCalls[0].filter.familyId.should.equal("familyA");
         familyUpdateOneCalls[0].update.$inc.dividendsPaidOut.should.equal(10);
+      });
+
+      it("does not distribute family dividends to game participants, except the winner themselves", async function () {
+        const snapshot = {
+          shareSupply: 10,
+          holders: [
+            { holderId: "h1", sharesOwned: 6 },
+            { holderId: "winner1", sharesOwned: 4 }
+          ]
+        };
+
+        // coinsEarned = 40. Dividend pool = 40 * 0.25 = 10.
+        // Participants are ["h1", "winner1"], but winnerId is "winner1".
+        // h1 is excluded. winner1 is NOT excluded because they are the winner! -> gets 4 coins
+        const res = await stockMarket.distributeFamilyDividends("familyA", 40, snapshot, ["h1", "winner1"], "winner1");
+        res.length.should.equal(1);
+
+        res[0].holderId.should.equal("winner1");
+        res[0].payout.should.equal(4);
+
+        bulkWriteCalls.length.should.equal(1);
+        bulkWriteCalls[0].length.should.equal(1);
+        bulkWriteCalls[0][0].updateOne.filter.id.should.equal("winner1");
+        bulkWriteCalls[0][0].updateOne.update.$inc.coins.should.equal(4);
+
+        familyUpdateOneCalls.length.should.equal(1);
+        familyUpdateOneCalls[0].filter.familyId.should.equal("familyA");
+        familyUpdateOneCalls[0].update.$inc.dividendsPaidOut.should.equal(4);
       });
     });
   });


### PR DESCRIPTION
This PR resolves stock-market related bugs: (1) Corrects Avatar prop to hasImage in TradeDialog. (2) Displays Supply, Net Investment, and Dividends on mobile stock cards. (3) Excludes game participants from dividends except for their own stock wins.