### PR TITLE
Reset dividendsReceived when opening a new stock position

### DIFF
--- a/routes/stockMarket.js
+++ b/routes/stockMarket.js
@@ -208,9 +208,17 @@ function createBuyHandler(config) {
         }
 
         // 6. Update shareholder balance
+        const currentHolding = await config.shareholderModel.findOne(
+          config.getShareholderFilter(entityId, userId)
+        ).lean().exec();
+        const needsReset = !currentHolding || currentHolding.sharesOwned === 0;
+
         await config.shareholderModel.updateOne(
           config.getShareholderFilter(entityId, userId),
-          { $inc: { sharesOwned: sharesToBuy } },
+          {
+            $inc: { sharesOwned: sharesToBuy },
+            ...(needsReset ? { $set: { dividendsReceived: 0 } } : {})
+          },
           { upsert: true }
         ).exec();
 


### PR DESCRIPTION
This PR resets the dividendsReceived field to 0 when a user opens a new stock position (i.e., when their sharesOwned transitions from 0 to >0). This ensures the Dividends column in the user's portfolio strictly represents the current open position rather than mixing in historical dividends from previously closed positions.