### PR TITLE
Yakuza Behaviour Tweak

### DIFF
--- a/Games/types/Mafia/roles/cards/CommitSeppuku.js
+++ b/Games/types/Mafia/roles/cards/CommitSeppuku.js
@@ -29,8 +29,6 @@ module.exports = class CommitSeppuku extends Card {
             });
             if (temp.dominates(this.actor)) {
               this.actor.kill("basic", this.actor);
-            } else {
-              return;
             }
 
             if (this.dominates()) {


### PR DESCRIPTION
Yazuka modified to still attempt conversion when death is prevented. If the yakuza is killed at night from another source, I believe the conversion will fail.
