### PR TITLE
fix: competitive/ranked setupStats memory leak (unbounded row arrays)

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -3612,20 +3612,6 @@ module.exports = class Game {
         factionToPlayers[factionName].push(playerId);
       }
 
-      const alignmentRows = [];
-      for (const f of Object.keys(factionToPlayers)) {
-        const anyWon = factionToPlayers[f].some((pid) => winners.has(pid));
-        alignmentRows.push([f, gameTypeTag, anyWon]);
-      }
-
-      const roleRows = [];
-      for (const playerId in finalRoleByPlayer) {
-        const { roleName, modifier } = finalRoleByPlayer[playerId];
-        const roleKey = modifier ? `${roleName}:${modifier}` : roleName;
-        const won = winners.has(playerId);
-        roleRows.push([roleKey, gameTypeTag, won]);
-      }
-
       var rolePlays = {};
       var alignmentPlays = {};
       var roleWins = {};
@@ -3673,19 +3659,47 @@ module.exports = class Game {
         increments[`dayCountWins.${this.dayCount}`] = 1;
       }
 
+      // Fixed-size aggregates instead of unbounded $push of per-game rows.
+      // Competitive seasons concentrate play on few setups; row arrays were
+      // loading multi-MB setupStats into memory every game end (fortune calc).
+      const sanitizeStatKey = (key) =>
+        String(key == null ? "" : key).replace(/[.$]/g, "_");
+
+      for (const f of Object.keys(factionToPlayers)) {
+        const anyWon = factionToPlayers[f].some((pid) => winners.has(pid));
+        const safeF = sanitizeStatKey(f);
+        const base = `setupStats.alignmentAgg.${safeF}.${gameTypeTag}`;
+        increments[`${base}.games`] = (increments[`${base}.games`] || 0) + 1;
+        if (anyWon) {
+          increments[`${base}.wins`] = (increments[`${base}.wins`] || 0) + 1;
+        }
+      }
+
+      for (const playerId in finalRoleByPlayer) {
+        const { roleName, modifier } = finalRoleByPlayer[playerId];
+        const roleKey = sanitizeStatKey(
+          modifier ? `${roleName}:${modifier}` : roleName
+        );
+        const won = winners.has(playerId);
+        const base = `setupStats.roleAgg.${roleKey}.${gameTypeTag}`;
+        increments[`${base}.games`] = (increments[`${base}.games`] || 0) + 1;
+        if (won) {
+          increments[`${base}.wins`] = (increments[`${base}.wins`] || 0) + 1;
+        }
+      }
+
+      const lengthBase = `setupStats.lengthAgg.${gameTypeTag}`;
+      increments[`${lengthBase}.count`] =
+        (increments[`${lengthBase}.count`] || 0) + 1;
+      increments[`${lengthBase}.sumMs`] =
+        (increments[`${lengthBase}.sumMs`] || 0) + lengthMs;
+
       await models.SetupVersion.updateOne(
         { _id: new ObjectID(setupVersion._id) },
         {
           $inc: {
             ...increments,
             played: 1,
-          },
-          $push: {
-            "setupStats.alignmentRows": { $each: alignmentRows },
-            "setupStats.roleRows": { $each: roleRows },
-            "setupStats.gameLengthRows": {
-              $each: [[gameTypeTag, lengthMs]],
-            },
           },
         }
       ).exec();
