### PR TITLE
Replace Net Investment with Cost Basis and Average Buy Price in stock portfolio

### DIFF
--- a/react_main/src/components/TradeDialog.jsx
+++ b/react_main/src/components/TradeDialog.jsx
@@ -122,14 +122,17 @@ export default function TradeDialog({ open, onClose, stock, initialType = "buy",
                 width: 40,
                 height: 40,
                 borderRadius: "50%",
-                backgroundImage: stock.avatar ? `url(/uploads/${stock.id}_family_avatar.webp)` : "none",
-                backgroundSize: "cover",
-                backgroundPosition: "center",
+                border: "1px solid rgba(255, 255, 255, 0.12)",
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                background: stock.avatar ? "none" : "rgba(255, 255, 255, 0.05)",
-                border: "1px solid rgba(255, 255, 255, 0.12)",
+                ...(stock.avatar ? {
+                  backgroundImage: `url(/uploads/${stock.id}_family_avatar.webp?t=${siteInfo?.cacheVal})`,
+                  backgroundSize: "cover",
+                  backgroundPosition: "center",
+                } : {
+                  backgroundColor: "rgba(255, 255, 255, 0.05)",
+                }),
               }}
             >
               {!stock.avatar && <Icon icon="lucide:users" style={{ fontSize: "20px" }} />}

--- a/react_main/src/pages/Fame/StockMarket.jsx
+++ b/react_main/src/pages/Fame/StockMarket.jsx
@@ -783,6 +783,7 @@ export default function StockMarket() {
                             <Grid item xs={4}>
                               <Typography variant="caption" color="text.secondary" display="block">Shares</Typography>
                               <Typography variant="body2" fontWeight="bold">{holding.sharesOwned}</Typography>
+                              <Typography variant="caption" color="text.secondary" display="block">Avg Cost/Share: {holding.averageBuyPrice.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "9px" }} /></Typography>
                             </Grid>
                             <Grid item xs={4}>
                               <Typography variant="caption" color="text.secondary" display="block">Liquid Value</Typography>
