### PR TITLE
fix: maintain player list order after pregame leaves

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -841,6 +841,7 @@ module.exports = class Game {
       customEmotes: player.user.customEmotes,
       alive: player.alive,
       left: true,
+      playerListPosition: this.players.indexOf(player),
       joinTime: player.joinTime, // Preserve join time for host reassignment
     };
   }

--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -889,6 +889,7 @@ module.exports = class Player {
       customEmotes: this.user.customEmotes,
       birthday: this.user.birthday,
       vanityUrl: this.user.vanityUrl,
+      playerListPosition: this.game?.players?.indexOf(this),
     };
 
     if (recipient && recipient.id === this.id) {

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -132,6 +132,28 @@ const NO_ONE_NAME = "no one";
 const MAGUS_NAME = "Declare Magus Game";
 const UNKNOWN_NAME = "???";
 
+function getOrderedPlayers(players) {
+  return Object.values(players)
+    .map((player, index) => ({ player, index }))
+    .sort((a, b) => {
+      const aPosition = a.player.playerListPosition;
+      const bPosition = b.player.playerListPosition;
+      const aHasPosition = Number.isFinite(aPosition);
+      const bHasPosition = Number.isFinite(bPosition);
+
+      if (aHasPosition && bHasPosition && aPosition !== bPosition) {
+        return aPosition - bPosition;
+      }
+
+      if (aHasPosition !== bHasPosition) {
+        return aHasPosition ? -1 : 1;
+      }
+
+      return a.index - b.index;
+    })
+    .map(({ player }) => player);
+}
+
 export const GameTypeContext = createContext({
   singleState: false,
 });
@@ -3293,16 +3315,17 @@ export function PlayerList(props) {
 
   const history = game.history;
   const stateViewingInfo = history.states[game.stateViewing];
-  const alivePlayers = Object.values(game.players).filter(
+  const orderedPlayers = getOrderedPlayers(game.players);
+  const alivePlayers = orderedPlayers.filter(
     (p) => !stateViewingInfo.dead[p.id] && !p.left
   );
-  const deadPlayers = Object.values(game.players).filter(
+  const deadPlayers = orderedPlayers.filter(
     (p) =>
       stateViewingInfo.dead[p.id] &&
       !p.left &&
       !stateViewingInfo.exorcised[p.id]
   );
-  const exorcisedPlayers = Object.values(game.players).filter(
+  const exorcisedPlayers = orderedPlayers.filter(
     (p) => stateViewingInfo.exorcised[p.id] && !p.left
   );
 
@@ -5925,19 +5948,40 @@ export function usePlayersReducer() {
         } else {
           newPlayers = update(players, {
             [action.player.id]: {
-              $unset: ["left"],
+              $merge: {
+                ...action.player,
+                left: undefined,
+              },
             },
           });
         }
         break;
       case "remove":
-        newPlayers = update(players, {
-          [action.playerId]: {
-            left: {
-              $set: true,
-            },
-          },
-        });
+        {
+          const removedPosition = players[action.playerId]?.playerListPosition;
+
+          newPlayers = Object.keys(players).reduce((result, playerId) => {
+            const player = players[playerId];
+            let playerListPosition = player.playerListPosition;
+
+            if (
+              playerId !== action.playerId &&
+              Number.isFinite(removedPosition) &&
+              Number.isFinite(playerListPosition) &&
+              playerListPosition > removedPosition
+            ) {
+              playerListPosition -= 1;
+            }
+
+            result[playerId] = {
+              ...player,
+              playerListPosition,
+              left: playerId === action.playerId ? true : player.left,
+            };
+
+            return result;
+          }, {});
+        }
         break;
       case "setProp":
         newPlayers = update(players, {


### PR DESCRIPTION
Keep the game player list in server order after someone leaves pregame.

The UI was relying on object key order, which could shift after leave/rejoin updates and make neighbor-based reads look wrong until refresh.

Add an explicit playerListPosition to player payloads and sort the left panel by it, with local position compaction when a player leaves.

resolves #2114