@@ -3803,6 +3817,16 @@ module.exports = class Game {
 
     for (let player of this.players)
       if (!player.left) player.user.disconnect();
+
+    // Drop EventEmitter listeners so role/card closures cannot retain the game
+    // after it is removed from the process-local `games` map (GC help).
+    try {
+      if (this.events && typeof this.events.removeAllListeners === "function") {
+        this.events.removeAllListeners();
+      }
+    } catch (e) {
+      /* ignore */
+    }
 
     delete games[this.id];
     deprecationCheck();

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -299,11 +299,22 @@ var schemas = {
     alignmentPlays: {},
     alignmentWins: {},
     dayCountWins: {},
-    // Per-game stats (clean games only: no leavers, no veg). Rows are [factionOrRoleKey, gameType, wonBool] or [gameType, lengthMs].
+    // Per-game stats (clean games only: no leavers, no veg).
+    // Prefer fixed-size aggregates (alignmentAgg/roleAgg/lengthAgg) — competitive
+    // seasons used to $push unbounded *Rows arrays, loading multi-MB setupStats
+    // into memory on every game end (fortune) and setup page view.
+    // Legacy *Rows arrays may still exist until migrations/compactSetupStatsRows.js runs.
     setupStats: {
       alignmentWinRates: { type: mongoose.Schema.Types.Mixed, default: {} },
       roleWinRates: { type: mongoose.Schema.Types.Mixed, default: {} },
       gameLengths: { type: Array, default: [] },
+      // faction -> gameType -> { wins, games }
+      alignmentAgg: { type: mongoose.Schema.Types.Mixed, default: {} },
+      // roleKey -> gameType -> { wins, games }
+      roleAgg: { type: mongoose.Schema.Types.Mixed, default: {} },
+      // gameType -> { sumMs, count }
+      lengthAgg: { type: mongoose.Schema.Types.Mixed, default: {} },
+      // LEGACY unbounded per-game rows (no longer written; kept for backcompat reads)
       alignmentRows: { type: [mongoose.Schema.Types.Mixed], default: [] },
       roleRows: { type: [mongoose.Schema.Types.Mixed], default: [] },
       gameLengthRows: { type: [mongoose.Schema.Types.Mixed], default: [] },

--- a/migrations/compactSetupStatsRows.js
+++ b/migrations/compactSetupStatsRows.js
@@ -1,0 +1,174 @@
+/**
+ * Compact legacy SetupVersion.setupStats.*Rows into fixed-size aggregates
+ * and drop the unbounded row arrays.
+ *
+ * Why: competitive (and ranked) games $push'ed one row per faction/role per
+ * finished game. Popular competitive setups grew multi-MB setupStats docs;
+ * every game end loaded the full array for fortune calculation, causing
+ * process memory to climb with competitive play.
+ *
+ * Usage (from repo root, with MONGO_URL / env loaded like other migrations):
+ *   node migrations/compactSetupStatsRows.js
+ *   node migrations/compactSetupStatsRows.js --dry-run
+ *   node migrations/compactSetupStatsRows.js --min-rows 100
+ */
+const path = require("path");
+require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
+const mongoose = require("mongoose");
+const models = require("../db/models");
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const minRowsIdx = args.indexOf("--min-rows");
+const minRows =
+  minRowsIdx >= 0 && args[minRowsIdx + 1]
+    ? parseInt(args[minRowsIdx + 1], 10)
+    : 1;
+
+function sanitizeKey(key) {
+  return String(key == null ? "" : key).replace(/[.$]/g, "_");
+}
+
+function foldWinRows(rows, into) {
+  if (!Array.isArray(rows)) return;
+  for (const row of rows) {
+    if (!Array.isArray(row) || row.length < 3) continue;
+    const [rawKey, gameType, won] = row;
+    if (!rawKey || !gameType) continue;
+    const key = sanitizeKey(rawKey);
+    if (!into[key]) into[key] = {};
+    if (!into[key][gameType]) into[key][gameType] = { wins: 0, games: 0 };
+    into[key][gameType].games += 1;
+    if (won === true) into[key][gameType].wins += 1;
+  }
+}
+
+function foldLengthRows(rows, into) {
+  if (!Array.isArray(rows)) return;
+  for (const row of rows) {
+    if (!Array.isArray(row) || row.length < 2) continue;
+    const [gameType, lengthMs] = row;
+    if (!gameType) continue;
+    if (!into[gameType]) into[gameType] = { sumMs: 0, count: 0 };
+    into[gameType].sumMs += Number(lengthMs) || 0;
+    into[gameType].count += 1;
+  }
+}
+
+function mergeAgg(existing, folded) {
+  // Sum row history with any post-deploy aggregate increments.
+  // After the fix ships, new games only touch *Agg; legacy *Rows hold history
+  // until this migration. Summing recovers both without losing either window.
+  const out = {};
+  for (const src of [existing, folded]) {
+    if (!src || typeof src !== "object") continue;
+    for (const [key, byType] of Object.entries(src)) {
+      if (!byType || typeof byType !== "object") continue;
+      if (!out[key]) out[key] = {};
+      for (const [gameType, stats] of Object.entries(byType)) {
+        if (!stats || typeof stats !== "object") continue;
+        if (!out[key][gameType]) out[key][gameType] = { wins: 0, games: 0 };
+        out[key][gameType].wins += Number(stats.wins) || 0;
+        out[key][gameType].games += Number(stats.games) || 0;
+      }
+    }
+  }
+  return out;
+}
+
+function mergeLength(existing, folded) {
+  const out = {};
+  for (const src of [existing, folded]) {
+    if (!src || typeof src !== "object") continue;
+    for (const [gameType, stats] of Object.entries(src)) {
+      if (!stats || typeof stats !== "object") continue;
+      if (!out[gameType]) out[gameType] = { sumMs: 0, count: 0 };
+      out[gameType].sumMs += Number(stats.sumMs) || 0;
+      out[gameType].count += Number(stats.count) || 0;
+    }
+  }
+  return out;
+}
+
+async function main() {
+  const uri = process.env.MONGO_URL || process.env.MONGODB_URI;
+  if (!uri) {
+    console.error("MONGO_URL / MONGODB_URI not set");
+    process.exit(1);
+  }
+  await mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true });
+  console.log(
+    `[compactSetupStatsRows] connected (dryRun=${dryRun}, minRows=${minRows})`
+  );
+
+  const cursor = models.SetupVersion.find({
+    $or: [
+      { "setupStats.alignmentRows.0": { $exists: true } },
+      { "setupStats.roleRows.0": { $exists: true } },
+      { "setupStats.gameLengthRows.0": { $exists: true } },
+    ],
+  })
+    .select("_id setupStats")
+    .cursor();
+
+  let scanned = 0;
+  let updated = 0;
+  let skipped = 0;
+  let maxRows = 0;
+
+  for await (const doc of cursor) {
+    scanned++;
+    const ss = doc.setupStats || {};
+    const aLen = Array.isArray(ss.alignmentRows) ? ss.alignmentRows.length : 0;
+    const rLen = Array.isArray(ss.roleRows) ? ss.roleRows.length : 0;
+    const lLen = Array.isArray(ss.gameLengthRows) ? ss.gameLengthRows.length : 0;
+    const totalRows = aLen + rLen + lLen;
+    if (totalRows > maxRows) maxRows = totalRows;
+    if (totalRows < minRows) {
+      skipped++;
+      continue;
+    }
+
+    const alignmentFolded = {};
+    const roleFolded = {};
+    const lengthFolded = {};
+    foldWinRows(ss.alignmentRows, alignmentFolded);
+    foldWinRows(ss.roleRows, roleFolded);
+    foldLengthRows(ss.gameLengthRows, lengthFolded);
+
+    const alignmentAgg = mergeAgg(ss.alignmentAgg, alignmentFolded);
+    const roleAgg = mergeAgg(ss.roleAgg, roleFolded);
+    const lengthAgg = mergeLength(ss.lengthAgg, lengthFolded);
+
+    console.log(
+      `  SetupVersion ${doc._id}: rows a=${aLen} r=${rLen} l=${lLen} -> agg factions=${Object.keys(alignmentAgg).length} roles=${Object.keys(roleAgg).length}`
+    );
+
+    if (!dryRun) {
+      await models.SetupVersion.updateOne(
+        { _id: doc._id },
+        {
+          $set: {
+            "setupStats.alignmentAgg": alignmentAgg,
+            "setupStats.roleAgg": roleAgg,
+            "setupStats.lengthAgg": lengthAgg,
+            "setupStats.alignmentRows": [],
+            "setupStats.roleRows": [],
+            "setupStats.gameLengthRows": [],
+          },
+        }
+      ).exec();
+    }
+    updated++;
+  }
+
+  console.log(
+    `[compactSetupStatsRows] done scanned=${scanned} updated=${updated} skipped=${skipped} maxRowsSeen=${maxRows} dryRun=${dryRun}`
+  );
+  await mongoose.disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/modules/fortunePoints.js
+++ b/modules/fortunePoints.js
@@ -50,7 +50,17 @@ function winRateFromAlignmentEntries(entries) {
   if (!entries || !entries.length) return null;
   let wins = 0;
   let games = 0;
-  for (const [gameType, isFactionWin] of entries) {
+  for (const entry of entries) {
+    if (!Array.isArray(entry) || entry.length < 2) continue;
+    // Aggregated summary: ["__agg__", gameType, wins, games]
+    if (entry[0] === "__agg__") {
+      const gameType = entry[1];
+      if (!FORTUNE_GAME_TYPES.has(gameType)) continue;
+      wins += Number(entry[2]) || 0;
+      games += Number(entry[3]) || 0;
+      continue;
+    }
+    const [gameType, isFactionWin] = entry;
     if (!FORTUNE_GAME_TYPES.has(gameType)) continue;
     games++;
     if (isFactionWin === true) wins++;
@@ -62,7 +72,15 @@ function winRateFromAlignmentEntries(entries) {
 function countFortuneGames(entries) {
   if (!entries || !entries.length) return 0;
   let games = 0;
-  for (const [gameType] of entries) {
+  for (const entry of entries) {
+    if (!Array.isArray(entry) || entry.length < 1) continue;
+    if (entry[0] === "__agg__") {
+      const gameType = entry[1];
+      if (!FORTUNE_GAME_TYPES.has(gameType)) continue;
+      games += Number(entry[3]) || 0;
+      continue;
+    }
+    const [gameType] = entry;
     if (FORTUNE_GAME_TYPES.has(gameType)) games++;
   }
   return games;
@@ -188,13 +206,25 @@ function getMafiaFactionsFromSetup(setupRoles) {
 }
 
 /**
- * Build alignmentWinRates-shaped map from SetupVersion.setupStats.alignmentRows.
+ * Build alignmentWinRates-shaped map from SetupVersion.setupStats.
+ * Prefers fixed-size alignmentAgg (faction -> gameType -> {wins, games}).
+ * Falls back to legacy unbounded alignmentRows for unmigrated documents.
+ *
+ * When using aggregates, expands to a compact synthetic entry list is avoided
+ * for large N — instead we store a single summary triple per gameType:
+ *   [gameType, wins, games] with a marker shape detected by winRate helpers.
+ * For backcompat with code that expects [gameType, wonBool] pairs, we expand
+ * only when games is small; for large counts we use a special summary form
+ * handled by winRateFromAlignmentEntries / countFortuneGames.
+ *
  * @param {object} setupStats
- * @returns {object} map factionKey -> Array<[gameType, boolean]>
+ * @returns {object} map factionKey -> entries
  */
 function alignmentRowsToWinRateMap(setupStats) {
   const map = {};
   if (!setupStats) return map;
+
+  // Legacy per-game rows (unbounded; still present until compactSetupStatsRows migration)
   const rows = setupStats.alignmentRows;
   if (Array.isArray(rows)) {
     for (const row of rows) {
@@ -202,6 +232,24 @@ function alignmentRowsToWinRateMap(setupStats) {
       const [factionKey, gameType, isFactionWin] = row;
       if (!map[factionKey]) map[factionKey] = [];
       map[factionKey].push([gameType, isFactionWin]);
+    }
+  }
+
+  // Fixed-size aggregates (preferred going forward). During transition both may
+  // exist: rows hold pre-fix history, agg holds post-fix games — sum both.
+  const agg = setupStats.alignmentAgg;
+  if (agg && typeof agg === "object") {
+    for (const [factionKey, byType] of Object.entries(agg)) {
+      if (!byType || typeof byType !== "object") continue;
+      if (!map[factionKey]) map[factionKey] = [];
+      for (const [gameType, stats] of Object.entries(byType)) {
+        if (!stats || typeof stats !== "object") continue;
+        const games = Number(stats.games) || 0;
+        const wins = Number(stats.wins) || 0;
+        if (games <= 0 && wins <= 0) continue;
+        // Summary form: ["__agg__", gameType, wins, games]
+        map[factionKey].push(["__agg__", gameType, wins, games]);
+      }
     }
   }
   return map;

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -386,6 +386,89 @@ function filterStatRows(rows, filter) {
   return rows.filter((r) => r && r[1] === filter);
 }
 
+/** Aggregate fixed-size setupStats.*Agg maps into UI winrate rows. */
+function aggregateWinAgg(agg, filter) {
+  const byKey = {};
+  if (!agg || typeof agg !== "object") return [];
+  for (const [key, byType] of Object.entries(agg)) {
+    if (!byType || typeof byType !== "object") continue;
+    for (const [gameType, stats] of Object.entries(byType)) {
+      if (filter !== "all" && gameType !== filter) continue;
+      if (!stats || typeof stats !== "object") continue;
+      if (!byKey[key]) byKey[key] = { wins: 0, total: 0 };
+      byKey[key].total += Number(stats.games) || 0;
+      byKey[key].wins += Number(stats.wins) || 0;
+    }
+  }
+  return Object.keys(byKey)
+    .map((key) => ({
+      key,
+      winRate: byKey[key].total ? byKey[key].wins / byKey[key].total : 0,
+      totalGames: byKey[key].total,
+    }))
+    .sort((a, b) => b.winRate - a.winRate || a.key.localeCompare(b.key));
+}
+
+function averageLengthAgg(lengthAgg, filter) {
+  if (!lengthAgg || typeof lengthAgg !== "object") return null;
+  let sum = 0;
+  let n = 0;
+  for (const [gameType, stats] of Object.entries(lengthAgg)) {
+    if (filter !== "all" && gameType !== filter) continue;
+    if (!stats || typeof stats !== "object") continue;
+    sum += Number(stats.sumMs) || 0;
+    n += Number(stats.count) || 0;
+  }
+  if (!n) return null;
+  return sum / n;
+}
+
+function mergeWinrateLists(a, b) {
+  const byKey = {};
+  for (const list of [a || [], b || []]) {
+    for (const row of list) {
+      if (!row || row.key == null) continue;
+      if (!byKey[row.key]) byKey[row.key] = { wins: 0, total: 0 };
+      const total = Number(row.totalGames) || 0;
+      const winRate = Number(row.winRate) || 0;
+      byKey[row.key].total += total;
+      byKey[row.key].wins += winRate * total;
+    }
+  }
+  return Object.keys(byKey)
+    .map((key) => ({
+      key,
+      winRate: byKey[key].total ? byKey[key].wins / byKey[key].total : 0,
+      totalGames: byKey[key].total,
+    }))
+    .sort((x, y) => y.winRate - x.winRate || x.key.localeCompare(y.key));
+}
+
+function mergeAverageLength(avgAgg, avgRows, lengthAgg, lengthRows, filter) {
+  // Prefer computing from raw sources so both windows contribute by weight.
+  let sum = 0;
+  let n = 0;
+  if (lengthAgg && typeof lengthAgg === "object") {
+    for (const [gameType, stats] of Object.entries(lengthAgg)) {
+      if (filter !== "all" && gameType !== filter) continue;
+      if (!stats || typeof stats !== "object") continue;
+      sum += Number(stats.sumMs) || 0;
+      n += Number(stats.count) || 0;
+    }
+  }
+  if (Array.isArray(lengthRows)) {
+    for (const row of lengthRows) {
+      if (!Array.isArray(row) || row.length < 2) continue;
+      if (filter !== "all" && row[0] !== filter) continue;
+      sum += Number(row[1]) || 0;
+      n += 1;
+    }
+  }
+  if (n > 0) return sum / n;
+  if (avgAgg != null) return avgAgg;
+  return avgRows;
+}
+
 function aggregateWinRows(rows, filter) {
   const filtered = filterStatRows(rows, filter);
   const byKey = {};
@@ -431,20 +514,38 @@ function calculateStatsWithGranular(setupVersion, gameType) {
   const alignmentRows = ss.alignmentRows || [];
   const roleRows = ss.roleRows || [];
   const lengthRows = ss.gameLengthRows || [];
+  const alignmentAgg = ss.alignmentAgg || {};
+  const roleAgg = ss.roleAgg || {};
+  const lengthAgg = ss.lengthAgg || {};
   const totalVegs = ss.totalVegs != null ? ss.totalVegs : 0;
+  // Prefer fixed-size aggregates (new); fall back to legacy unbounded rows.
+  const hasAgg =
+    Object.keys(alignmentAgg).length > 0 || Object.keys(roleAgg).length > 0;
   // lengthRows is metadata, not win/loss data — excluding it lets legacy
   // setups (alignmentRows empty, lengthRows populated) fall back to the pie.
   const hasGranular =
-    alignmentRows.length > 0 ||
-    roleRows.length > 0;
+    hasAgg || alignmentRows.length > 0 || roleRows.length > 0;
 
   const filters = ["all", "unranked", "ranked", "competitive"];
   const granular = {};
   for (const f of filters) {
+    // Merge agg + legacy rows during transition (sum games/wins by key).
     granular[f] = {
-      alignment: aggregateWinRows(alignmentRows, f),
-      role: aggregateWinRows(roleRows, f),
-      averageLengthMs: averageLengthRows(lengthRows, f),
+      alignment: mergeWinrateLists(
+        aggregateWinAgg(alignmentAgg, f),
+        aggregateWinRows(alignmentRows, f)
+      ),
+      role: mergeWinrateLists(
+        aggregateWinAgg(roleAgg, f),
+        aggregateWinRows(roleRows, f)
+      ),
+      averageLengthMs: mergeAverageLength(
+        averageLengthAgg(lengthAgg, f),
+        averageLengthRows(lengthRows, f),
+        lengthAgg,
+        lengthRows,
+        f
+      ),
       totalVegs,
     };
   }


### PR DESCRIPTION
## Summary

Competitive seasons (and ranked) were pushing **unbounded** per-game stats onto `SetupVersion.setupStats`:

- `alignmentRows` — one row per faction per finished clean game
- `roleRows` — one row per player role per game
- `gameLengthRows` — one row per game

Popular competitive setups concentrate thousands of games onto a few setup versions, creating multi-MB documents. Every competitive/ranked game end then loads the **full** `setupStats` into memory for fortune calculation (`adjustSkillRatings` → `alignmentRowsToWinRateMap`), and setup pages do the same for granular winrate UI. That matches reports of growing process memory under competitive play.

### Fix

1. **Write fixed-size aggregates** instead of `$push`ing rows:
   - `setupStats.alignmentAgg[faction][gameType] = { wins, games }`
   - `setupStats.roleAgg[roleKey][gameType] = { wins, games }`
   - `setupStats.lengthAgg[gameType] = { sumMs, count }`
2. **Read path** merges aggregates with legacy `*Rows` during transition so history is not lost before migration.
3. **Postgame cleanup** calls `events.removeAllListeners()` so role/card listeners cannot retain finished games after they leave the process `games` map.
4. **Migration** `migrations/compactSetupStatsRows.js` folds existing row arrays into aggregates and clears them (run on prod after deploy).

### Deploy notes

After merging, run once against production Mongo:

```bash
node migrations/compactSetupStatsRows.js --dry-run
node migrations/compactSetupStatsRows.js
```

Optional: `--min-rows 100` to only touch large docs first.

## Test plan

- [ ] Finish a ranked or competitive game; confirm fortune still pays
- [ ] Confirm setup page granular winrates still show for a setup that has history
- [ ] After migration dry-run, verify largest setupStats docs shrink when run for real
- [ ] Watch games process RSS over a competitive evening — should stop climbing with setupStats size
