### PR TITLE
style(dialog): make target name in trade dialog bold and h5

### DIFF
--- a/react_main/src/components/TradeDialog.jsx
+++ b/react_main/src/components/TradeDialog.jsx
@@ -142,7 +142,7 @@ export default function TradeDialog({ open, onClose, stock, initialType = "buy",
             </Box>
           )}
           <Box>
-            <Typography variant="h6" sx={{ lineHeight: 1.2 }}>
+            <Typography variant="h5" sx={{ fontWeight: "bold", lineHeight: 1.2 }}>
               {stock.name}
             </Typography>
             <Typography variant="caption" color="text.secondary">


### PR DESCRIPTION
Increase font size of the family/player name to h5 and add bold font weight to improve readability in the TradeDialog.