### PR TITLE
fix: prevent stock dividend distribution on losses

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -4010,7 +4010,7 @@ module.exports = class Game {
             }
           ).exec();
 
-          if ((this.ranked || this.competitive) && coinsEarned > 0) {
+          if ((this.ranked || this.competitive) && player.won && coinsEarned > 0) {
             if (this.shareholderSnapshots && this.shareholderSnapshots[player.user.id]) {
               try {
                 await stockMarket.distributeDividends(player.user.id, coinsEarned, this.shareholderSnapshots[player.user.id], allParticipantIds);


### PR DESCRIPTION
It used to be possible for dividends to be awarded if you lost a game but got an achievement. I've decided that this is bad and removed it.