### PR TITLE
Add Dividends Paid to user profile stock widget and format into a 2x2 grid

### DIFF
--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -1717,7 +1717,7 @@ export default function Profile() {
                   </Stack>
 
                   <Grid container spacing={2} sx={{ mt: 0.5, borderTop: "1px solid rgba(255, 255, 255, 0.08)", pt: 1.5 }}>
-                    <Grid item xs={4}>
+                    <Grid item xs={6}>
                       <Typography variant="caption" color="text.secondary" display="block">
                         Total Supply
                       </Typography>
@@ -1725,20 +1725,28 @@ export default function Profile() {
                         {stockInfo.shareSupply} Shares
                       </Typography>
                     </Grid>
-                    <Grid item xs={4}>
+                    <Grid item xs={6}>
                       <Typography variant="caption" color="text.secondary" display="block">
                         Market Cap
                       </Typography>
                       <Typography variant="body2" sx={{ fontWeight: "bold", color: goldColor }}>
-                        {(stockInfo.marketCap).toFixed(2)}
+                        {stockInfo.marketCap.toFixed(2)} Coins
                       </Typography>
                     </Grid>
-                    <Grid item xs={4}>
+                    <Grid item xs={6}>
                       <Typography variant="caption" color="text.secondary" display="block">
                         Your Holdings
                       </Typography>
                       <Typography variant="body2" sx={{ fontWeight: "bold", color: stockInfo.sharesOwned > 0 ? "success.main" : "text.secondary" }}>
                         {stockInfo.sharesOwned} Shares
+                      </Typography>
+                    </Grid>
+                    <Grid item xs={6}>
+                      <Typography variant="caption" color="text.secondary" display="block">
+                        Dividends Paid
+                      </Typography>
+                      <Typography variant="body2" sx={{ fontWeight: "bold", color: goldColor }}>
+                        {(stockInfo.dividendsPaidOut || 0).toFixed(2)} Coins
                       </Typography>
                     </Grid>
                   </Grid>

--- a/routes/user.js
+++ b/routes/user.js
@@ -930,7 +930,8 @@ router.get("/:id/profile", async function (req, res) {
         buyPrice,
         sellPrice,
         priceHistory: history,
-        sharesOwned: 0
+        sharesOwned: 0,
+        dividendsPaidOut: playerStock.dividendsPaidOut || 0
       };
       if (reqUserId) {
         const holding = await models.Shareholder.findOne({ subjectId: userId, holderId: reqUserId }).select("sharesOwned").lean().exec();


### PR DESCRIPTION
This PR adds dividendsPaidOut to the backend stockInfo object on user profiles, formats the profile stock widget in Profile.jsx into a clean 2x2 grid layout, and renders the Dividends Paid value.