### PR TITLE
fix: ranked/comp typing paste false positives + paste spam (exact/similar)

### DIFF
--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -214,7 +214,12 @@ module.exports = class Player {
             speechPast,
             message.content,
             constants.rankedCompetitiveTypingWpm,
-            constants.rankedCompetitiveAvgWordLength
+            constants.rankedCompetitiveAvgWordLength,
+            Date.now(),
+            {
+              pasteGraceChars: constants.rankedCompetitiveTypingPasteGraceChars,
+              maxIntervalMs: constants.rankedCompetitiveTypingMaxIntervalMs,
+            }
           );
 
           if (typingCooldownMs > 0) {

--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -209,6 +209,21 @@ module.exports = class Player {
           return;
         }
 
+        // Same content twice in a row is OK; third consecutive identical paste is blocked.
+        if (
+          Spam.isRepeatedContentSpam(
+            speechPast,
+            message.content,
+            constants.msgDuplicateMaxConsecutive
+          )
+        ) {
+          sendSpeakCooldown(
+            message.meetingId,
+            constants.msgDuplicateCooldownMs
+          );
+          return;
+        }
+
         if (isRankedCompetitive()) {
           const typingCooldownMs = Spam.getTypingSpeedCooldownRemainingMs(
             speechPast,
@@ -236,7 +251,10 @@ module.exports = class Player {
           return;
         }
 
-        speechPast.push(Date.now());
+        speechPast.push({
+          at: Date.now(),
+          content: Spam.normalizeSpeakContent(message.content),
+        });
 
         var meeting = this.game.getMeeting(message.meetingId);
         if (!meeting) return;

--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -140,6 +140,8 @@ module.exports = class Player {
     var votePast = [];
     var lastQuoteMessageId = null;
     var lastQuoteTime = 0;
+    // Last time we blocked for identical/similar paste spam (for similar-check window)
+    var lastSpeakContentBlockAt = 0;
 
     const isRankedCompetitive = () =>
       this.game.started && (this.game.ranked || this.game.competitive);
@@ -217,6 +219,33 @@ module.exports = class Player {
             constants.msgDuplicateMaxConsecutive
           )
         ) {
+          lastSpeakContentBlockAt = Date.now();
+          sendSpeakCooldown(
+            message.meetingId,
+            constants.msgDuplicateCooldownMs
+          );
+          return;
+        }
+
+        // Near-duplicates (same paste block with small edits) only when sending
+        // quickly, or still in the window after a recent content-spam block.
+        if (
+          Spam.shouldCheckSimilarContent(
+            speechPast,
+            lastSpeakContentBlockAt,
+            Date.now(),
+            constants.msgSimilarQuickWindowMs,
+            constants.msgSimilarAfterBlockWindowMs
+          ) &&
+          Spam.isRepeatedSimilarContentSpam(
+            speechPast,
+            message.content,
+            constants.msgDuplicateMaxConsecutive,
+            constants.msgSimilarThreshold,
+            constants.msgSimilarMinLength
+          )
+        ) {
+          lastSpeakContentBlockAt = Date.now();
           sendSpeakCooldown(
             message.meetingId,
             constants.msgDuplicateCooldownMs

--- a/Games/core/Spam.js
+++ b/Games/core/Spam.js
@@ -78,9 +78,33 @@ module.exports = class Spam {
     return count;
   }
 
-  static getRankedCompetitiveMinIntervalMs(content, wpm, avgWordLength) {
+  /**
+   * Minimum time after the previous send before this content is allowed under
+   * the ranked/competitive typing gate.
+   *
+   * pasteGraceChars: non-ws chars that do not require typing time (prep/paste).
+   * maxIntervalMs: hard cap so a long line never demands 10–20s after a short one.
+   */
+  static getRankedCompetitiveMinIntervalMs(
+    content,
+    wpm,
+    avgWordLength,
+    options = {}
+  ) {
     const messageLen = this.getMessageCharCountExcludingWhitespace(content);
-    return ((messageLen / avgWordLength) / wpm) * 60 * 1000;
+    if (messageLen === 0 || !wpm || !avgWordLength) return 0;
+
+    const pasteGrace =
+      options.pasteGraceChars != null ? options.pasteGraceChars : 0;
+    const maxIntervalMs =
+      options.maxIntervalMs != null ? options.maxIntervalMs : Infinity;
+
+    // Only bill chars beyond the paste/prep grace toward the WPM clock.
+    const billableLen = Math.max(0, messageLen - pasteGrace);
+    if (billableLen === 0) return 0;
+
+    const rawMs = (billableLen / avgWordLength / wpm) * 60 * 1000;
+    return Math.min(rawMs, maxIntervalMs);
   }
 
   static getTypingSpeedCooldownRemainingMs(
@@ -88,17 +112,20 @@ module.exports = class Spam {
     content,
     wpm,
     avgWordLength,
-    now = Date.now()
+    now = Date.now(),
+    options = {}
   ) {
     if (past.length === 0) return 0;
 
     const minIntervalMs = this.getRankedCompetitiveMinIntervalMs(
       content,
       wpm,
-      avgWordLength
+      avgWordLength,
+      options
     );
-    const elapsed = now - past[past.length - 1];
+    if (minIntervalMs <= 0) return 0;
 
+    const elapsed = now - past[past.length - 1];
     return Math.max(0, minIntervalMs - elapsed);
   }
 
@@ -107,7 +134,8 @@ module.exports = class Spam {
     content,
     wpm,
     avgWordLength,
-    now = Date.now()
+    now = Date.now(),
+    options = {}
   ) {
     return (
       this.getTypingSpeedCooldownRemainingMs(
@@ -115,7 +143,8 @@ module.exports = class Spam {
         content,
         wpm,
         avgWordLength,
-        now
+        now,
+        options
       ) > 0
     );
   }

--- a/Games/core/Spam.js
+++ b/Games/core/Spam.js
@@ -131,6 +131,124 @@ module.exports = class Spam {
     );
   }
 
+  /** Dice coefficient on character bigrams (0–1). */
+  static diceCoefficient(a, b) {
+    if (!a || !b) return 0;
+    if (a === b) return 1;
+    if (a.length < 2 || b.length < 2) return 0;
+
+    const bigrams = new Map();
+    for (let i = 0; i < a.length - 1; i++) {
+      const bg = a.slice(i, i + 2);
+      bigrams.set(bg, (bigrams.get(bg) || 0) + 1);
+    }
+
+    let overlap = 0;
+    for (let i = 0; i < b.length - 1; i++) {
+      const bg = b.slice(i, i + 2);
+      const count = bigrams.get(bg) || 0;
+      if (count > 0) {
+        bigrams.set(bg, count - 1);
+        overlap += 1;
+      }
+    }
+
+    return (2 * overlap) / (a.length - 1 + (b.length - 1));
+  }
+
+  /**
+   * True if two messages look like the same paste with small edits / extensions.
+   * Also treats a substantial shared block (substring) as similar.
+   */
+  static isSimilarContent(
+    a,
+    b,
+    threshold = 0.8,
+    minLength = 12
+  ) {
+    const na = this.normalizeSpeakContent(a);
+    const nb = this.normalizeSpeakContent(b);
+    if (!na || !nb) return false;
+    if (na === nb) return true;
+    if (na.length < minLength || nb.length < minLength) return false;
+
+    const shorter = na.length <= nb.length ? na : nb;
+    const longer = na.length <= nb.length ? nb : na;
+
+    // Shared paste block: longer contains shorter (or large common chunk)
+    if (longer.includes(shorter) && shorter.length / longer.length >= 0.45) {
+      return true;
+    }
+
+    return this.diceCoefficient(na, nb) >= threshold;
+  }
+
+  /**
+   * Trailing consecutive past entries similar to `content`.
+   */
+  static getConsecutiveSimilarCount(
+    past,
+    content,
+    threshold = 0.8,
+    minLength = 12,
+    now = Date.now()
+  ) {
+    this.prunePast(past, now);
+    const norm = this.normalizeSpeakContent(content);
+    if (!norm || norm.length < minLength) return 0;
+
+    let count = 0;
+    for (let i = past.length - 1; i >= 0; i--) {
+      const prev = this.entryContent(past[i]);
+      if (prev == null) break;
+      if (this.isSimilarContent(prev, norm, threshold, minLength)) count += 1;
+      else break;
+    }
+    return count;
+  }
+
+  /**
+   * Near-duplicate paste spam: 3rd consecutive similar line blocked.
+   * Caller should only invoke when sending quickly or recently blocked.
+   */
+  static isRepeatedSimilarContentSpam(
+    past,
+    content,
+    maxConsecutive = 2,
+    threshold = 0.8,
+    minLength = 12,
+    now = Date.now()
+  ) {
+    return (
+      this.getConsecutiveSimilarCount(
+        past,
+        content,
+        threshold,
+        minLength,
+        now
+      ) >= maxConsecutive
+    );
+  }
+
+  /**
+   * Whether the similar-paste gate should run: rapid sends, or still inside
+   * the window after a prior duplicate/similar block.
+   */
+  static shouldCheckSimilarContent(
+    past,
+    lastBlockAt,
+    now = Date.now(),
+    quickWindowMs = 3500,
+    afterBlockWindowMs = 5000
+  ) {
+    if (lastBlockAt && now - lastBlockAt <= afterBlockWindowMs) {
+      return true;
+    }
+    if (past.length === 0) return false;
+    const lastAt = this.entryTime(past[past.length - 1]);
+    return lastAt > 0 && now - lastAt <= quickWindowMs;
+  }
+
   /**
    * Minimum time after the previous send before this content is allowed under
    * the ranked/competitive typing gate.

--- a/Games/core/Spam.js
+++ b/Games/core/Spam.js
@@ -1,7 +1,19 @@
 module.exports = class Spam {
+  /** speechPast entries may be a timestamp number or { at, content }. */
+  static entryTime(entry) {
+    if (entry == null) return 0;
+    if (typeof entry === "number") return entry;
+    return entry.at || 0;
+  }
+
+  static entryContent(entry) {
+    if (entry == null || typeof entry === "number") return null;
+    return entry.content != null ? entry.content : null;
+  }
+
   static prunePast(past, now = Date.now()) {
     for (let i = past.length - 1; i >= 0; i--) {
-      if ((now - past[i]) / 1000 > 20) {
+      if ((now - this.entryTime(past[i])) / 1000 > 20) {
         past.splice(i, 1);
       }
     }
@@ -12,7 +24,7 @@ module.exports = class Spam {
 
     let sum = 0;
     for (let i in past) {
-      sum += 1 / ((now - past[i] + 1) / 1000);
+      sum += 1 / ((now - this.entryTime(past[i]) + 1) / 1000);
     }
 
     return {
@@ -40,7 +52,7 @@ module.exports = class Spam {
       let count = 0;
 
       for (let i in past) {
-        const elapsed = checkTime - past[i];
+        const elapsed = checkTime - this.entryTime(past[i]);
         if (elapsed <= maxCooldownMs) {
           count += 1;
           sum += 1 / ((elapsed + 1) / 1000);
@@ -58,7 +70,7 @@ module.exports = class Spam {
   static getFixedCooldownRemainingMs(past, cooldownMs, now = Date.now()) {
     if (!cooldownMs || past.length === 0) return 0;
 
-    const elapsed = now - past[past.length - 1];
+    const elapsed = now - this.entryTime(past[past.length - 1]);
     return Math.max(0, cooldownMs - elapsed);
   }
 
@@ -76,6 +88,47 @@ module.exports = class Spam {
     }
 
     return count;
+  }
+
+  /** Normalize for duplicate detection (trim + collapse whitespace). */
+  static normalizeSpeakContent(content) {
+    return String(content || "")
+      .trim()
+      .replace(/\s+/g, " ");
+  }
+
+  /**
+   * How many trailing speechPast entries match this content (consecutive).
+   * Uses entries still inside the prune window.
+   */
+  static getConsecutiveDuplicateCount(past, content, now = Date.now()) {
+    this.prunePast(past, now);
+    const norm = this.normalizeSpeakContent(content);
+    if (!norm) return 0;
+
+    let count = 0;
+    for (let i = past.length - 1; i >= 0; i--) {
+      const prev = this.entryContent(past[i]);
+      if (prev == null) break;
+      if (prev === norm) count += 1;
+      else break;
+    }
+    return count;
+  }
+
+  /**
+   * Block when the same content was already sent maxConsecutive times in a row.
+   * maxConsecutive = 2 → first and second OK, third blocked.
+   */
+  static isRepeatedContentSpam(
+    past,
+    content,
+    maxConsecutive = 2,
+    now = Date.now()
+  ) {
+    return (
+      this.getConsecutiveDuplicateCount(past, content, now) >= maxConsecutive
+    );
   }
 
   /**
@@ -125,7 +178,7 @@ module.exports = class Spam {
     );
     if (minIntervalMs <= 0) return 0;
 
-    const elapsed = now - past[past.length - 1];
+    const elapsed = now - this.entryTime(past[past.length - 1]);
     return Math.max(0, minIntervalMs - elapsed);
   }
 

--- a/Games/core/Spectator.js
+++ b/Games/core/Spectator.js
@@ -91,6 +91,22 @@ module.exports = class Spectator extends Player {
         }
 
         if (
+          Spam.isRepeatedContentSpam(
+            speechPast,
+            message.content,
+            constants.msgDuplicateMaxConsecutive
+          )
+        ) {
+          const sentAt = Date.now();
+          this.send("speakCooldown", {
+            meetingId: message.meetingId,
+            sentAt,
+            cooldownMs: constants.msgDuplicateCooldownMs,
+          });
+          return;
+        }
+
+        if (
           message.content[0] == "/" &&
           message.content.slice(0, 4) != "/me "
         ) {
@@ -98,7 +114,10 @@ module.exports = class Spectator extends Player {
           return;
         }
 
-        speechPast.push(Date.now());
+        speechPast.push({
+          at: Date.now(),
+          content: Spam.normalizeSpeakContent(message.content),
+        });
 
         var meeting = this.game.getMeeting(message.meetingId);
         if (!meeting) return;

--- a/Games/core/Spectator.js
+++ b/Games/core/Spectator.js
@@ -22,6 +22,7 @@ module.exports = class Spectator extends Player {
   socketListeners() {
     const socket = this.socket;
     var speechPast = [];
+    var lastSpeakContentBlockAt = 0;
 
     socket.on("leave", () => {
       try {
@@ -97,6 +98,33 @@ module.exports = class Spectator extends Player {
             constants.msgDuplicateMaxConsecutive
           )
         ) {
+          lastSpeakContentBlockAt = Date.now();
+          const sentAt = Date.now();
+          this.send("speakCooldown", {
+            meetingId: message.meetingId,
+            sentAt,
+            cooldownMs: constants.msgDuplicateCooldownMs,
+          });
+          return;
+        }
+
+        if (
+          Spam.shouldCheckSimilarContent(
+            speechPast,
+            lastSpeakContentBlockAt,
+            Date.now(),
+            constants.msgSimilarQuickWindowMs,
+            constants.msgSimilarAfterBlockWindowMs
+          ) &&
+          Spam.isRepeatedSimilarContentSpam(
+            speechPast,
+            message.content,
+            constants.msgDuplicateMaxConsecutive,
+            constants.msgSimilarThreshold,
+            constants.msgSimilarMinLength
+          )
+        ) {
+          lastSpeakContentBlockAt = Date.now();
           const sentAt = Date.now();
           this.send("speakCooldown", {
             meetingId: message.meetingId,

--- a/data/constants.js
+++ b/data/constants.js
@@ -359,6 +359,11 @@ module.exports = {
   // Same line may be sent twice in a row; the 3rd consecutive identical paste is blocked.
   msgDuplicateMaxConsecutive: 2,
   msgDuplicateCooldownMs: 3 * 1000,
+  // Near-duplicate (similar) paste spam — only when sending quickly or recently blocked.
+  msgSimilarThreshold: 0.8,
+  msgSimilarMinLength: 12,
+  msgSimilarQuickWindowMs: 3500,
+  msgSimilarAfterBlockWindowMs: 5000,
   voteSpamSumLimit: 15,
   voteSpamRateLimit: 10,
   rankedCompetitiveTypingWpm: 130,

--- a/data/constants.js
+++ b/data/constants.js
@@ -356,6 +356,9 @@ module.exports = {
 
   msgSpamSumLimit: 15,
   msgSpamRateLimit: 10,
+  // Same line may be sent twice in a row; the 3rd consecutive identical paste is blocked.
+  msgDuplicateMaxConsecutive: 2,
+  msgDuplicateCooldownMs: 3 * 1000,
   voteSpamSumLimit: 15,
   voteSpamRateLimit: 10,
   rankedCompetitiveTypingWpm: 130,

--- a/data/constants.js
+++ b/data/constants.js
@@ -360,6 +360,11 @@ module.exports = {
   voteSpamRateLimit: 10,
   rankedCompetitiveTypingWpm: 130,
   rankedCompetitiveAvgWordLength: 3.9914985005289525,
+  // Free non-whitespace chars after the last send (prep/paste is normal in game).
+  // Without this, a short line then a long paste looks like impossible WPM.
+  rankedCompetitiveTypingPasteGraceChars: 180,
+  // Never gate solely on typing speed for longer than this after the last send.
+  rankedCompetitiveTypingMaxIntervalMs: 2500,
   rankedCompetitiveQuoteCooldownMs: 2 * 1000,
 
   maxUserNameLength: 20,

--- a/test/Spam.test.js
+++ b/test/Spam.test.js
@@ -149,3 +149,55 @@ describe("Games/core/Spam typing speed (ranked/competitive)", function () {
     remaining.should.be.at.most(MAX_IV - 200);
   });
 });
+
+describe("Games/core/Spam repeated content", function () {
+  const max = 2;
+
+  it("allows the first and second identical paste", function () {
+    const now = 20_000_000;
+    const past = [];
+    const msg = "I am town claim cop";
+
+    Spam.isRepeatedContentSpam(past, msg, max, now).should.equal(false);
+    past.push({ at: now, content: Spam.normalizeSpeakContent(msg) });
+
+    Spam.isRepeatedContentSpam(past, msg, max, now + 100).should.equal(false);
+    past.push({ at: now + 100, content: Spam.normalizeSpeakContent(msg) });
+
+    // third consecutive identical is blocked
+    Spam.isRepeatedContentSpam(past, msg, max, now + 200).should.equal(true);
+  });
+
+  it("resets when content changes", function () {
+    const now = 21_000_000;
+    const past = [
+      { at: now, content: Spam.normalizeSpeakContent("aaa") },
+      { at: now + 50, content: Spam.normalizeSpeakContent("aaa") },
+      { at: now + 100, content: Spam.normalizeSpeakContent("bbb") },
+    ];
+    Spam.isRepeatedContentSpam(past, "aaa", max, now + 150).should.equal(false);
+    Spam.isRepeatedContentSpam(past, "bbb", max, now + 150).should.equal(false);
+  });
+
+  it("treats whitespace-normalized content as the same", function () {
+    const now = 22_000_000;
+    const past = [
+      { at: now, content: Spam.normalizeSpeakContent("hello   world") },
+      { at: now + 50, content: Spam.normalizeSpeakContent("hello world") },
+    ];
+    Spam.isRepeatedContentSpam(
+      past,
+      "  hello\tworld  ",
+      max,
+      now + 100
+    ).should.equal(true);
+  });
+
+  it("rate helpers still accept plain timestamp entries", function () {
+    const now = Date.now();
+    const past = [now - 1000, now - 500];
+    const info = Spam.getRateInfo(past, now);
+    info.count.should.equal(2);
+    Spam.rateLimit(past, 15, 10).should.equal(false);
+  });
+});

--- a/test/Spam.test.js
+++ b/test/Spam.test.js
@@ -1,0 +1,151 @@
+const chai = require("chai");
+const should = chai.should();
+const Spam = require("../Games/core/Spam");
+
+const WPM = 130;
+const AVG = 3.9914985005289525;
+const GRACE = 180;
+const MAX_IV = 2500;
+
+const opts = { pasteGraceChars: GRACE, maxIntervalMs: MAX_IV };
+
+describe("Games/core/Spam typing speed (ranked/competitive)", function () {
+  it("does not block the first message", function () {
+    Spam.getTypingSpeedCooldownRemainingMs(
+      [],
+      "hello world",
+      WPM,
+      AVG,
+      Date.now(),
+      opts
+    ).should.equal(0);
+  });
+
+  it("allows a long paste immediately after a one-word line (paste grace)", function () {
+    const now = 1_000_000;
+    const past = [now - 200]; // 200ms after a short send
+    // Typical night write-up paste after saying "N1" or "vote"
+    const longLine =
+      "I was town last night and checked Bob. He is suspicious because he claimed wrong. " +
+      "Please vote him with me. I have receipts from night actions. Also watch Alice. " +
+      "She pushed too hard on me D1 without evidence and refused to claim properly.";
+    const len = Spam.getMessageCharCountExcludingWhitespace(longLine);
+    len.should.be.above(150);
+
+    const remaining = Spam.getTypingSpeedCooldownRemainingMs(
+      past,
+      longLine,
+      WPM,
+      AVG,
+      now,
+      opts
+    );
+    // Uncapped old formula would demand many seconds
+    const uncapped = Spam.getRankedCompetitiveMinIntervalMs(longLine, WPM, AVG, {
+      pasteGraceChars: 0,
+      maxIntervalMs: Infinity,
+    });
+    uncapped.should.be.above(5000);
+    remaining.should.be.at.most(MAX_IV);
+    if (len <= GRACE) {
+      remaining.should.equal(0);
+    } else {
+      remaining.should.be.below(MAX_IV);
+    }
+  });
+
+  it("daystart: two prepared lines back-to-back are not multi-second blocked", function () {
+    const t0 = 10_000_000;
+    const line1 = "a".repeat(160);
+    const line2 = "b".repeat(160);
+    Spam.getTypingSpeedCooldownRemainingMs(
+      [],
+      line1,
+      WPM,
+      AVG,
+      t0,
+      opts
+    ).should.equal(0);
+    const past = [t0];
+    const remaining = Spam.getTypingSpeedCooldownRemainingMs(
+      past,
+      line2,
+      WPM,
+      AVG,
+      t0 + 400,
+      opts
+    );
+    remaining.should.equal(0);
+  });
+
+  it("allows a full max-length message after a short gap when within paste grace", function () {
+    const now = 2_000_000;
+    const past = [now - 100];
+    const content = "a".repeat(GRACE);
+    Spam.getTypingSpeedCooldownRemainingMs(
+      past,
+      content,
+      WPM,
+      AVG,
+      now,
+      opts
+    ).should.equal(0);
+  });
+
+  it("still applies a (capped) delay for content far beyond paste grace", function () {
+    const now = 3_000_000;
+    const past = [now]; // just sent
+    const content = "a".repeat(GRACE + 200);
+    const remaining = Spam.getTypingSpeedCooldownRemainingMs(
+      past,
+      content,
+      WPM,
+      AVG,
+      now,
+      opts
+    );
+    remaining.should.equal(MAX_IV);
+  });
+
+  it("clears after max interval has elapsed", function () {
+    const now = 4_000_000;
+    const past = [now - MAX_IV - 1];
+    const content = "a".repeat(GRACE + 200);
+    Spam.getTypingSpeedCooldownRemainingMs(
+      past,
+      content,
+      WPM,
+      AVG,
+      now,
+      opts
+    ).should.equal(0);
+  });
+
+  it("old uncapped formula would have blocked short-then-long (regression guard)", function () {
+    const now = 5_000_000;
+    const past = [now - 200];
+    const longLine = "x".repeat(200);
+    const uncapped = Spam.getRankedCompetitiveMinIntervalMs(longLine, WPM, AVG, {
+      pasteGraceChars: 0,
+      maxIntervalMs: Infinity,
+    });
+    uncapped.should.be.above(10_000);
+
+    const cappedMin = Spam.getRankedCompetitiveMinIntervalMs(
+      longLine,
+      WPM,
+      AVG,
+      opts
+    );
+    cappedMin.should.be.at.most(MAX_IV);
+    const remaining = Spam.getTypingSpeedCooldownRemainingMs(
+      past,
+      longLine,
+      WPM,
+      AVG,
+      now,
+      opts
+    );
+    remaining.should.be.at.most(MAX_IV - 200);
+  });
+});

--- a/test/Spam.test.js
+++ b/test/Spam.test.js
@@ -201,3 +201,86 @@ describe("Games/core/Spam repeated content", function () {
     Spam.rateLimit(past, 15, 10).should.equal(false);
   });
 });
+
+describe("Games/core/Spam similar content", function () {
+  const max = 2;
+  const thr = 0.8;
+  const minLen = 12;
+
+  it("detects extended paste blocks as similar", function () {
+    const a = "vote Bob he is sus from n1 checks";
+    const b = "vote Bob he is sus from n1 checks also watch Alice";
+    Spam.isSimilarContent(a, b, thr, minLen).should.equal(true);
+  });
+
+  it("does not mark unrelated long lines as similar", function () {
+    const a = "I am claiming doctor and will protect the mayor tonight";
+    const b = "Jester is fake claiming cop and pushing wrong people";
+    Spam.isSimilarContent(a, b, thr, minLen).should.equal(false);
+  });
+
+  it("blocks third consecutive similar paste", function () {
+    const now = 30_000_000;
+    const base = "I checked Bob last night he is mafia please vote";
+    const past = [
+      { at: now, content: Spam.normalizeSpeakContent(base) },
+      {
+        at: now + 100,
+        content: Spam.normalizeSpeakContent(base + " him now"),
+      },
+    ];
+    const third = base + " with me";
+    Spam.isRepeatedSimilarContentSpam(
+      past,
+      third,
+      max,
+      thr,
+      minLen,
+      now + 200
+    ).should.equal(true);
+  });
+
+  it("allows two similar pastes", function () {
+    const now = 31_000_000;
+    const base = "I checked Bob last night he is mafia please vote";
+    const past = [{ at: now, content: Spam.normalizeSpeakContent(base) }];
+    Spam.isRepeatedSimilarContentSpam(
+      past,
+      base + " today",
+      max,
+      thr,
+      minLen,
+      now + 100
+    ).should.equal(false);
+  });
+
+  it("shouldCheckSimilarContent when sending quickly", function () {
+    const now = 32_000_000;
+    const past = [{ at: now - 500, content: "hello there friend" }];
+    Spam.shouldCheckSimilarContent(past, 0, now, 3500, 5000).should.equal(
+      true
+    );
+  });
+
+  it("shouldCheckSimilarContent when recently blocked even if slow", function () {
+    const now = 33_000_000;
+    const past = [{ at: now - 10_000, content: "hello there friend" }];
+    Spam.shouldCheckSimilarContent(past, now - 1000, now, 3500, 5000).should.equal(
+      true
+    );
+  });
+
+  it("should not check similar when slow and not recently blocked", function () {
+    const now = 34_000_000;
+    const past = [{ at: now - 10_000, content: "hello there friend" }];
+    Spam.shouldCheckSimilarContent(past, 0, now, 3500, 5000).should.equal(
+      false
+    );
+  });
+
+  it("skips similar match for very short strings", function () {
+    Spam.isSimilarContent("hi there!!", "hi there??", thr, minLen).should.equal(
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Summary

### 1. Paste / typing-speed false positives
Ranked/competitive WPM gate treated every message as typed from scratch since the last send, so short line then long paste (and daystart double-paste) got blocked.

**Fix:** paste/prep grace (180 non-ws chars) + max typing wait 2.5s. Message rate limits unchanged.

### 2. Repeated identical paste spam
**Fix:** same content may be sent **twice in a row**; the **3rd consecutive** identical paste is blocked (3s cooldown). Always on. Whitespace-normalized.

### 3. Near-duplicate (similar) paste spam
Catches the same paste block with small edits/extensions (Dice bigrams + shared substring).

**Only runs when:**
- sending within **3.5s** of the previous line, **or**
- blocked for content-spam in the last **5s** (keeps catching slight variations after a timeout)

Same rule: two similar lines OK, third blocked. Skips very short strings (&lt; 12 chars).

### Constants
- `rankedCompetitiveTypingPasteGraceChars: 180`
- `rankedCompetitiveTypingMaxIntervalMs: 2500`
- `msgDuplicateMaxConsecutive: 2`
- `msgDuplicateCooldownMs: 3000`
- `msgSimilarThreshold: 0.8`
- `msgSimilarMinLength: 12`
- `msgSimilarQuickWindowMs: 3500`
- `msgSimilarAfterBlockWindowMs: 5000`

## Test plan
- [ ] Unit tests (`test/Spam.test.js` — 19 cases)
- [ ] Ranked/comp: short then long paste OK; daystart two lines OK
- [ ] Identical paste twice OK; third blocked
- [ ] Rapid similar pastes (same block + small edit) third blocked
- [ ] Slow non-spam similar claims minutes apart still allowed
- [ ] After a content block, slight reword still caught for a few seconds
