### PR TITLE
fix(nginx): allow large animated avatar/banner uploads

### DIFF
--- a/react_main/nginx.conf
+++ b/react_main/nginx.conf
@@ -23,6 +23,8 @@ map $http_upgrade $connection_upgrade {
 
 server {
 	server_name ultimafia.com;
+    # Animated avatars (25 MB) / banners (20 MB) / other uploads need more than nginx default 1m
+    client_max_body_size 30m;
     root /usr/share/nginx/html;
     index index.html index.htm index.nginx-debian.html;
 	


### PR DESCRIPTION
﻿## Summary
- Production nginx rejected animated user/family avatar (and large banner) uploads with 413 because `client_max_body_size` was unset (nginx default is **1m**).
- App limits allow up to **25 MB** for animated avatars and **20 MB** for banners; those work locally because the dev stack does not go through this nginx proxy.
- Set `client_max_body_size 30m` on the HTTPS server block in `react_main/nginx.conf`.

## Deploy note
After merge, reload/restart the nginx container so the mounted config is picked up.

## Test plan
- [ ] Deploy/reload nginx with this conf
- [ ] Upload an animated user avatar larger than 1 MB (under 25 MB) with Animated Profile Picture owned
- [ ] Upload an animated family avatar larger than 1 MB with the family perk
- [ ] Confirm static avatars under 1 MB still work
- [ ] Confirm banners up to 20 MB still work
