### PR TITLE
style(profile): ratings UI improvements and solid card backgrounds

### DIFF
--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -1825,7 +1825,7 @@ export default function Profile() {
                   ) : (
                     <>
                       <Stack spacing={2} sx={{ px: 1, py: 1 }}>
-                        <Paper variant="outlined" sx={{ p: 2, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", borderRadius: 2 }}>
+                        <Paper variant="outlined" sx={{ p: 2, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", borderRadius: 2, backgroundColor: (theme) => theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.02)' : '#ffffff' }}>
                           <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1, color: "text.secondary" }}>
                             Win/Loss Distribution
                           </Typography>
@@ -1849,7 +1849,7 @@ export default function Profile() {
                               display: "flex",
                               alignItems: "center",
                               gap: 2,
-                              backgroundColor: (theme) => theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.02)' : 'rgba(0, 0, 0, 0.01)',
+                              backgroundColor: (theme) => theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.02)' : '#ffffff',
                               borderColor: "divider",
                               borderRadius: 2
                             }}
@@ -1922,7 +1922,7 @@ export default function Profile() {
                             </Stack>
                           </Paper>
                         ) : statsBucket === "ranked" ? (
-                          <Paper variant="outlined" sx={{ p: 2, display: "flex", justifyContent: "center", alignItems: "center", borderRadius: 2 }}>
+                          <Paper variant="outlined" sx={{ p: 2, display: "flex", justifyContent: "center", alignItems: "center", borderRadius: 2, backgroundColor: (theme) => theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.02)' : '#ffffff' }}>
                             <Typography variant="body2" color="text.secondary" sx={{ fontStyle: "italic", textAlign: "center", p: 1 }}>
                               No rated games played yet. Play ranked or competitive games to establish a skill rating.
                             </Typography>

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -1845,10 +1845,10 @@ export default function Profile() {
                           <Paper
                             variant="outlined"
                             sx={{
-                              p: 2,
+                              p: 1.5,
                               display: "flex",
                               alignItems: "center",
-                              gap: 2,
+                              gap: 1,
                               backgroundColor: (theme) => theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.02)' : '#ffffff',
                               borderColor: "divider",
                               borderRadius: 2

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -1859,7 +1859,7 @@ export default function Profile() {
                                 <img
                                   src={TIER_ICONS[skillRating.tier]}
                                   alt={skillRating.tier}
-                                  style={{ width: 64, height: 64, objectFit: "contain", imageRendering: "pixelated" }}
+                                  style={{ width: 80, height: 80, objectFit: "contain", imageRendering: "pixelated" }}
                                 />
                               </Box>
                             )}


### PR DESCRIPTION
This PR fixes several visual bugs in the Mafia Ratings card on user profiles:\n\n1. Background: Makes card backgrounds solid white (#ffffff) in light mode, overriding the theme's transparent/secondary color overrides for outlined papers.\n2. Medal Size: Enlarges the pixelated tier icon from 64px to 80px to make the achievement feel more satisfying and visually prominent.\n3. Margin & Layout: Reduces card padding (to 1.5) and layout gap (to 1) to bring the medal closer to the edge, reclaiming horizontal space to prevent the stats text from squishing.