### PR TITLE
feat(competitive): setup completed-game counts for current round

### DIFF
--- a/modules/redis.js
+++ b/modules/redis.js
@@ -661,6 +661,9 @@ async function _getCompRoundInfo(seasonNumber = null, roundNumber = null) {
     round: null,
     allowedSetups: [],
     gameCompletions: [],
+    // setupId -> number of completed competitive games this round
+    // (unique games only; excludes veg/broken/refunded/invalid)
+    setupPlayCounts: {},
     standings: [],
     users: {},
     nextEvent: null,
@@ -788,6 +791,20 @@ async function _getCompRoundInfo(seasonNumber = null, roundNumber = null) {
   for (let gameCompletion of roundInfo.gameCompletions) {
     gameCompletion.game.status = "Finished";
   }
+
+  // Count completed games per setup for the selected round.
+  // gameCompletions is already unique-by-game and valid:true only, and
+  // CompetitiveGameCompletion is only written when a competitive game finishes
+  // without being demoted (veg/leave integrity break).
+  const setupPlayCounts = {};
+  for (const gameCompletion of roundInfo.gameCompletions) {
+    const setup = gameCompletion.game && gameCompletion.game.setup;
+    if (!setup) continue;
+    const setupId = setup.id || String(setup._id);
+    if (!setupId) continue;
+    setupPlayCounts[setupId] = (setupPlayCounts[setupId] || 0) + 1;
+  }
+  roundInfo.setupPlayCounts = setupPlayCounts;
 
   // Accumulate points by user ID
   for (const gameCompletion of roundInfo.gameCompletions) {

--- a/react_main/src/pages/Fame/Competitive.jsx
+++ b/react_main/src/pages/Fame/Competitive.jsx
@@ -283,7 +283,41 @@ function Overview({ roundInfo, seasonInfo }) {
                 <Typography variant="h3">Round {i + 1}</Typography>
                 {roundSetups.map((setupNumber) => {
                   const setup = seasonInfo.setups[setupNumber];
-                  return <Setup setup={setup} key={setup.id} />;
+                  // Only show play counts for the currently selected/viewed round
+                  const isViewedRound =
+                    roundInfo.round && i + 1 === roundInfo.round.number;
+                  const playCount = isViewedRound
+                    ? roundInfo.setupPlayCounts?.[setup.id] ?? 0
+                    : null;
+                  return (
+                    <Stack
+                      direction="row"
+                      spacing={1}
+                      key={setup.id}
+                      sx={{
+                        alignItems: "center",
+                        justifyContent: "center",
+                        width: "100%",
+                      }}
+                    >
+                      <Setup setup={setup} />
+                      {playCount !== null && (
+                        <Tooltip title="Completed games this round">
+                          <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            sx={{
+                              lineHeight: 1,
+                              whiteSpace: "nowrap",
+                              fontVariantNumeric: "tabular-nums",
+                            }}
+                          >
+                            {playCount}
+                          </Typography>
+                        </Tooltip>
+                      )}
+                    </Stack>
+                  );
                 })}
               </Stack>
             </Grid2>


### PR DESCRIPTION
﻿## Summary
- Adds a per-setup completed-game counter on the Competitive page for the currently selected/viewed round.
- Counts come from valid `CompetitiveGameCompletion` records (unique games only). Those are only written when a competitive game finishes without being demoted for veg/leave integrity breaks, so vegs, incomplete, broken, and refunded games are excluded.
- Closes #2944.

## Test plan
- [ ] Open Competitive page during an active round with completed games; confirm each setup for that round shows the correct completed-game count.
- [ ] Confirm setups in other rounds on the schedule do not show a count for the selected round.
- [ ] Switch to another historical round and confirm counts update for that round only.
- [ ] Confirm vegged / demoted competitive games do not increase the count.
