### PR TITLE
fix: Preserving colon delimiter in Oracle death reveal for player modifier rendering

### DIFF
--- a/Games/types/Mafia/information/RevealInfo.js
+++ b/Games/types/Mafia/information/RevealInfo.js
@@ -58,7 +58,7 @@ module.exports = class RevealInfo extends Information {
     if (this.truthValue == "Normal") {
       this.target.setTempAppearance(
         this.investType,
-        this.target.getRoleAppearance(this.investType)
+        this.target.getAppearance(this.investType)
       );
       this.revealTarget();
     } else if (this.truthValue == "True") {


### PR DESCRIPTION
# fix: Preserving colon delimiter in Oracle death reveal for player modifier rendering

## Problem
When an Oracle dies and triggers a target reveal, the backend class `RevealInfo` formatted the revealed target's role using `getRoleAppearance(type)`, which yields the user-facing format (e.g. `"Town Crier (Armed)"`). 

This string was then set as the player's temporary appearance and broadcasted to clients as the `role` property in the socket `"reveal"` event payload.

On the client side, `RoleCount` expects the raw colon-delimited string format (e.g. `"Town Crier:Armed"`) to properly parse the role name and modifiers. When it received `"Town Crier (Armed)"` instead:
1. It failed to split the modifiers, resolving `roleName` to `"Town Crier (Armed)"` and `modifiers` to `""`.
2. It failed to map the role name to css class names or look up its metadata/alignment in `siteInfo.rolesRaw`, causing the client to render a generic fallback role icon and display empty hover popovers.

## Solution
Modified [RevealInfo.js](file:///home/tt/Documents/Ultimafia/Games/types/Mafia/information/RevealInfo.js#L61) to call `getAppearance(type)` instead of `getRoleAppearance(type)` when setting the temporary appearance for normal reveals. This preserves the standard colon-separated format (`"Town Crier:Armed"`), allowing the client to parse, match, and render the role icon and details correctly.
