### PR TITLE
style(dialog): match name and supply text sizes in trade dialog

### DIFF
--- a/react_main/src/components/TradeDialog.jsx
+++ b/react_main/src/components/TradeDialog.jsx
@@ -142,10 +142,10 @@ export default function TradeDialog({ open, onClose, stock, initialType = "buy",
             </Box>
           )}
           <Box>
-            <Typography sx={{ fontWeight: "bold", fontSize: "1.1rem", lineHeight: 1.2 }}>
+            <Typography sx={{ fontWeight: "bold", fontSize: "0.875rem", lineHeight: 1.2 }}>
               {stock.name}
             </Typography>
-            <Typography variant="caption" color="text.secondary">
+            <Typography sx={{ fontSize: "0.875rem" }} color="text.secondary">
               Current share supply: {stock.shareSupply}
             </Typography>
           </Box>

--- a/react_main/src/components/TradeDialog.jsx
+++ b/react_main/src/components/TradeDialog.jsx
@@ -142,7 +142,7 @@ export default function TradeDialog({ open, onClose, stock, initialType = "buy",
             </Box>
           )}
           <Box>
-            <Typography sx={{ fontWeight: "bold", fontSize: "1.25rem", lineHeight: 1.2 }}>
+            <Typography sx={{ fontWeight: "bold", fontSize: "1.1rem", lineHeight: 1.2 }}>
               {stock.name}
             </Typography>
             <Typography variant="caption" color="text.secondary">

--- a/react_main/src/components/TradeDialog.jsx
+++ b/react_main/src/components/TradeDialog.jsx
@@ -145,7 +145,7 @@ export default function TradeDialog({ open, onClose, stock, initialType = "buy",
             <Typography sx={{ fontWeight: "bold", fontSize: "0.875rem", lineHeight: 1.2 }}>
               {stock.name}
             </Typography>
-            <Typography sx={{ fontSize: "0.875rem" }} color="text.secondary">
+            <Typography variant="caption" color="text.secondary">
               Current share supply: {stock.shareSupply}
             </Typography>
           </Box>

--- a/react_main/src/components/TradeDialog.jsx
+++ b/react_main/src/components/TradeDialog.jsx
@@ -142,7 +142,7 @@ export default function TradeDialog({ open, onClose, stock, initialType = "buy",
             </Box>
           )}
           <Box>
-            <Typography variant="h5" sx={{ fontWeight: "bold", lineHeight: 1.2 }}>
+            <Typography sx={{ fontWeight: "bold", fontSize: "1.25rem", lineHeight: 1.2 }}>
               {stock.name}
             </Typography>
             <Typography variant="caption" color="text.secondary">

--- a/react_main/src/components/TradeDialog.jsx
+++ b/react_main/src/components/TradeDialog.jsx
@@ -142,7 +142,7 @@ export default function TradeDialog({ open, onClose, stock, initialType = "buy",
             </Box>
           )}
           <Box>
-            <Typography variant="h6" sx={{ lineHeight: 1.2 }}>
+            <Typography variant="h5" sx={{ fontWeight: "bold", lineHeight: 1.2 }}>
               {stock.name}
             </Typography>
             <Typography variant="caption" color="text.secondary">


### PR DESCRIPTION
Increase the size of the target player/family name in the TradeDialog header to match the subtitle size (0.875rem), fixing the issue where it was rendered too small due to global theme heading overrides.