### PR TITLE
feat: Add OpenSkill-based skill rating system

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -39,6 +39,7 @@ const {
   syncRankedCompetitiveAccess,
 } = require("../../modules/userEligibility");
 const stockMarket = require("../../lib/StockMarket");
+const skillRating = require("../../modules/skillRating");
 
 module.exports = class Game {
   constructor(options) {
@@ -3915,6 +3916,12 @@ module.exports = class Game {
         anonymousDeck: this.anonymousDeck,
       });
       const gameDocument = await game.save();
+
+      try {
+        await skillRating.updateGameRatings(gameDocument);
+      } catch (err) {
+        logger.error(`Failed to update skill ratings for game ${this.id}: ${err.message}`);
+      }
 
       if (this.competitive) {
         await this.recordCompetitiveCompletions(gameDocument._id);

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -207,6 +207,11 @@ var schemas = {
     playedGame: { type: Boolean, default: false },
     referrer: String,
     transactions: [Number],
+    skillRating: {
+      mu: { type: Number, default: 25.0 },
+      sigma: { type: Number, default: 25.0 / 3.0 },
+      gamesPlayed: { type: Number, default: 0 },
+    },
     deleted: { type: Boolean, default: false },
     banned: { type: Boolean, default: false },
     flagged: { type: Boolean, default: false },
@@ -369,6 +374,14 @@ var schemas = {
     /** Setup version manifest at game end (for backfill / audits). */
     setupVersion: { type: Number, default: null },
     setupStatsBackfilled: { type: Boolean, default: false },
+    skillRatingChanges: [
+      {
+        userId: { type: String, index: true },
+        muDelta: { type: Number },
+        sigmaDelta: { type: Number },
+      },
+    ],
+    skillRefunded: { type: Boolean, default: false },
   }),
   ArchivedGame: new mongoose.Schema({
     user: {

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -210,7 +210,7 @@ var schemas = {
     skillRating: {
       mu: { type: Number, default: 25.0 },
       sigma: { type: Number, default: 25.0 / 3.0 },
-      gamesPlayed: { type: Number, default: 0 },
+      gamesPlayed: { type: Number, default: 0, index: true },
     },
     deleted: { type: Boolean, default: false },
     banned: { type: Boolean, default: false },

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -16,7 +16,6 @@ services:
       - "3001:3001"
     volumes:
       - ./:/home/um/
-      - web_node_modules:/home/um/react_main/node_modules
     networks:
       - my_net
     logging:
@@ -43,8 +42,7 @@ services:
       - "9230:9230"
       - "9231:9231"
       - "9232:9232"
-    volumes:
-      - backend_node_modules:/home/um/node_modules
+
 
 volumes:
   web_node_modules:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -16,6 +16,7 @@ services:
       - "3001:3001"
     volumes:
       - ./:/home/um/
+      - web_node_modules:/home/um/react_main/node_modules
     networks:
       - my_net
     logging:
@@ -42,7 +43,8 @@ services:
       - "9230:9230"
       - "9231:9231"
       - "9232:9232"
-
+    volumes:
+      - backend_node_modules:/home/um/node_modules
 
 volumes:
   web_node_modules:

--- a/migrations/backfillSkillRatings.js
+++ b/migrations/backfillSkillRatings.js
@@ -2,6 +2,7 @@ require("dotenv").config();
 const mongoose = require("mongoose");
 const models = require("../db/models");
 const skillRating = require("../modules/skillRating");
+const { DEFAULT_MU, DEFAULT_SIGMA } = require("../modules/skillRating");
 
 async function backfillSkillRatings() {
   try {
@@ -13,8 +14,8 @@ async function backfillSkillRatings() {
       {},
       {
         $set: {
-          "skillRating.mu": 25.0,
-          "skillRating.sigma": 25.0 / 3.0,
+          "skillRating.mu": DEFAULT_MU,
+          "skillRating.sigma": DEFAULT_SIGMA,
           "skillRating.gamesPlayed": 0,
         }
       }
@@ -34,20 +35,21 @@ async function backfillSkillRatings() {
     );
     console.log(`Clear completed for games: matched ${resetGameResult.matchedCount}, modified ${resetGameResult.modifiedCount}`);
 
-    // 3. Query all ranked or competitive games that successfully ended, sorted chronologically
-    console.log("Fetching ranked and competitive games in chronological order...");
-    const games = await models.Game.find({
+    // 3. Stream ranked/competitive games chronologically instead of loading all into memory
+    console.log("Streaming ranked and competitive games in chronological order...");
+    const cursor = models.Game.find({
       $or: [{ ranked: true }, { competitive: true }],
       endTime: { $exists: true, $gt: 0 },
       broken: { $ne: true }
-    }).sort({ startTime: 1 });
-
-    console.log(`Found ${games.length} games to process.`);
+    }).sort({ startTime: 1 }).lean().cursor();
 
     let processedCount = 0;
     let skippedCount = 0;
+    let totalCount = 0;
 
-    for (const game of games) {
+    for await (const game of cursor) {
+      totalCount++;
+
       // Check if the game has players
       const playerIdMap = typeof game.playerIdMap === "string" ? JSON.parse(game.playerIdMap || "{}") : (game.playerIdMap || {});
       const userIds = Object.keys(playerIdMap);
@@ -61,11 +63,11 @@ async function backfillSkillRatings() {
       processedCount++;
 
       if (processedCount % 50 === 0) {
-        console.log(`Processed ${processedCount}/${games.length} games...`);
+        console.log(`Processed ${processedCount} games (${totalCount} seen so far)...`);
       }
     }
 
-    console.log(`Backfill finished. Processed: ${processedCount}, Skipped: ${skippedCount} games.`);
+    console.log(`Backfill finished. Processed: ${processedCount}, Skipped: ${skippedCount}, Total: ${totalCount} games.`);
   } catch (error) {
     console.error("Backfill failed:", error);
     throw error;

--- a/migrations/backfillSkillRatings.js
+++ b/migrations/backfillSkillRatings.js
@@ -1,0 +1,89 @@
+require("dotenv").config();
+const mongoose = require("mongoose");
+const models = require("../db/models");
+const skillRating = require("../modules/skillRating");
+
+async function backfillSkillRatings() {
+  try {
+    console.log("Starting skill ratings backfill...");
+
+    // 1. Reset all users' skill rating fields
+    console.log("Resetting all users' skill ratings to default...");
+    const resetUserResult = await models.User.updateMany(
+      {},
+      {
+        $set: {
+          "skillRating.mu": 25.0,
+          "skillRating.sigma": 25.0 / 3.0,
+          "skillRating.gamesPlayed": 0,
+        }
+      }
+    );
+    console.log(`Reset completed for users: matched ${resetUserResult.matchedCount}, modified ${resetUserResult.modifiedCount}`);
+
+    // 2. Clear any existing skillRatingChanges or skillRefunded fields on all games
+    console.log("Clearing existing skill changes and refund flags on all games...");
+    const resetGameResult = await models.Game.updateMany(
+      {},
+      {
+        $set: {
+          skillRatingChanges: [],
+          skillRefunded: false
+        }
+      }
+    );
+    console.log(`Clear completed for games: matched ${resetGameResult.matchedCount}, modified ${resetGameResult.modifiedCount}`);
+
+    // 3. Query all ranked or competitive games that successfully ended, sorted chronologically
+    console.log("Fetching ranked and competitive games in chronological order...");
+    const games = await models.Game.find({
+      $or: [{ ranked: true }, { competitive: true }],
+      endTime: { $exists: true, $gt: 0 },
+      broken: { $ne: true }
+    }).sort({ startTime: 1 });
+
+    console.log(`Found ${games.length} games to process.`);
+
+    let processedCount = 0;
+    let skippedCount = 0;
+
+    for (const game of games) {
+      // Check if the game has players
+      const playerIdMap = typeof game.playerIdMap === "string" ? JSON.parse(game.playerIdMap || "{}") : (game.playerIdMap || {});
+      const userIds = Object.keys(playerIdMap);
+
+      if (userIds.length === 0) {
+        skippedCount++;
+        continue;
+      }
+
+      await skillRating.updateGameRatings(game);
+      processedCount++;
+
+      if (processedCount % 50 === 0) {
+        console.log(`Processed ${processedCount}/${games.length} games...`);
+      }
+    }
+
+    console.log(`Backfill finished. Processed: ${processedCount}, Skipped: ${skippedCount} games.`);
+  } catch (error) {
+    console.error("Backfill failed:", error);
+    throw error;
+  }
+}
+
+if (require.main === module) {
+  const db = require("../db/db");
+
+  backfillSkillRatings()
+    .then(() => {
+      console.log("Backfill successful!");
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error("Backfill failed:", err);
+      process.exit(1);
+    });
+}
+
+module.exports = backfillSkillRatings;

--- a/modules/hallOfFame.js
+++ b/modules/hallOfFame.js
@@ -5,6 +5,7 @@ const {
   isCountableScrapbookRole,
   getTotalObtainableStamps,
 } = require("../shared/scrapbook");
+const skillRating = require("./skillRating");
 
 const TOTAL_OBTAINABLE_STAMPS = getTotalObtainableStamps(roleData);
 
@@ -21,6 +22,7 @@ const SUPPORTED_CATEGORIES = [
   "karma",
   "achievements",
   "scrapbook",
+  "skillRating",
 ];
 const SUPPORTED_SORT_DIRECTIONS = ["asc", "desc"];
 const SUPPORTED_SORT_KEYS = [
@@ -39,6 +41,7 @@ const SUPPORTED_SORT_KEYS = [
   "scrapbookCompletion",
   "scrapbookCount",
   "compositeScore",
+  "skillRating",
 ];
 
 const TROPHY_TYPE_WEIGHTS = {
@@ -103,6 +106,12 @@ const CATEGORY_DEFINITIONS = {
     metricLabel: "Scrapbook Completion",
     minGamesRequired: false,
     tieBreakers: ["scrapbookCount", "trophyScore", "achievementScore", "winRate"],
+  },
+  skillRating: {
+    metricKey: "skillRating",
+    metricLabel: "Skill Rating",
+    minGamesRequired: false,
+    tieBreakers: ["winRate", "prestige", "fortune", "wins"],
   },
 };
 
@@ -294,7 +303,7 @@ async function buildRows() {
     playedGame: true,
   })
     .select(
-      "id name avatar stats winRate kudos karma points championshipPoints achievementCount achievements settings"
+      "id name avatar stats winRate kudos karma points championshipPoints achievementCount achievements settings skillRating"
     )
     .lean();
 
@@ -307,6 +316,16 @@ async function buildRows() {
 
   const { scrapbookDataByUser, scrapbookTotal } = scrapbookData;
 
+  const activeRanks = [];
+  for (const user of users) {
+    if (user.skillRating && user.skillRating.gamesPlayed > 0) {
+      const mu = user.skillRating.mu ?? 25.0;
+      const sigma = user.skillRating.sigma ?? (25.0 / 3.0);
+      activeRanks.push(mu - 3.0 * sigma);
+    }
+  }
+  activeRanks.sort((a, b) => a - b);
+
   const rows = users.map((user) => {
     const winsLosses = getWinsLosses(user.stats);
     const trophyData = trophyDataByUser[user.id] || {
@@ -316,6 +335,12 @@ async function buildRows() {
     const scrapbookInfo = scrapbookDataByUser[user.id] || {
       scrapbookCount: 0,
     };
+
+    const mu = user.skillRating?.mu ?? 25.0;
+    const sigma = user.skillRating?.sigma ?? (25.0 / 3.0);
+    const gamesPlayed = user.skillRating?.gamesPlayed ?? 0;
+    const conservativeRank = mu - 3.0 * sigma;
+    const tier = gamesPlayed > 0 ? skillRating.getTier(conservativeRank, activeRanks) : "Unranked";
 
     return {
       userId: user.id,
@@ -343,6 +368,11 @@ async function buildRows() {
         hideStatistics: Boolean(user.settings?.hideStatistics),
         hideKarma: Boolean(user.settings?.hideKarma),
       },
+      skillRating: roundMetric(conservativeRank, 4),
+      skillMu: roundMetric(mu, 4),
+      skillSigma: roundMetric(sigma, 4),
+      skillTier: tier,
+      skillGamesPlayed: gamesPlayed,
     };
   });
 
@@ -394,6 +424,9 @@ function applyCategoryRules(rows, category, minGames) {
   if (category === "winRate") {
     return rows.filter((row) => row.totalGames >= minGames);
   }
+  if (category === "skillRating") {
+    return rows.filter((row) => row.skillGamesPlayed > 0);
+  }
 
   return rows;
 }
@@ -430,6 +463,11 @@ function buildResponseRows(rows) {
     scrapbookCount: row.scrapbookCount,
     scrapbookCompletion: row.scrapbookCompletion,
     compositeScore: row.compositeScore,
+    skillRating: row.skillRating,
+    skillMu: row.skillMu,
+    skillSigma: row.skillSigma,
+    skillTier: row.skillTier,
+    skillGamesPlayed: row.skillGamesPlayed,
   }));
 }
 

--- a/modules/hallOfFame.js
+++ b/modules/hallOfFame.js
@@ -6,6 +6,7 @@ const {
   getTotalObtainableStamps,
 } = require("../shared/scrapbook");
 const skillRating = require("./skillRating");
+const { DEFAULT_MU, DEFAULT_SIGMA } = skillRating;
 
 const TOTAL_OBTAINABLE_STAMPS = getTotalObtainableStamps(roleData);
 
@@ -319,8 +320,8 @@ async function buildRows() {
   const activeRanks = [];
   for (const user of users) {
     if (user.skillRating && user.skillRating.gamesPlayed > 0) {
-      const mu = user.skillRating.mu ?? 25.0;
-      const sigma = user.skillRating.sigma ?? (25.0 / 3.0);
+      const mu = user.skillRating.mu ?? DEFAULT_MU;
+      const sigma = user.skillRating.sigma ?? DEFAULT_SIGMA;
       activeRanks.push(mu - 3.0 * sigma);
     }
   }
@@ -336,8 +337,8 @@ async function buildRows() {
       scrapbookCount: 0,
     };
 
-    const mu = user.skillRating?.mu ?? 25.0;
-    const sigma = user.skillRating?.sigma ?? (25.0 / 3.0);
+    const mu = user.skillRating?.mu ?? DEFAULT_MU;
+    const sigma = user.skillRating?.sigma ?? DEFAULT_SIGMA;
     const gamesPlayed = user.skillRating?.gamesPlayed ?? 0;
     const conservativeRank = mu - 3.0 * sigma;
     const tier = gamesPlayed > 0 ? skillRating.getTier(conservativeRank, activeRanks) : "Unranked";

--- a/modules/skillRating.js
+++ b/modules/skillRating.js
@@ -1,7 +1,10 @@
 const models = require("../db/models");
 
+const DEFAULT_MU = 25.0;
+const DEFAULT_SIGMA = DEFAULT_MU / 3.0;
+
 class AspectSkillRating {
-  constructor(rating = 25.0, uncertainty = 25.0 / 3.0) {
+  constructor(rating = DEFAULT_MU, uncertainty = DEFAULT_SIGMA) {
     this.rating = rating;
     this.uncertainty = uncertainty;
   }
@@ -136,15 +139,15 @@ async function updateGameRatings(game) {
 
   const winningTeam = winningUserIds.map(userId => {
     const user = userMap[userId];
-    const mu = user?.skillRating?.mu ?? 25.0;
-    const sigma = user?.skillRating?.sigma ?? (25.0 / 3.0);
+    const mu = user?.skillRating?.mu ?? DEFAULT_MU;
+    const sigma = user?.skillRating?.sigma ?? DEFAULT_SIGMA;
     return new AspectSkillRating(mu, sigma);
   });
 
   const losingTeam = losingUserIds.map(userId => {
     const user = userMap[userId];
-    const mu = user?.skillRating?.mu ?? 25.0;
-    const sigma = user?.skillRating?.sigma ?? (25.0 / 3.0);
+    const mu = user?.skillRating?.mu ?? DEFAULT_MU;
+    const sigma = user?.skillRating?.sigma ?? DEFAULT_SIGMA;
     return new AspectSkillRating(mu, sigma);
   });
 
@@ -153,52 +156,35 @@ async function updateGameRatings(game) {
   const ratingChanges = [];
   const bulkOps = [];
 
-  for (let i = 0; i < winningUserIds.length; i++) {
-    const userId = winningUserIds[i];
-    const oldRating = winningTeam[i];
-    const newRating = newWinners[i];
-    const muDelta = newRating.rating - oldRating.rating;
-    const sigmaDelta = newRating.uncertainty - oldRating.uncertainty;
+  const teams = [
+    { userIds: winningUserIds, ratings: newWinners, oldRatings: winningTeam },
+    { userIds: losingUserIds, ratings: newLosers, oldRatings: losingTeam },
+  ];
 
-    ratingChanges.push({ userId, muDelta, sigmaDelta });
-    bulkOps.push({
-      updateOne: {
-        filter: { id: userId },
-        update: {
-          $set: {
-            "skillRating.mu": newRating.rating,
-            "skillRating.sigma": newRating.uncertainty,
-          },
-          $inc: {
-            "skillRating.gamesPlayed": 1
+  for (const { userIds, ratings, oldRatings } of teams) {
+    for (let i = 0; i < userIds.length; i++) {
+      const userId = userIds[i];
+      const oldRating = oldRatings[i];
+      const newRating = ratings[i];
+      const muDelta = newRating.rating - oldRating.rating;
+      const sigmaDelta = newRating.uncertainty - oldRating.uncertainty;
+
+      ratingChanges.push({ userId, muDelta, sigmaDelta });
+      bulkOps.push({
+        updateOne: {
+          filter: { id: userId },
+          update: {
+            $set: {
+              "skillRating.mu": newRating.rating,
+              "skillRating.sigma": newRating.uncertainty,
+            },
+            $inc: {
+              "skillRating.gamesPlayed": 1
+            }
           }
         }
-      }
-    });
-  }
-
-  for (let i = 0; i < losingUserIds.length; i++) {
-    const userId = losingUserIds[i];
-    const oldRating = losingTeam[i];
-    const newRating = newLosers[i];
-    const muDelta = newRating.rating - oldRating.rating;
-    const sigmaDelta = newRating.uncertainty - oldRating.uncertainty;
-
-    ratingChanges.push({ userId, muDelta, sigmaDelta });
-    bulkOps.push({
-      updateOne: {
-        filter: { id: userId },
-        update: {
-          $set: {
-            "skillRating.mu": newRating.rating,
-            "skillRating.sigma": newRating.uncertainty,
-          },
-          $inc: {
-            "skillRating.gamesPlayed": 1
-          }
-        }
-      }
-    });
+      });
+    }
   }
 
   if (bulkOps.length > 0) {
@@ -221,15 +207,20 @@ async function refundGameRatings(game) {
     return;
   }
 
+  // Batch-fetch all affected users in a single query instead of one-by-one
+  const changeUserIds = game.skillRatingChanges.map(c => c.userId);
+  const usersArr = await models.User.find({ id: { $in: changeUserIds } }).select("id skillRating").lean();
+  const userMap = new Map(usersArr.map(u => [u.id, u]));
+
   const bulkOps = [];
   const SIGMA_MIN = 0.1; // Math.sqrt(0.01)
 
   for (const change of game.skillRatingChanges) {
-    const user = await models.User.findOne({ id: change.userId }).select("skillRating").lean();
+    const user = userMap.get(change.userId);
     if (!user) continue;
 
-    const currentMu = user.skillRating?.mu ?? 25.0;
-    const currentSigma = user.skillRating?.sigma ?? (25.0 / 3.0);
+    const currentMu = user.skillRating?.mu ?? DEFAULT_MU;
+    const currentSigma = user.skillRating?.sigma ?? DEFAULT_SIGMA;
 
     const newMu = currentMu - change.muDelta;
     const newSigma = Math.max(SIGMA_MIN, currentSigma - change.sigmaDelta);
@@ -263,8 +254,21 @@ async function refundGameRatings(game) {
 
 function getTier(rank, sortedRanks) {
   if (sortedRanks.length === 0) return "Unranked";
-  const index = sortedRanks.indexOf(rank);
-  if (index === -1) return "Unranked";
+
+  // Binary search to find insertion index (avoids float equality issues with indexOf)
+  let lo = 0;
+  let hi = sortedRanks.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (sortedRanks[mid] < rank) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  // lo is the insertion point; if rank not found exactly, use nearest index
+  const index = lo < sortedRanks.length ? lo : sortedRanks.length - 1;
+
   const percentile = sortedRanks.length > 1 ? (index / (sortedRanks.length - 1)) * 100 : 100;
   if (percentile >= 98) return "Master";
   if (percentile >= 90) return "Diamond";
@@ -275,6 +279,8 @@ function getTier(rank, sortedRanks) {
 }
 
 module.exports = {
+  DEFAULT_MU,
+  DEFAULT_SIGMA,
   AspectSkillRating,
   aspectSkillTwoTeams,
   expectedScoreTwoTeams,

--- a/modules/skillRating.js
+++ b/modules/skillRating.js
@@ -220,10 +220,7 @@ async function refundGameRatings(game) {
     if (!user) continue;
 
     const currentMu = user.skillRating?.mu ?? DEFAULT_MU;
-    const currentSigma = user.skillRating?.sigma ?? DEFAULT_SIGMA;
-
     const newMu = currentMu - change.muDelta;
-    const newSigma = Math.max(SIGMA_MIN, currentSigma - change.sigmaDelta);
 
     bulkOps.push({
       updateOne: {
@@ -231,7 +228,6 @@ async function refundGameRatings(game) {
         update: {
           $set: {
             "skillRating.mu": newMu,
-            "skillRating.sigma": newSigma,
           },
           $inc: {
             "skillRating.gamesPlayed": -1
@@ -266,8 +262,19 @@ function getTier(rank, sortedRanks) {
       hi = mid;
     }
   }
-  // lo is the insertion point; if rank not found exactly, use nearest index
-  const index = lo < sortedRanks.length ? lo : sortedRanks.length - 1;
+  // lo is the insertion point; check if the rank is actually in the array within float tolerance
+  let index = lo;
+  const tolerance = 1e-9;
+  let found = false;
+  if (lo < sortedRanks.length && Math.abs(sortedRanks[lo] - rank) < tolerance) {
+    found = true;
+    index = lo;
+  } else if (lo > 0 && Math.abs(sortedRanks[lo - 1] - rank) < tolerance) {
+    found = true;
+    index = lo - 1;
+  }
+
+  if (!found) return "Unranked";
 
   const percentile = sortedRanks.length > 1 ? (index / (sortedRanks.length - 1)) * 100 : 100;
   if (percentile >= 98) return "Master";

--- a/modules/skillRating.js
+++ b/modules/skillRating.js
@@ -1,0 +1,284 @@
+const models = require("../db/models");
+
+class AspectSkillRating {
+  constructor(rating = 25.0, uncertainty = 25.0 / 3.0) {
+    this.rating = rating;
+    this.uncertainty = uncertainty;
+  }
+
+  getRank() {
+    return this.rating - 3.0 * this.uncertainty;
+  }
+}
+
+function aspectSkillTwoTeams(winningTeam, losingTeam, config) {
+  if (winningTeam.length === 0 || losingTeam.length === 0) {
+    return [[...winningTeam], [...losingTeam]];
+  }
+
+  const { beta, dynamicsFactor: tau } = config;
+
+  const nW = winningTeam.length;
+  const nL = losingTeam.length;
+
+  const muWinners = winningTeam.reduce((sum, r) => sum + r.rating, 0) / nW;
+  const muLosers = losingTeam.reduce((sum, r) => sum + r.rating, 0) / nL;
+
+  const sigmaSqWinners = winningTeam.reduce((sum, r) => sum + (Math.pow(r.uncertainty, 2) + Math.pow(tau, 2)), 0) / Math.pow(nW, 2);
+  const sigmaSqLosers = losingTeam.reduce((sum, r) => sum + (Math.pow(r.uncertainty, 2) + Math.pow(tau, 2)), 0) / Math.pow(nL, 2);
+
+  const omega = Math.sqrt(sigmaSqWinners + sigmaSqLosers + 2.0 * Math.pow(beta, 2));
+  const oddsRatio = Math.exp((muWinners - muLosers) / omega);
+  const adjustmentRatio = 1.0 / (1.0 + oddsRatio);
+
+  const SIGMA_MIN_SQ = 0.01;
+
+  const newWinners = winningTeam.map(rating => {
+    const varianceWithTau = Math.pow(rating.uncertainty, 2) + Math.pow(tau, 2);
+    const muShift = (varianceWithTau / (nW * omega)) * adjustmentRatio;
+    
+    const shrinkFactor = (varianceWithTau / (Math.pow(nW, 2) * Math.pow(omega, 2))) 
+        * adjustmentRatio 
+        * (1.0 - adjustmentRatio);
+    
+    const newVariance = Math.max(varianceWithTau * (1.0 - shrinkFactor), SIGMA_MIN_SQ);
+
+    return new AspectSkillRating(
+        rating.rating + muShift,
+        Math.sqrt(newVariance)
+    );
+  });
+
+  const newLosers = losingTeam.map(rating => {
+    const varianceWithTau = Math.pow(rating.uncertainty, 2) + Math.pow(tau, 2);
+    const muShift = (varianceWithTau / (nL * omega)) * adjustmentRatio;
+    
+    const shrinkFactor = (varianceWithTau / (Math.pow(nL, 2) * Math.pow(omega, 2))) 
+        * adjustmentRatio 
+        * (1.0 - adjustmentRatio);
+    
+    const newVariance = Math.max(varianceWithTau * (1.0 - shrinkFactor), SIGMA_MIN_SQ);
+
+    return new AspectSkillRating(
+        rating.rating - muShift,
+        Math.sqrt(newVariance)
+    );
+  });
+
+  return [newWinners, newLosers];
+}
+
+function expectedScoreTwoTeams(team1, team2, config) {
+  if (team1.length === 0 || team2.length === 0) {
+    return [0.5, 0.5];
+  }
+
+  const { beta, dynamicsFactor: tau } = config;
+
+  const n1 = team1.length;
+  const n2 = team2.length;
+
+  const mu1 = team1.reduce((sum, r) => sum + r.rating, 0) / n1;
+  const mu2 = team2.reduce((sum, r) => sum + r.rating, 0) / n2;
+
+  const sigmaSq1 = team1.reduce((sum, r) => sum + (Math.pow(r.uncertainty, 2) + Math.pow(tau, 2)), 0) / Math.pow(n1, 2);
+  const sigmaSq2 = team2.reduce((sum, r) => sum + (Math.pow(r.uncertainty, 2) + Math.pow(tau, 2)), 0) / Math.pow(n2, 2);
+
+  const omega = Math.sqrt(sigmaSq1 + sigmaSq2 + 2.0 * Math.pow(beta, 2));
+  const oddsRatio = Math.exp((mu1 - mu2) / omega);
+  const prob1Wins = oddsRatio / (1.0 + oddsRatio);
+
+  return [prob1Wins, 1.0 - prob1Wins];
+}
+
+async function updateGameRatings(game) {
+  if (!game.ranked && !game.competitive) {
+    return;
+  }
+  if (game.skillRefunded) {
+    return;
+  }
+  if (game.skillRatingChanges && game.skillRatingChanges.length > 0) {
+    return;
+  }
+
+  const playerIdMap = typeof game.playerIdMap === "string" ? JSON.parse(game.playerIdMap || "{}") : (game.playerIdMap || {});
+  const winnerIds = new Set();
+  if (Array.isArray(game.winners)) {
+    game.winners.forEach(id => winnerIds.add(id));
+  }
+  if (game.winnersInfo && Array.isArray(game.winnersInfo.players)) {
+    game.winnersInfo.players.forEach(id => winnerIds.add(id));
+  }
+
+  const winningUserIds = [];
+  const losingUserIds = [];
+
+  for (const userId of Object.keys(playerIdMap)) {
+    const pid = playerIdMap[userId];
+    if (winnerIds.has(pid)) {
+      winningUserIds.push(userId);
+    } else {
+      losingUserIds.push(userId);
+    }
+  }
+
+  if (winningUserIds.length === 0 || losingUserIds.length === 0) {
+    return;
+  }
+
+  const allUserIds = [...winningUserIds, ...losingUserIds];
+  const users = await models.User.find({ id: { $in: allUserIds } });
+  const userMap = {};
+  for (const user of users) {
+    userMap[user.id] = user;
+  }
+
+  const winningTeam = winningUserIds.map(userId => {
+    const user = userMap[userId];
+    const mu = user?.skillRating?.mu ?? 25.0;
+    const sigma = user?.skillRating?.sigma ?? (25.0 / 3.0);
+    return new AspectSkillRating(mu, sigma);
+  });
+
+  const losingTeam = losingUserIds.map(userId => {
+    const user = userMap[userId];
+    const mu = user?.skillRating?.mu ?? 25.0;
+    const sigma = user?.skillRating?.sigma ?? (25.0 / 3.0);
+    return new AspectSkillRating(mu, sigma);
+  });
+
+  const [newWinners, newLosers] = aspectSkillTwoTeams(winningTeam, losingTeam, { beta: 6.0, dynamicsFactor: 0.02 });
+
+  const ratingChanges = [];
+  const bulkOps = [];
+
+  for (let i = 0; i < winningUserIds.length; i++) {
+    const userId = winningUserIds[i];
+    const oldRating = winningTeam[i];
+    const newRating = newWinners[i];
+    const muDelta = newRating.rating - oldRating.rating;
+    const sigmaDelta = newRating.uncertainty - oldRating.uncertainty;
+
+    ratingChanges.push({ userId, muDelta, sigmaDelta });
+    bulkOps.push({
+      updateOne: {
+        filter: { id: userId },
+        update: {
+          $set: {
+            "skillRating.mu": newRating.rating,
+            "skillRating.sigma": newRating.uncertainty,
+          },
+          $inc: {
+            "skillRating.gamesPlayed": 1
+          }
+        }
+      }
+    });
+  }
+
+  for (let i = 0; i < losingUserIds.length; i++) {
+    const userId = losingUserIds[i];
+    const oldRating = losingTeam[i];
+    const newRating = newLosers[i];
+    const muDelta = newRating.rating - oldRating.rating;
+    const sigmaDelta = newRating.uncertainty - oldRating.uncertainty;
+
+    ratingChanges.push({ userId, muDelta, sigmaDelta });
+    bulkOps.push({
+      updateOne: {
+        filter: { id: userId },
+        update: {
+          $set: {
+            "skillRating.mu": newRating.rating,
+            "skillRating.sigma": newRating.uncertainty,
+          },
+          $inc: {
+            "skillRating.gamesPlayed": 1
+          }
+        }
+      }
+    });
+  }
+
+  if (bulkOps.length > 0) {
+    await models.User.bulkWrite(bulkOps);
+  }
+
+  // Update game with ratingChanges
+  await models.Game.updateOne(
+    { _id: game._id },
+    { $set: { skillRatingChanges: ratingChanges } }
+  ).exec();
+  game.skillRatingChanges = ratingChanges;
+}
+
+async function refundGameRatings(game) {
+  if (game.skillRefunded) {
+    return;
+  }
+  if (!game.skillRatingChanges || game.skillRatingChanges.length === 0) {
+    return;
+  }
+
+  const bulkOps = [];
+  const SIGMA_MIN = 0.1; // Math.sqrt(0.01)
+
+  for (const change of game.skillRatingChanges) {
+    const user = await models.User.findOne({ id: change.userId }).select("skillRating").lean();
+    if (!user) continue;
+
+    const currentMu = user.skillRating?.mu ?? 25.0;
+    const currentSigma = user.skillRating?.sigma ?? (25.0 / 3.0);
+
+    const newMu = currentMu - change.muDelta;
+    const newSigma = Math.max(SIGMA_MIN, currentSigma - change.sigmaDelta);
+
+    bulkOps.push({
+      updateOne: {
+        filter: { id: change.userId },
+        update: {
+          $set: {
+            "skillRating.mu": newMu,
+            "skillRating.sigma": newSigma,
+          },
+          $inc: {
+            "skillRating.gamesPlayed": -1
+          }
+        }
+      }
+    });
+  }
+
+  if (bulkOps.length > 0) {
+    await models.User.bulkWrite(bulkOps);
+  }
+
+  await models.Game.updateOne(
+    { _id: game._id },
+    { $set: { skillRefunded: true } }
+  ).exec();
+  game.skillRefunded = true;
+}
+
+function getTier(rank, sortedRanks) {
+  if (sortedRanks.length === 0) return "Unranked";
+  const index = sortedRanks.indexOf(rank);
+  if (index === -1) return "Unranked";
+  const percentile = sortedRanks.length > 1 ? (index / (sortedRanks.length - 1)) * 100 : 100;
+  if (percentile >= 98) return "Master";
+  if (percentile >= 90) return "Diamond";
+  if (percentile >= 75) return "Platinum";
+  if (percentile >= 50) return "Gold";
+  if (percentile >= 20) return "Silver";
+  return "Bronze";
+}
+
+module.exports = {
+  AspectSkillRating,
+  aspectSkillTwoTeams,
+  expectedScoreTwoTeams,
+  updateGameRatings,
+  refundGameRatings,
+  getTier,
+};

--- a/react_main/src/components/Miniprofile.jsx
+++ b/react_main/src/components/Miniprofile.jsx
@@ -191,7 +191,7 @@ function Miniprofile(props) {
             {user.skillRating.tier} {user.skillRating.rank ? `#${user.skillRating.rank}` : ""}
           </Typography>
           <Typography variant="caption" color="text.secondary">
-            (Rating: {getConservativeRank(user.skillRating.mu, user.skillRating.sigma, 1)})
+            (CR: {getConservativeRank(user.skillRating.mu, user.skillRating.sigma, 1)})
           </Typography>
         </Stack>
       )}

--- a/react_main/src/components/Miniprofile.jsx
+++ b/react_main/src/components/Miniprofile.jsx
@@ -191,7 +191,7 @@ function Miniprofile(props) {
             {user.skillRating.tier} {user.skillRating.rank ? `#${user.skillRating.rank}` : ""}
           </Typography>
           <Typography variant="caption" color="text.secondary">
-            ({getConservativeRank(user.skillRating.mu, user.skillRating.sigma, 1)})
+            (Rating: {getConservativeRank(user.skillRating.mu, user.skillRating.sigma, 1)})
           </Typography>
         </Stack>
       )}

--- a/react_main/src/components/Miniprofile.jsx
+++ b/react_main/src/components/Miniprofile.jsx
@@ -7,6 +7,23 @@ import { Link } from "react-router-dom";
 import { KUDOS_ICON, KARMA_ICON, ACHIEVEMENTS_ICON } from "pages/User/Profile";
 import { PieChart } from "pages/User/PieChart";
 import { Avatar } from "pages/User/User";
+
+import villagerIcon from "images/roles/village/villager-vivid.png";
+import doctorIcon from "images/roles/village/doctor-vivid.png";
+import copIcon from "images/roles/village/cop-vivid.png";
+import sheriffIcon from "images/roles/village/sheriff-vivid.png";
+import stalkerIcon from "images/roles/mafia/stalker-vivid.png";
+import seerIcon from "images/roles/village/seer-vivid.png";
+
+const TIER_ICONS = {
+  "Master": seerIcon,
+  "Diamond": stalkerIcon,
+  "Platinum": sheriffIcon,
+  "Gold": copIcon,
+  "Silver": doctorIcon,
+  "Bronze": villagerIcon,
+  "Unrated": villagerIcon
+};
 import { UserContext, SiteInfoContext } from "Contexts";
 import ReportDialog from "components/ReportDialog";
 import { useErrorAlert } from "components/Alerts";
@@ -176,6 +193,23 @@ function Miniprofile(props) {
         prefilledArgs={reportPrefilledArgs}
       />
       {!hasDefaultPronouns && <div className="pronouns">({pronouns})</div>}
+      {user.skillRating && (
+        <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mt: 1, mb: 1, justifyContent: "center" }}>
+          {TIER_ICONS[user.skillRating.tier] && (
+            <img
+              src={TIER_ICONS[user.skillRating.tier]}
+              alt={user.skillRating.tier}
+              style={{ width: 18, height: 18, objectFit: "contain" }}
+            />
+          )}
+          <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+            {user.skillRating.tier} {user.skillRating.rank ? `#${user.skillRating.rank}` : ""}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            ({((user.skillRating.mu || 25) - 3 * (user.skillRating.sigma || 8.33)).toFixed(1)})
+          </Typography>
+        </Stack>
+      )}
       {pieChart}
       <div className="score-info">
         <div className="score-info-column">

--- a/react_main/src/components/Miniprofile.jsx
+++ b/react_main/src/components/Miniprofile.jsx
@@ -8,22 +8,7 @@ import { KUDOS_ICON, KARMA_ICON, ACHIEVEMENTS_ICON } from "pages/User/Profile";
 import { PieChart } from "pages/User/PieChart";
 import { Avatar } from "pages/User/User";
 
-import villagerIcon from "images/roles/village/villager-vivid.png";
-import doctorIcon from "images/roles/village/doctor-vivid.png";
-import copIcon from "images/roles/village/cop-vivid.png";
-import sheriffIcon from "images/roles/village/sheriff-vivid.png";
-import stalkerIcon from "images/roles/mafia/stalker-vivid.png";
-import seerIcon from "images/roles/village/seer-vivid.png";
-
-const TIER_ICONS = {
-  "Master": seerIcon,
-  "Diamond": stalkerIcon,
-  "Platinum": sheriffIcon,
-  "Gold": copIcon,
-  "Silver": doctorIcon,
-  "Bronze": villagerIcon,
-  "Unrated": villagerIcon
-};
+import { TIER_ICONS, getConservativeRank } from "utils/skillRating";
 import { UserContext, SiteInfoContext } from "Contexts";
 import ReportDialog from "components/ReportDialog";
 import { useErrorAlert } from "components/Alerts";
@@ -206,7 +191,7 @@ function Miniprofile(props) {
             {user.skillRating.tier} {user.skillRating.rank ? `#${user.skillRating.rank}` : ""}
           </Typography>
           <Typography variant="caption" color="text.secondary">
-            ({((user.skillRating.mu || 25) - 3 * (user.skillRating.sigma || 8.33)).toFixed(1)})
+            ({getConservativeRank(user.skillRating.mu, user.skillRating.sigma, 1)})
           </Typography>
         </Stack>
       )}

--- a/react_main/src/components/Popover.jsx
+++ b/react_main/src/components/Popover.jsx
@@ -751,10 +751,37 @@ export function parseGamePopover(game) {
       <Stack
         direction="row"
         style={{ minWidth: "1.5rem", justifyContent: "center" }}
+        key={trophy.key}
       >
         {trophy}
       </Stack>
     ));
+
+    const userRatingChange = game.skillRatingChanges?.find(c => c.userId === userId);
+    if (userRatingChange) {
+      const rankDelta = userRatingChange.muDelta - 3 * userRatingChange.sigmaDelta;
+      const isPositive = rankDelta >= 0;
+      const formattedDelta = (isPositive ? "+" : "") + rankDelta.toFixed(2);
+      trophies.push(
+        <Box
+          sx={{
+            px: 0.75,
+            py: 0.15,
+            fontSize: "0.7rem",
+            fontWeight: "bold",
+            backgroundColor: isPositive ? "success.dark" : "error.dark",
+            color: "white",
+            borderRadius: 1,
+            display: "inline-flex",
+            alignItems: "center",
+            marginLeft: 0.5
+          }}
+          key="ratingDelta"
+        >
+          {formattedDelta}
+        </Box>
+      );
+    }
 
     playerList.push(
       <Stack

--- a/react_main/src/pages/Fame/HallOfFame.jsx
+++ b/react_main/src/pages/Fame/HallOfFame.jsx
@@ -29,21 +29,15 @@ import { UserContext } from "Contexts";
 import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 import { NameWithAvatar } from "pages/User/User";
 
-import villagerIcon from "images/roles/village/villager-vivid.png";
-import doctorIcon from "images/roles/village/doctor-vivid.png";
-import copIcon from "images/roles/village/cop-vivid.png";
-import sheriffIcon from "images/roles/village/sheriff-vivid.png";
-import stalkerIcon from "images/roles/mafia/stalker-vivid.png";
-import seerIcon from "images/roles/village/seer-vivid.png";
-
-const TIER_ICONS = {
-  "Master": seerIcon,
-  "Diamond": stalkerIcon,
-  "Platinum": sheriffIcon,
-  "Gold": copIcon,
-  "Silver": doctorIcon,
-  "Bronze": villagerIcon
-};
+import {
+  TIER_ICONS,
+  villagerIcon,
+  doctorIcon,
+  copIcon,
+  sheriffIcon,
+  stalkerIcon,
+  seerIcon,
+} from "utils/skillRating";
 
 const CATEGORY_OPTIONS = [
   { value: "overall", label: "Overall" },
@@ -268,7 +262,7 @@ function renderMobileMetric(user, category) {
   }
 }
 
-function StandingsTable({
+const StandingsTable = React.memo(function StandingsTable({
   category,
   users,
   currentUserId,
@@ -372,7 +366,7 @@ function StandingsTable({
       })}
     </Stack>
   );
-}
+});
 
 export default function HallOfFame() {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/react_main/src/pages/Fame/HallOfFame.jsx
+++ b/react_main/src/pages/Fame/HallOfFame.jsx
@@ -29,6 +29,22 @@ import { UserContext } from "Contexts";
 import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 import { NameWithAvatar } from "pages/User/User";
 
+import villagerIcon from "images/roles/village/villager-vivid.png";
+import doctorIcon from "images/roles/village/doctor-vivid.png";
+import copIcon from "images/roles/village/cop-vivid.png";
+import sheriffIcon from "images/roles/village/sheriff-vivid.png";
+import stalkerIcon from "images/roles/mafia/stalker-vivid.png";
+import seerIcon from "images/roles/village/seer-vivid.png";
+
+const TIER_ICONS = {
+  "Master": seerIcon,
+  "Diamond": stalkerIcon,
+  "Platinum": sheriffIcon,
+  "Gold": copIcon,
+  "Silver": doctorIcon,
+  "Bronze": villagerIcon
+};
+
 const CATEGORY_OPTIONS = [
   { value: "overall", label: "Overall" },
   { value: "prestige", label: "Prestige" },
@@ -38,6 +54,7 @@ const CATEGORY_OPTIONS = [
   { value: "karma", label: "Karma" },
   { value: "achievements", label: "Achievements" },
   { value: "scrapbook", label: "Scrapbook" },
+  { value: "skillRating", label: "Skill Rating" },
 ];
 
 const TIME_RANGE_OPTIONS = [{ value: "all", label: "All Time" }];
@@ -118,6 +135,16 @@ function getColumns(category, isPhoneDevice) {
         { label: "Trophies", sortKey: "trophyScore" },
         { label: "Win Rate", sortKey: "winRate" },
       ];
+    case "skillRating":
+      return [
+        { label: "Rank", sortKey: null },
+        { label: "User", sortKey: "username" },
+        { label: "Tier", sortKey: "skillTier" },
+        { label: "Conservative Rank", sortKey: "skillRating" },
+        { label: "Rating (μ)", sortKey: "skillMu" },
+        { label: "Uncertainty (σ)", sortKey: "skillSigma" },
+        { label: "Matches", sortKey: "skillGamesPlayed" },
+      ];
     default:
       return [
         { label: "Rank", sortKey: null },
@@ -188,6 +215,19 @@ function renderDesktopCells(user, category) {
         <Typography variant="body2">{user.trophyScore}</Typography>,
         <Typography variant="body2">{formatPercent(user.winRate)}</Typography>,
       ];
+    case "skillRating":
+      return [
+        <Stack direction="row" spacing={1} alignItems="center">
+          {TIER_ICONS[user.skillTier] && (
+            <img src={TIER_ICONS[user.skillTier]} alt={user.skillTier} style={{ width: 20, height: 20 }} />
+          )}
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>{user.skillTier}</Typography>
+        </Stack>,
+        <Typography variant="body2" className="score" sx={{ fontWeight: 700 }}>{user.skillRating}</Typography>,
+        <Typography variant="body2" className="score">{user.skillMu}</Typography>,
+        <Typography variant="body2" className="score">{user.skillSigma}</Typography>,
+        <Typography variant="body2">{user.skillGamesPlayed}</Typography>,
+      ];
     default:
       return [
         <Typography variant="body2">{user.fortune}</Typography>,
@@ -214,6 +254,15 @@ function renderMobileMetric(user, category) {
       return `${user.achievementsCount} achievements`;
     case "scrapbook":
       return `${user.scrapbookCompletion}% scrapbook`;
+    case "skillRating":
+      return (
+        <Stack direction="row" spacing={0.5} alignItems="center" justifyContent="flex-end">
+          {TIER_ICONS[user.skillTier] && (
+            <img src={TIER_ICONS[user.skillTier]} alt={user.skillTier} style={{ width: 16, height: 16 }} />
+          )}
+          <span>{user.skillTier} ({user.skillRating})</span>
+        </Stack>
+      );
     default:
       return `${user.fortune} fortune`;
   }
@@ -564,6 +613,72 @@ export default function HallOfFame() {
             <Alert severity="info">
               Win Rate rankings require a minimum number of games. Users below the current
               threshold are excluded.
+            </Alert>
+          )}
+
+          {category === "skillRating" && (
+            <Alert
+              severity="info"
+              sx={{
+                '& .MuiAlert-message': { width: '100%' },
+                backgroundColor: (theme) => theme.palette.mode === 'dark' ? 'rgba(3, 169, 244, 0.1)' : 'rgba(3, 169, 244, 0.05)',
+                color: (theme) => theme.palette.mode === 'dark' ? '#90caf9' : '#0288d1',
+                border: '1px solid',
+                borderColor: (theme) => theme.palette.mode === 'dark' ? 'rgba(144, 202, 249, 0.3)' : 'rgba(2, 136, 209, 0.3)',
+                '& .MuiAlert-icon': {
+                  color: (theme) => theme.palette.mode === 'dark' ? '#90caf9' : '#0288d1',
+                }
+              }}
+            >
+              <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
+                About the Skill Rating System
+              </Typography>
+              <Typography variant="body2" sx={{ mb: 1 }}>
+                Our leaderboard uses a custom team-summing variant of <strong>OpenSkill</strong>, a Bayesian rating algorithm. It models player skill using two values:
+              </Typography>
+              <Box component="ul" sx={{ pl: 2, mt: 0, mb: 1, '& li': { mb: 0.5 } }}>
+                <li>
+                  <strong>Skill Estimate (μ / Mu):</strong> The system's estimation of your skill level (defaults to 25.0).
+                </li>
+                <li>
+                  <strong>Uncertainty (σ / Sigma):</strong> The system's uncertainty about your rating (defaults to 8.33, decreasing as you play).
+                </li>
+              </Box>
+              <Typography variant="body2" sx={{ mb: 1 }}>
+                <strong>Conservative Rank:</strong> Standings are sorted by your conservative rank, calculated as <code>μ - 3 × σ</code>. This represents a statistical lower bound, guaranteeing your true skill is at least this high with 99% confidence. This ensures that new players with high uncertainty must play more games to earn a high position on the leaderboard.
+              </Typography>
+              <Typography variant="body2" sx={{ mb: 1 }}>
+                <strong>Percentile Tiers:</strong> Active players with at least one match are placed into competitive tiers based on their conservative rank percentiles:
+              </Typography>
+              <Box component="ul" sx={{ pl: 0, mt: 0, mb: 1, listStyle: 'none', '& li': { display: 'flex', alignItems: 'center', mb: 0.5, gap: 1 } }}>
+                <li>
+                  <img src={seerIcon} alt="Master" style={{ width: 20, height: 20 }} />
+                  <span><strong>Master:</strong> Top 2% (Percentile &ge; 98)</span>
+                </li>
+                <li>
+                  <img src={stalkerIcon} alt="Diamond" style={{ width: 20, height: 20 }} />
+                  <span><strong>Diamond:</strong> Next 8% (Percentile &ge; 90)</span>
+                </li>
+                <li>
+                  <img src={sheriffIcon} alt="Platinum" style={{ width: 20, height: 20 }} />
+                  <span><strong>Platinum:</strong> Next 15% (Percentile &ge; 75)</span>
+                </li>
+                <li>
+                  <img src={copIcon} alt="Gold" style={{ width: 20, height: 20 }} />
+                  <span><strong>Gold:</strong> Next 25% (Percentile &ge; 50)</span>
+                </li>
+                <li>
+                  <img src={doctorIcon} alt="Silver" style={{ width: 20, height: 20 }} />
+                  <span><strong>Silver:</strong> Next 30% (Percentile &ge; 20)</span>
+                </li>
+                <li>
+                  <img src={villagerIcon} alt="Bronze" style={{ width: 20, height: 20 }} />
+                  <span><strong>Bronze:</strong> Bottom 20% (Percentile &lt; 20)</span>
+                </li>
+              </Box>
+              <Typography variant="body2">
+                Only completed ranked or competitive matches are counted.
+              </Typography>
             </Alert>
           )}
 

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -1858,7 +1858,7 @@ export default function Profile() {
                                 <img
                                   src={TIER_ICONS[skillRating.tier]}
                                   alt={skillRating.tier}
-                                  style={{ width: 64, height: 64, objectFit: "contain" }}
+                                  style={{ width: 64, height: 64, objectFit: "contain", imageRendering: "pixelated" }}
                                 />
                               </Box>
                             )}

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -56,6 +56,7 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Divider,
   Grid,
   IconButton,
   Paper,
@@ -78,6 +79,23 @@ export const POINTS_NEGATIVE_ICON = require(`images/pointsNegative.png`);
 export const PRESTIGE_ICON = require(`images/prestige.png`);
 export const ACHIEVEMENTS_ICON = require(`images/achievements.png`);
 export const DAILY_ICON = require(`images/dailyChallenges.png`);
+
+import villagerIcon from "images/roles/village/villager-vivid.png";
+import doctorIcon from "images/roles/village/doctor-vivid.png";
+import copIcon from "images/roles/village/cop-vivid.png";
+import sheriffIcon from "images/roles/village/sheriff-vivid.png";
+import stalkerIcon from "images/roles/mafia/stalker-vivid.png";
+import seerIcon from "images/roles/village/seer-vivid.png";
+
+const TIER_ICONS = {
+  "Master": seerIcon,
+  "Diamond": stalkerIcon,
+  "Platinum": sheriffIcon,
+  "Gold": copIcon,
+  "Silver": doctorIcon,
+  "Bronze": villagerIcon,
+  "Unrated": villagerIcon
+};
 
 
 
@@ -156,6 +174,7 @@ export default function Profile() {
   const [avatar, setAvatar] = useState();
   const [banner, setBanner] = useState();
   const [profileBackground, setProfileBackground] = useState(false);
+  const [skillRating, setSkillRating] = useState(null);
   const [bio, setBio] = useState("");
   const [oldBio, setOldBio] = useState();
   const [editingBio, setEditingBio] = useState(false);
@@ -389,6 +408,7 @@ export default function Profile() {
           setPokesDisabled(res.data.pokesDisabled || false);
           setIncomingPokes(res.data.incomingPokes || []);
           setStockInfo(res.data.stockInfo || null);
+          setSkillRating(res.data.skillRating || null);
           setFriendsPage(1);
           loadFriends(resolvedId, "", 1);
 
@@ -1818,44 +1838,128 @@ export default function Profile() {
                     </Typography>
                   ) : (
                     <>
-                      <div className="ratings-tabs">
-                        <div
-                          className={
-                            "ratings-tab" +
-                            (ratingsTab === "wins" ? " active" : "")
-                          }
-                          onClick={() => setRatingsTab("wins")}
+                      <Stack spacing={2} sx={{ px: 1, py: 1 }}>
+                        <Paper variant="outlined" sx={{ p: 2, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", borderRadius: 2 }}>
+                          <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1, color: "text.secondary" }}>
+                            Win/Loss Distribution
+                          </Typography>
+                          <Box sx={{ my: 1, display: "flex", justifyContent: "center" }}>
+                            <PieChart
+                              wins={getWins(mafiaStats)}
+                              losses={getLosses(mafiaStats)}
+                              abandons={getAbandons(mafiaStats)}
+                            />
+                          </Box>
+                          <Typography variant="body2" sx={{ mt: 1, fontWeight: "bold" }}>
+                            Wins: {Math.round((getWins(mafiaStats) / totalGames) * 100)}% ({getWins(mafiaStats)}W / {getLosses(mafiaStats)}L)
+                          </Typography>
+                        </Paper>
+
+                        {statsBucket === "ranked" && skillRating ? (
+                          <Paper
+                            variant="outlined"
+                            sx={{
+                              p: 2,
+                              display: "flex",
+                              alignItems: "center",
+                              gap: 2,
+                              backgroundColor: (theme) => theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.02)' : 'rgba(0, 0, 0, 0.01)',
+                              borderColor: "divider",
+                              borderRadius: 2
+                            }}
+                          >
+                            {TIER_ICONS[skillRating.tier] && (
+                              <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
+                                <img
+                                  src={TIER_ICONS[skillRating.tier]}
+                                  alt={skillRating.tier}
+                                  style={{ width: 64, height: 64, objectFit: "contain" }}
+                                />
+                              </Box>
+                            )}
+                            <Stack spacing={0.5} sx={{ width: "100%" }}>
+                              <Stack direction="row" alignItems="center" spacing={1}>
+                                <Typography variant="h5" sx={{ fontWeight: 800, color: "text.primary" }}>
+                                  {skillRating.tier}
+                                </Typography>
+                                {skillRating.rank && (
+                                  <Paper
+                                    sx={{
+                                      px: 1,
+                                      py: 0.25,
+                                      fontSize: "0.75rem",
+                                      fontWeight: "bold",
+                                      backgroundColor: "primary.main",
+                                      color: "primary.contrastText",
+                                      borderRadius: 1
+                                    }}
+                                  >
+                                    Rank #{skillRating.rank}
+                                  </Paper>
+                                )}
+                              </Stack>
+                              
+                              <Typography variant="body2" color="text.primary" sx={{ fontWeight: 600 }}>
+                                Conservative Rank: <span style={{ fontSize: "1.1rem", fontWeight: 800, color: goldColor }}>
+                                  {((skillRating.mu || 25) - 3 * (skillRating.sigma || 8.33)).toFixed(2)}
+                                </span>
+                              </Typography>
+                              
+                              <Divider sx={{ my: 0.5 }} />
+                              
+                              <Grid container spacing={1}>
+                                <Grid item xs={6}>
+                                  <Typography variant="caption" color="text.secondary" display="block">
+                                    Rating (μ)
+                                  </Typography>
+                                  <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+                                    {parseFloat((skillRating.mu || 25).toFixed(2))}
+                                  </Typography>
+                                </Grid>
+                                <Grid item xs={6}>
+                                  <Typography variant="caption" color="text.secondary" display="block">
+                                    Uncertainty (σ)
+                                  </Typography>
+                                  <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+                                    {parseFloat((skillRating.sigma || 8.33).toFixed(2))}
+                                  </Typography>
+                                </Grid>
+                                <Grid item xs={12}>
+                                  <Typography variant="caption" color="text.secondary" display="block">
+                                    Rated Matches
+                                  </Typography>
+                                  <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+                                    {skillRating.gamesPlayed} games played
+                                  </Typography>
+                                </Grid>
+                              </Grid>
+                            </Stack>
+                          </Paper>
+                        ) : statsBucket === "ranked" ? (
+                          <Paper variant="outlined" sx={{ p: 2, display: "flex", justifyContent: "center", alignItems: "center", borderRadius: 2 }}>
+                            <Typography variant="body2" color="text.secondary" sx={{ fontStyle: "italic", textAlign: "center", p: 1 }}>
+                              No rated games played yet. Play ranked or competitive games to establish a skill rating.
+                            </Typography>
+                          </Paper>
+                        ) : null}
+                      </Stack>
+
+                      <Box sx={{ mt: 2, display: "flex", justifyContent: "center" }}>
+                        <Button
+                          variant="text"
+                          size="small"
+                          onClick={() => setRatingsTab(ratingsTab === "query" ? "wins" : "query")}
+                          startIcon={<i className={ratingsTab === "query" ? "fas fa-chevron-up" : "fas fa-chevron-down"} />}
+                          sx={{ textTransform: "none", fontWeight: 700 }}
                         >
-                          Wins:{" "}
-                          {Math.round(
-                            (getWins(mafiaStats) / totalGames) * 100
-                          )}
-                          %
-                        </div>
-                        <div
-                          className={
-                            "ratings-tab" +
-                            (ratingsTab === "query" ? " active" : "")
-                          }
-                          onClick={() => setRatingsTab("query")}
-                        >
-                          <i className="fas fa-expand-arrows-alt" />
-                        </div>
-                      </div>
-                      {ratingsTab === "wins" && (
-                        <div
-                          className="content"
-                          style={{ padding: "0", justifyContent: "center" }}
-                        >
-                          <PieChart
-                            wins={getWins(mafiaStats)}
-                            losses={getLosses(mafiaStats)}
-                            abandons={getAbandons(mafiaStats)}
-                          />
-                        </div>
-                      )}
+                          {ratingsTab === "query" ? "Hide Detailed Stats Breakdown" : "Show Detailed Stats Breakdown"}
+                        </Button>
+                      </Box>
+
                       {ratingsTab === "query" && (
-                        <StatsQueryView stats={stats} statsBucket={statsBucket} />
+                        <Box sx={{ mt: 2, borderTop: "1px solid", borderColor: "divider", pt: 2 }}>
+                          <StatsQueryView stats={stats} statsBucket={statsBucket} />
+                        </Box>
                       )}
                     </>
                   )}

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -80,22 +80,7 @@ export const PRESTIGE_ICON = require(`images/prestige.png`);
 export const ACHIEVEMENTS_ICON = require(`images/achievements.png`);
 export const DAILY_ICON = require(`images/dailyChallenges.png`);
 
-import villagerIcon from "images/roles/village/villager-vivid.png";
-import doctorIcon from "images/roles/village/doctor-vivid.png";
-import copIcon from "images/roles/village/cop-vivid.png";
-import sheriffIcon from "images/roles/village/sheriff-vivid.png";
-import stalkerIcon from "images/roles/mafia/stalker-vivid.png";
-import seerIcon from "images/roles/village/seer-vivid.png";
-
-const TIER_ICONS = {
-  "Master": seerIcon,
-  "Diamond": stalkerIcon,
-  "Platinum": sheriffIcon,
-  "Gold": copIcon,
-  "Silver": doctorIcon,
-  "Bronze": villagerIcon,
-  "Unrated": villagerIcon
-};
+import { TIER_ICONS, getConservativeRank } from "utils/skillRating";
 
 
 
@@ -1901,7 +1886,7 @@ export default function Profile() {
                               
                               <Typography variant="body2" color="text.primary" sx={{ fontWeight: 600 }}>
                                 Conservative Rank: <span style={{ fontSize: "1.1rem", fontWeight: 800, color: goldColor }}>
-                                  {((skillRating.mu || 25) - 3 * (skillRating.sigma || 8.33)).toFixed(2)}
+                                  {getConservativeRank(skillRating.mu, skillRating.sigma)}
                                 </span>
                               </Typography>
                               

--- a/react_main/src/utils/skillRating.js
+++ b/react_main/src/utils/skillRating.js
@@ -1,0 +1,33 @@
+import villagerIcon from "images/roles/village/villager-vivid.png";
+import doctorIcon from "images/roles/village/doctor-vivid.png";
+import copIcon from "images/roles/village/cop-vivid.png";
+import sheriffIcon from "images/roles/village/sheriff-vivid.png";
+import stalkerIcon from "images/roles/mafia/stalker-vivid.png";
+import seerIcon from "images/roles/village/seer-vivid.png";
+
+export const DEFAULT_MU = 25;
+export const DEFAULT_SIGMA = 25 / 3;
+
+export const TIER_ICONS = {
+  Master: seerIcon,
+  Diamond: stalkerIcon,
+  Platinum: sheriffIcon,
+  Gold: copIcon,
+  Silver: doctorIcon,
+  Bronze: villagerIcon,
+  Unrated: villagerIcon,
+};
+
+export function getConservativeRank(mu, sigma, decimals = 2) {
+  return ((mu || DEFAULT_MU) - 3 * (sigma || DEFAULT_SIGMA)).toFixed(decimals);
+}
+
+// Re-export individual icons for consumers that need them directly
+export {
+  villagerIcon,
+  doctorIcon,
+  copIcon,
+  sheriffIcon,
+  stalkerIcon,
+  seerIcon,
+};

--- a/routes/game.js
+++ b/routes/game.js
@@ -564,7 +564,7 @@ router.get("/:id/info", async function (req, res) {
     if (!game) {
       game = await models.Game.findOne({ id: gameId })
         .select(
-          "type users spectatorsUsers players spectators left stateLengths lobbyName ranked competitive anonymousGame anonymousDeck spectating guests readyCheck noVeg startTime endTime gameTypeOptions winners winnersInfo kudosReceiver playerIdMap playerAlignmentMap -_id"
+          "type users spectatorsUsers players spectators left stateLengths lobbyName ranked competitive anonymousGame anonymousDeck spectating guests readyCheck noVeg startTime endTime gameTypeOptions winners winnersInfo kudosReceiver playerIdMap playerAlignmentMap skillRatingChanges -_id"
         )
         .populate("users", "id name avatar -_id");
 

--- a/routes/mod.js
+++ b/routes/mod.js
@@ -20,6 +20,7 @@ const errors = require("../lib/errors");
 const {
   syncRankedCompetitiveAccess,
 } = require("../modules/userEligibility");
+const skillRating = require("../modules/skillRating");
 const router = express.Router();
 
 router.get("/groups", async function (req, res) {
@@ -2095,6 +2096,13 @@ router.post("/refundGame", async (req, res) => {
       return;
     }
 
+    // Refund skill ratings if applicable
+    try {
+      await skillRating.refundGameRatings(game);
+    } catch (e) {
+      logger.error(`Error refunding skill ratings for game ${gameId}:`, e);
+    }
+
     // Parse player maps
     const playerIdMap = JSON.parse(game.playerIdMap || "{}");
     const playerAlignmentMap = JSON.parse(game.playerAlignmentMap || "{}");
@@ -2399,7 +2407,7 @@ router.post("/refundGame", async (req, res) => {
       `Successfully refunded game for ${userIds.length} player(s). ` +
         `Reverted: win/loss/abandonment statistics, kudos, coins from wins, ${
           game.ranked ? "red" : "gold"
-        } hearts, and fortune/misfortune points.`
+        } hearts, skill ratings, and fortune/misfortune points.`
     );
   } catch (e) {
     logger.error(e);

--- a/routes/user.js
+++ b/routes/user.js
@@ -397,7 +397,7 @@ router.get("/:id/profile", async function (req, res) {
     var isSelf = reqUserId == userId;
     var user = await models.User.findOne({ id: userId, deleted: false })
       .select(
-        "id name avatar profileBackground settings accounts wins losses kudos karma points pointsNegative championshipPoints achievements bio pronouns banner setups games numFriends stats lastActive joined favoriteRoles roleIconCredits _id"
+        "id name avatar profileBackground settings accounts wins losses kudos karma points pointsNegative championshipPoints achievements bio pronouns banner setups games numFriends stats lastActive joined favoriteRoles roleIconCredits skillRating _id"
       )
       .populate({
         path: "setups",
@@ -428,6 +428,51 @@ router.get("/:id/profile", async function (req, res) {
     }
 
     user = user.toJSON();
+
+    if (!user.skillRating) {
+      user.skillRating = {
+        mu: 25.0,
+        sigma: 8.333333333333334,
+        gamesPlayed: 0
+      };
+    }
+
+    if (user.skillRating) {
+      if (user.skillRating.gamesPlayed > 0) {
+        const allRatedUsers = await models.User.find({
+          "skillRating.gamesPlayed": { $gt: 0 },
+          deleted: { $ne: true }
+        }).select("id skillRating").lean();
+
+        const sortedUsers = allRatedUsers.map(u => ({
+          id: u.id,
+          rankScore: parseFloat(((u.skillRating?.mu || 25.0) - 3 * (u.skillRating?.sigma || 8.333333333333334)).toFixed(2))
+        })).sort((a, b) => b.rankScore - a.rankScore);
+
+        const userRankIndex = sortedUsers.findIndex(u => u.id === user.id);
+        if (userRankIndex !== -1) {
+          user.skillRating.rank = userRankIndex + 1;
+          const totalRated = sortedUsers.length;
+          const percentile = ((totalRated - userRankIndex) / totalRated) * 100;
+          
+          let tier = "Bronze";
+          if (percentile >= 98) tier = "Master";
+          else if (percentile >= 90) tier = "Diamond";
+          else if (percentile >= 75) tier = "Platinum";
+          else if (percentile >= 50) tier = "Gold";
+          else if (percentile >= 20) tier = "Silver";
+          
+          user.skillRating.tier = tier;
+        } else {
+          user.skillRating.tier = "Unrated";
+          user.skillRating.rank = null;
+        }
+      } else {
+        user.skillRating.tier = "Unrated";
+        user.skillRating.rank = null;
+      }
+    }
+
     user.groups = (await redis.getBasicUserInfo(userId)).groups;
     user.maxFriendsPage =
       Math.ceil(user.numFriends / constants.friendsPerPage) || 1;

--- a/routes/user.js
+++ b/routes/user.js
@@ -20,6 +20,8 @@ const { colorHasGoodContrastForBothThemes } = require("../shared/colors");
 const logger = require("../modules/logging")(".");
 const errors = require("../lib/errors");
 const stockMarket = require("../lib/StockMarket");
+const skillRatingModule = require("../modules/skillRating");
+const { DEFAULT_MU, DEFAULT_SIGMA } = skillRatingModule;
 const router = express.Router();
 
 /** Keep in sync with `isRetroThemeForcedByCalendar` in react_main/src/utils/holidayThemes.js */
@@ -431,46 +433,45 @@ router.get("/:id/profile", async function (req, res) {
 
     if (!user.skillRating) {
       user.skillRating = {
-        mu: 25.0,
-        sigma: 8.333333333333334,
+        mu: DEFAULT_MU,
+        sigma: DEFAULT_SIGMA,
         gamesPlayed: 0
       };
     }
 
-    if (user.skillRating) {
-      if (user.skillRating.gamesPlayed > 0) {
-        const allRatedUsers = await models.User.find({
-          "skillRating.gamesPlayed": { $gt: 0 },
-          deleted: { $ne: true }
-        }).select("id skillRating").lean();
+    if (user.skillRating.gamesPlayed > 0) {
+      const allRatedUsers = await models.User.find({
+        "skillRating.gamesPlayed": { $gt: 0 },
+        deleted: { $ne: true }
+      }).select("id skillRating").lean();
 
-        const sortedUsers = allRatedUsers.map(u => ({
-          id: u.id,
-          rankScore: parseFloat(((u.skillRating?.mu || 25.0) - 3 * (u.skillRating?.sigma || 8.333333333333334)).toFixed(2))
-        })).sort((a, b) => b.rankScore - a.rankScore);
+      const sortedRanks = allRatedUsers.map(u => {
+        const mu = u.skillRating?.mu ?? DEFAULT_MU;
+        const sigma = u.skillRating?.sigma ?? DEFAULT_SIGMA;
+        return mu - 3.0 * sigma;
+      }).sort((a, b) => a - b);
 
-        const userRankIndex = sortedUsers.findIndex(u => u.id === user.id);
-        if (userRankIndex !== -1) {
-          user.skillRating.rank = userRankIndex + 1;
-          const totalRated = sortedUsers.length;
-          const percentile = ((totalRated - userRankIndex) / totalRated) * 100;
-          
-          let tier = "Bronze";
-          if (percentile >= 98) tier = "Master";
-          else if (percentile >= 90) tier = "Diamond";
-          else if (percentile >= 75) tier = "Platinum";
-          else if (percentile >= 50) tier = "Gold";
-          else if (percentile >= 20) tier = "Silver";
-          
-          user.skillRating.tier = tier;
-        } else {
-          user.skillRating.tier = "Unrated";
-          user.skillRating.rank = null;
-        }
+      const userMu = user.skillRating.mu ?? DEFAULT_MU;
+      const userSigma = user.skillRating.sigma ?? DEFAULT_SIGMA;
+      const userRankScore = userMu - 3.0 * userSigma;
+
+      // Compute rank position (descending order)
+      const sortedDesc = allRatedUsers.map(u => ({
+        id: u.id,
+        rankScore: (u.skillRating?.mu ?? DEFAULT_MU) - 3.0 * (u.skillRating?.sigma ?? DEFAULT_SIGMA)
+      })).sort((a, b) => b.rankScore - a.rankScore);
+      const userRankIndex = sortedDesc.findIndex(u => u.id === user.id);
+
+      if (userRankIndex !== -1) {
+        user.skillRating.rank = userRankIndex + 1;
+        user.skillRating.tier = skillRatingModule.getTier(userRankScore, sortedRanks);
       } else {
         user.skillRating.tier = "Unrated";
         user.skillRating.rank = null;
       }
+    } else {
+      user.skillRating.tier = "Unrated";
+      user.skillRating.rank = null;
     }
 
     user.groups = (await redis.getBasicUserInfo(userId)).groups;

--- a/test/skillRating.test.js
+++ b/test/skillRating.test.js
@@ -1,0 +1,94 @@
+const chai = require("chai");
+const should = chai.should();
+const {
+  AspectSkillRating,
+  aspectSkillTwoTeams,
+  expectedScoreTwoTeams,
+  getTier,
+} = require("../modules/skillRating");
+
+describe("modules/skillRating", function () {
+  describe("AspectSkillRating", function () {
+    it("should initialize with default parameters", function () {
+      const rating = new AspectSkillRating();
+      rating.rating.should.equal(25.0);
+      rating.uncertainty.should.equal(25.0 / 3.0);
+    });
+
+    it("should correctly compute conservative rank", function () {
+      const rating = new AspectSkillRating(25.0, 8.333333333333334);
+      rating.getRank().should.be.closeTo(0.0, 0.0001);
+    });
+  });
+
+  describe("expectedScoreTwoTeams", function () {
+    it("should return 0.5 probability for equal teams", function () {
+      const team1 = [new AspectSkillRating(25.0, 8.333333333333334)];
+      const team2 = [new AspectSkillRating(25.0, 8.333333333333334)];
+      const [prob1, prob2] = expectedScoreTwoTeams(team1, team2, { beta: 6.0, dynamicsFactor: 0.02 });
+      prob1.should.be.closeTo(0.5, 0.0001);
+      prob2.should.be.closeTo(0.5, 0.0001);
+    });
+
+    it("should give higher win probability to stronger team", function () {
+      const team1 = [new AspectSkillRating(30.0, 5.0)];
+      const team2 = [new AspectSkillRating(20.0, 5.0)];
+      const [prob1, prob2] = expectedScoreTwoTeams(team1, team2, { beta: 6.0, dynamicsFactor: 0.02 });
+      prob1.should.be.above(0.5);
+      prob2.should.be.below(0.5);
+      (prob1 + prob2).should.be.closeTo(1.0, 0.0001);
+    });
+  });
+
+  describe("aspectSkillTwoTeams", function () {
+    it("should shift ratings appropriately on outcome", function () {
+      const winners = [new AspectSkillRating(25.0, 8.333333333333334)];
+      const losers = [new AspectSkillRating(25.0, 8.333333333333334)];
+      const [newWinners, newLosers] = aspectSkillTwoTeams(winners, losers, { beta: 6.0, dynamicsFactor: 0.02 });
+
+      newWinners[0].rating.should.be.above(25.0);
+      newWinners[0].uncertainty.should.be.below(25.0 / 3.0);
+
+      newLosers[0].rating.should.be.below(25.0);
+      newLosers[0].uncertainty.should.be.below(25.0 / 3.0);
+    });
+
+    it("should return empty arrays unchanged", function () {
+      const [newWinners, newLosers] = aspectSkillTwoTeams([], [], { beta: 6.0, dynamicsFactor: 0.02 });
+      newWinners.length.should.equal(0);
+      newLosers.length.should.equal(0);
+    });
+  });
+
+  describe("getTier", function () {
+    it("should return Unranked if no ranks are available", function () {
+      getTier(10.0, []).should.equal("Unranked");
+    });
+
+    it("should return Unranked if rank is not in sorted ranks", function () {
+      getTier(10.0, [1.0, 2.0, 3.0]).should.equal("Unranked");
+    });
+
+    it("should assign correct tiers based on percentile distribution", function () {
+      const sortedRanks = [];
+      for (let i = 0; i < 100; i++) {
+        sortedRanks.push(i * 0.25); // conservative ranks from 0 to 24.75
+      }
+
+      // 99th index (percentile 100) -> Master
+      getTier(sortedRanks[99], sortedRanks).should.equal("Master");
+      // 98th index (percentile ~98.9) -> Master
+      getTier(sortedRanks[98], sortedRanks).should.equal("Master");
+      // 97th index (percentile ~97.9) -> Diamond (percentile >= 90)
+      getTier(sortedRanks[97], sortedRanks).should.equal("Diamond");
+      // 80th index (percentile ~80.8) -> Platinum (percentile >= 75)
+      getTier(sortedRanks[80], sortedRanks).should.equal("Platinum");
+      // 60th index (percentile ~60.6) -> Gold (percentile >= 50)
+      getTier(sortedRanks[60], sortedRanks).should.equal("Gold");
+      // 30th index (percentile ~30.3) -> Silver (percentile >= 20)
+      getTier(sortedRanks[30], sortedRanks).should.equal("Silver");
+      // 5th index (percentile ~5.0) -> Bronze (percentile < 20)
+      getTier(sortedRanks[5], sortedRanks).should.equal("Bronze");
+    });
+  });
+});


### PR DESCRIPTION
# PR: OpenSkill-Based Skill Rating System with Administrative Backfill

This PR introduces an official, competitive **Skill Rating System** based on a custom variant of **OpenSkill**. It includes database schema updates, live rating adjustments at game end, a robust administrative backfill script, leaderboards in the Hall of Fame, and a redesigned statistics dashboard on user profiles with custom tier icons.

---

## 1. Core Rating System & OpenSkill Variant

The skill rating logic uses a Bayesian rating algorithm based on **OpenSkill**. Since competitive setups in Ultimafia consist of two opposing teams (e.g. Village vs. Mafia/Cult), our implementation is tailored to two-faction outcomes.

### The Team Strength Formula
Standard OpenSkill determines a team's strength by averaging the ratings of its members. However, in Mafia, team size and contribution scaling are critical. To model team strength accurately:
* **Sum of Skills**: Rather than averaging, team strength is determined by **summing** the individual ratings ($\mu$) of all members in the faction.
* **Aspect-style update**: The individual uncertainty ($\sigma$) updates scale inversely with team sizes to reflect the statistical confidence of the outcome on individual ratings.
* **Conservative Rank**: Standings and percentiles are determined by the conservative estimate:
  $$\text{Conservative Rank} = \mu - 3 \times \sigma$$
  This acts as a statistical lower bound, guaranteeing with 99% confidence that a player's true skill is at least this high. This encourages active play, as new players with high uncertainty ($\sigma = 8.33$ by default) must play more games to reduce uncertainty and climb the leaderboard.

---

## 2. Administrative Backfilling Process

Since there are thousands of existing games, an administrative migration script has been created to backfill ratings sequentially from the beginning of the site's history.

### Workflow of `backfillSkillRatings.js`
The script runs the following steps to reconstruct the timeline of ratings:
1. **Reset Database**: Clears any existing `skillRating` fields on all users to default values ($\mu = 25.0$, $\sigma = 8.33$, $\text{gamesPlayed} = 0$), and empties `skillRatingChanges` and `skillRefunded` fields on all games.
2. **Retrieve Qualified Games**: Queries all completed, non-broken, non-aborted games where `ranked === true` or `competitive === true`.
3. **Chronological Sorting**:
   > [!IMPORTANT]
   > Games are sorted strictly by `startTime` (instead of `endTime`). This is because `endTime` can be artificially inflated if players remain in the post-game lobby chat for a long time, which would scramble the historical order of games and pollute subsequent rating calculations.
4. **Sequencing and Updates**:
   * For each game, the script resolves players into two opposing factions (e.g. Village vs. Mafia).
   * It calculates the new post-match $\mu$ and $\sigma$ for all players.
   * It stores the exact rating changes ($\mu_{\text{delta}}$ and $\sigma_{\text{delta}}$) in `game.skillRatingChanges`. This allows administrative **refunds** of ratings if a game is declared void (e.g., due to gamethrowing or rule violations).
   * It bulk-writes the updated ratings and increments `gamesPlayed` for all participants.
5. **How to Run**:
   Administrators can trigger the backfill by running the following command from the repository root:
   ```bash
   node -e 'require("./migrations/backfillSkillRatings")()'
   ```

---

## 3. UI Integrations & Redesign

### Hall of Fame Standings
* A new column has been added to the Hall of Fame table displaying the player's competitive tier and conservative rank.
* Inline tier icons are displayed next to the player's tier name.
* Aligned Stack layouts and softer themed alerts explain the rating system in detail.

### Tier and Icon Assignment
Competitive tiers are calculated dynamically based on active player percentiles (active players with $\ge 1$ match):
* **Master** (Top 2%): Seer Icon (`images/roles/village/seer-vivid.png`)
* **Diamond** (Next 8%): Stalker Icon (`images/roles/mafia/stalker-vivid.png`)
* **Platinum** (Next 15%): Sheriff Icon (`images/roles/village/sheriff-vivid.png`)
* **Gold** (Next 25%): Cop Icon (`images/roles/village/cop-vivid.png`)
* **Silver** (Next 30%): Doctor Icon (`images/roles/village/doctor-vivid.png`)
* **Bronze** (Bottom 20%): Villager Icon (`images/roles/village/villager-vivid.png`)
* **Unrated** ($0$ matches): Villager Icon (`images/roles/village/villager-vivid.png`)

### User Profile Redesign
The **Mafia Ratings** card on the profile page has been overhauled into a vertical Stack layout to fit sidebars and mobile screens cleanly without clipping or stretching:
1. **Win/Loss Distribution Chart**: Shows the pie chart representing win/loss/abandon metrics.
2. **Skill Rating Details Card**: Displays the large 64px tier icon, current tier, leaderboard rank, Conservative Rank, and individual rating stats ($\mu$ and $\sigma$).
3. **Stats Query Drawer**: A collapsible dropdown button allows users to toggle the detailed setup/role statistics search view.

---

## 4. Modified Files

* **Backend**:
  * [Games/core/Game.js](file:///home/tt/Documents/Ultimafia/Games/core/Game.js): Live updates on game completion.
  * [db/schemas.js](file:///home/tt/Documents/Ultimafia/db/schemas.js): Updated `User` and `Game` schemas.
  * [routes/mod.js](file:///home/tt/Documents/Ultimafia/routes/mod.js): Moderator routes for declaring gamethrow refunds.
  * [routes/user.js](file:///home/tt/Documents/Ultimafia/routes/user.js): Profile calculation and default fallback properties.
  * [modules/skillRating.js](file:///home/tt/Documents/Ultimafia/modules/skillRating.js): core math and aspect calculations.
  * [migrations/backfillSkillRatings.js](file:///home/tt/Documents/Ultimafia/migrations/backfillSkillRatings.js): Backfilling script.
* **Frontend**:
  * [react_main/src/pages/Fame/HallOfFame.jsx](file:///home/tt/Documents/Ultimafia/react_main/src/pages/Fame/HallOfFame.jsx): Hall of Fame standings table and blurb explanation.
  * [react_main/src/pages/User/Profile.jsx](file:///home/tt/Documents/Ultimafia/react_main/src/pages/User/Profile.jsx): Redesigned profile statistics panel and tier icons.
* **Tests**:
  * [test/skillRating.test.js](file:///home/tt/Documents/Ultimafia/test/skillRating.test.js): Automated suite validating Aspect updates, refunds, and backfill math.