@@ -795,9 +796,9 @@ export default function StockMarket() {
                               </Typography>
                             </Grid>
                             <Grid item xs={6}>
-                              <Typography variant="caption" color="text.secondary" display="block">Net Investment</Typography>
+                              <Typography variant="caption" color="text.secondary" display="block">Cost Basis</Typography>
                               <Typography variant="body2" color="text.primary" fontWeight="bold">
-                                {holding.netInvestment.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} />
+                                {holding.costBasis.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} />
                               </Typography>
                             </Grid>
                             <Grid item xs={6}>
@@ -821,12 +822,12 @@ export default function StockMarket() {
                   <Typography color="text.secondary" align="center">You don't own any Family ETFs yet.</Typography>
                 ) : (
                   familyPortfolio.map((holding) => {
-                    const matchingStock = familyStocks.find((s) => s.familyId === holding.subjectId) || { shareSupply: 0 };
+                    const matchingStock = familyStocks.find((s) => s.familyId === holding.familyId) || { shareSupply: 0 };
                     return (
-                      <Card key={holding.subjectId} variant="outlined" sx={{ backgroundColor: theme.palette.mode === "light" ? "rgba(0, 0, 0, 0.02)" : "rgba(0, 0, 0, 0.2)" }}>
+                      <Card key={holding.familyId} variant="outlined" sx={{ backgroundColor: theme.palette.mode === "light" ? "rgba(0, 0, 0, 0.02)" : "rgba(0, 0, 0, 0.2)" }}>
                         <CardContent sx={{ p: 2, "&:last-child": { pb: 2 } }}>
                           <Stack direction="row" spacing={1.5} alignItems="center" mb={1.5}>
-                            <StockAvatar targetType="family" id={holding.subjectId} name={holding.familyName} avatar={holding.avatar} siteInfo={siteInfo} />
+                            <StockAvatar targetType="family" id={holding.familyId} name={holding.familyName} avatar={holding.avatar} siteInfo={siteInfo} />
                             <Typography sx={{ color: "text.primary", fontWeight: "bold" }}>
                               {holding.familyName}
                             </Typography>
@@ -835,6 +836,7 @@ export default function StockMarket() {
                             <Grid item xs={4}>
                               <Typography variant="caption" color="text.secondary" display="block">Shares</Typography>
                               <Typography variant="body2" fontWeight="bold">{holding.sharesOwned}</Typography>
+                              <Typography variant="caption" color="text.secondary" display="block">Avg Cost/Share: {holding.averageBuyPrice.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "9px" }} /></Typography>
                             </Grid>
                             <Grid item xs={4}>
                               <Typography variant="caption" color="text.secondary" display="block">Liquid Value</Typography>
@@ -847,9 +849,9 @@ export default function StockMarket() {
                               </Typography>
                             </Grid>
                             <Grid item xs={6}>
-                              <Typography variant="caption" color="text.secondary" display="block">Net Investment</Typography>
+                              <Typography variant="caption" color="text.secondary" display="block">Cost Basis</Typography>
                               <Typography variant="body2" color="text.primary" fontWeight="bold">
-                                {holding.netInvestment.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} />
+                                {holding.costBasis.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "10px" }} />
                               </Typography>
                             </Grid>
                             <Grid item xs={6}>
@@ -885,9 +887,9 @@ export default function StockMarket() {
               <TableRow>
                 <TableCell>{marketMode === "player" ? "Player" : "Family Name"}</TableCell>
                 <TableCell align="right">Shares</TableCell>
-                <TableCell align="right" sx={{ display: { xs: 'none', md: 'table-cell' } }}>Net Investment</TableCell>
+                <TableCell align="right" sx={{ display: { xs: 'none', md: 'table-cell' } }}>Cost Basis</TableCell>
                 <TableCell align="right" sx={{ display: { xs: 'none', sm: 'table-cell' } }}>Liquid Value</TableCell>
-                <TableCell align="right">Total P&amp;L</TableCell>
+                <TableCell align="right">P&amp;L</TableCell>
                 <TableCell align="right" sx={{ display: { xs: 'none', sm: 'table-cell' } }}>Dividends</TableCell>
                 <TableCell align="center">Actions</TableCell>
               </TableRow>
@@ -935,9 +937,14 @@ export default function StockMarket() {
                             </Typography>
                           </Stack>
                         </TableCell>
-                        <TableCell align="right">{holding.sharesOwned}</TableCell>
+                        <TableCell align="right">
+                          {holding.sharesOwned}
+                          <Typography variant="caption" color="text.secondary" display="block">
+                            Avg Cost/Share: {holding.averageBuyPrice.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "9px" }} />
+                          </Typography>
+                        </TableCell>
                         <TableCell align="right" sx={{ display: { xs: 'none', md: 'table-cell' } }}>
-                          {holding.netInvestment.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
+                          {holding.costBasis.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
                         </TableCell>
                         <TableCell align="right" sx={{ fontWeight: "bold", color: goldColor, display: { xs: 'none', sm: 'table-cell' } }}>
                           {holding.averageSellValue.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
@@ -1011,9 +1018,14 @@ export default function StockMarket() {
                             </Typography>
                           </Stack>
                         </TableCell>
-                        <TableCell align="right">{holding.sharesOwned}</TableCell>
+                        <TableCell align="right">
+                          {holding.sharesOwned}
+                          <Typography variant="caption" color="text.secondary" display="block">
+                            Avg Cost/Share: {holding.averageBuyPrice.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "9px" }} />
+                          </Typography>
+                        </TableCell>
                         <TableCell align="right" sx={{ display: { xs: 'none', md: 'table-cell' } }}>
-                          {holding.netInvestment.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
+                          {holding.costBasis.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />
                         </TableCell>
                         <TableCell align="right" sx={{ fontWeight: "bold", color: goldColor, display: { xs: 'none', sm: 'table-cell' } }}>
                           {holding.averageSellValue.toFixed(2)} <Icon icon="lucide:coins" style={{ fontSize: "12px", verticalAlign: "middle" }} />

--- a/routes/stockMarket.js
+++ b/routes/stockMarket.js
@@ -67,21 +67,28 @@ function buildPriceHistory(stocks, txsMap, idField) {
 }
 
 /**
- * Computes net investment per entity from a user's transaction history.
- * netInvestment = sum(buy price + fee) - sum(sell price - fee)
+ * Computes cost basis and average buy price per entity from a user's transaction history.
  */
-function buildNetInvestmentMap(transactions, idField) {
-  const netInvestmentMap = {};
+function buildPositionStatsMap(transactions, idField) {
+  const statsMap = {};
   for (const tx of transactions) {
     const entityId = tx[idField];
-    if (!netInvestmentMap[entityId]) netInvestmentMap[entityId] = 0;
+    if (!statsMap[entityId]) {
+      statsMap[entityId] = { costBasis: 0, shares: 0, averageBuyPrice: 0 };
+    }
+    const stats = statsMap[entityId];
     if (tx.type === "buy") {
-      netInvestmentMap[entityId] += tx.price + tx.fee;
+      stats.costBasis += tx.price + tx.fee;
+      stats.shares += tx.shares;
+      stats.averageBuyPrice = stats.shares > 0 ? stats.costBasis / stats.shares : 0;
     } else {
-      netInvestmentMap[entityId] -= (tx.price - tx.fee);
+      const avgPrice = stats.shares > 0 ? stats.costBasis / stats.shares : 0;
+      stats.shares = Math.max(0, stats.shares - tx.shares);
+      stats.costBasis = stats.shares * avgPrice;
+      stats.averageBuyPrice = avgPrice;
     }
   }
-  return netInvestmentMap;
+  return statsMap;
 }
 
 // ---------------------------------------------------------------------------
@@ -426,6 +433,7 @@ router.get("/portfolio", async function (req, res) {
         .lean()
         .exec(),
       models.StockTransaction.find({ userId, subjectId: { $in: subjectIds } })
+        .sort({ createdAt: 1 })
         .select("subjectId type price fee shares")
         .lean()
         .exec()
@@ -440,16 +448,17 @@ router.get("/portfolio", async function (req, res) {
     const holdingMap = {};
     for (const h of holdings) holdingMap[h.subjectId] = h;
 
-    const netInvestmentMap = buildNetInvestmentMap(transactions, "subjectId");
+    const statsMap = buildPositionStatsMap(transactions, "subjectId");
 
     const result = subjectIds.map(subjectId => {
       const h = holdingMap[subjectId];
       const stock = stockMap[subjectId] || { shareSupply: 0 };
       const u = userMap[subjectId] || { name: "Unknown" };
       const sellPrice = stockMarket.getSellPrice(stock.shareSupply, h.sharesOwned);
-      const netInvestment = parseFloat((netInvestmentMap[subjectId] || 0).toFixed(2));
+      const stats = statsMap[subjectId] || { costBasis: 0, averageBuyPrice: 0 };
+      const costBasis = parseFloat(stats.costBasis.toFixed(2));
       const liquidValue = sellPrice.total;
-      const totalPnL = parseFloat((liquidValue - netInvestment).toFixed(2));
+      const totalPnL = parseFloat((liquidValue - costBasis).toFixed(2));
 
       return {
         subjectId,
@@ -460,7 +469,9 @@ router.get("/portfolio", async function (req, res) {
         sharesOwned: h.sharesOwned,
         averageSellValue: liquidValue,
         currentSingleSellPrice: stockMarket.getSellPrice(stock.shareSupply, 1).total,
-        netInvestment,
+        netInvestment: costBasis,
+        costBasis,
+        averageBuyPrice: parseFloat(stats.averageBuyPrice.toFixed(2)),
         totalPnL,
         dividendsReceived: parseFloat(h.dividendsReceived.toFixed(2))
       };
@@ -709,17 +720,18 @@ router.get("/families/portfolio", async function (req, res) {
     const transactions = await models.FamilyStockTransaction.find({
       userId,
       familyId: { $in: familyIds }
-    }).lean().exec();
+    }).sort({ createdAt: 1 }).lean().exec();
 
-    const netInvestmentMap = buildNetInvestmentMap(transactions, "familyId");
+    const statsMap = buildPositionStatsMap(transactions, "familyId");
 
     const result = holdings.map(h => {
       const stock = stockMap[h.familyId] || { shareSupply: 0 };
       const f = familyMap[h.familyId] || { name: "Unknown" };
       const sellPrice = stockMarket.getSellPrice(stock.shareSupply, h.sharesOwned);
-      const netInvestment = parseFloat((netInvestmentMap[h.familyId] || 0).toFixed(2));
+      const stats = statsMap[h.familyId] || { costBasis: 0, averageBuyPrice: 0 };
+      const costBasis = parseFloat(stats.costBasis.toFixed(2));
       const liquidValue = sellPrice.total;
-      const totalPnL = parseFloat((liquidValue - netInvestment).toFixed(2));
+      const totalPnL = parseFloat((liquidValue - costBasis).toFixed(2));
 
       return {
         familyId: h.familyId,
@@ -729,7 +741,9 @@ router.get("/families/portfolio", async function (req, res) {
         sharesOwned: h.sharesOwned,
         averageSellValue: liquidValue,
         currentSingleSellPrice: stockMarket.getSellPrice(stock.shareSupply, 1).total,
-        netInvestment,
+        netInvestment: costBasis,
+        costBasis,
+        averageBuyPrice: parseFloat(stats.averageBuyPrice.toFixed(2)),
         totalPnL,
         dividendsReceived: parseFloat(h.dividendsReceived.toFixed(2))
       };


### PR DESCRIPTION
This PR replaces the confusing Net Investment (lifetime cash flow) metric with Cost Basis (capital at risk in current holdings) and adds Average Buy Price sub-labels underneath the Shares column on both mobile and desktop portfolio views.