### PR TITLE
fix(profile): stop previous user media when navigating profiles

### DIFF
--- a/react_main/src/pages/User/Family.jsx
+++ b/react_main/src/pages/User/Family.jsx
@@ -58,9 +58,9 @@ export default function Family() {
   const errorAlert = useErrorAlert();
   const isPhoneDevice = useIsPhoneDevice();
 
-  function loadFamilyProfile() {
+  function loadFamilyProfile(signal) {
     axios
-      .get(`/api/family/${familyId}/profile`)
+      .get(`/api/family/${familyId}/profile`, signal ? { signal } : undefined)
       .then((res) => {
         setFamily(res.data);
         setBio(res.data.bio || "");
@@ -68,6 +68,13 @@ export default function Family() {
         document.title = `${res.data.name} | UltiMafia`;
       })
       .catch((e) => {
+        if (
+          e.code === "ERR_CANCELED" ||
+          e.name === "CanceledError" ||
+          e.name === "AbortError"
+        ) {
+          return;
+        }
         errorAlert(e);
         setFamilyLoaded(true);
       });
@@ -81,12 +88,16 @@ export default function Family() {
   useEffect(() => {
     if (familyId) {
       setFamilyLoaded(false);
-      loadFamilyProfile();
+      setFamily(null);
+      const controller = new AbortController();
+      loadFamilyProfile(controller.signal);
 
       // Check for pending invite
       if (user.loggedIn) {
         axios
-          .get(`/api/family/${familyId}/pendingInvite`)
+          .get(`/api/family/${familyId}/pendingInvite`, {
+            signal: controller.signal,
+          })
           .then((res) => {
             if (res.data.hasPendingInvite) {
               setPendingInvite(res.data.family);
@@ -96,6 +107,8 @@ export default function Family() {
             // Ignore errors
           });
       }
+
+      return () => controller.abort();
     }
   }, [familyId]);
 
@@ -515,6 +528,7 @@ export default function Family() {
             {family.hasMusicPlayer && family.mediaUrl && (
               <Paper sx={panelStyle}>
                 <MediaEmbed
+                  key={`${familyId}:${family.mediaUrl}`}
                   mediaUrl={family.mediaUrl}
                   autoplay={!!family.mediaAutoplay}
                   collapsible

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -323,6 +323,11 @@ export default function Profile() {
     setEditingPronouns(false);
     setUserFamily(null);
     setProfileFamily(null);
+    // Stop previous profile's player immediately; otherwise the iframe
+    // keeps playing user A's track on user B's page until the next fetch.
+    setMediaUrl("");
+    setAutoplay(false);
+    setCollapseMedia(false);
 
     if (userId) {
       setProfileLoaded(false);
@@ -330,8 +335,10 @@ export default function Profile() {
       setProfileTotalGames(0);
       setStockInfo(null);
 
+      const controller = new AbortController();
+
       axios
-        .get(`/api/user/${userId}/profile`)
+        .get(`/api/user/${userId}/profile`, { signal: controller.signal })
         .then((res) => {
           const resolvedId = res.data.id;
           setCanonicalUserId(resolvedId);
@@ -419,9 +426,18 @@ export default function Profile() {
           document.title = `${res.data.name}'s Profile | UltiMafia`;
         })
         .catch((e) => {
+          if (
+            e.code === "ERR_CANCELED" ||
+            e.name === "CanceledError" ||
+            e.name === "AbortError"
+          ) {
+            return;
+          }
           errorAlert(e);
           navigate("/play");
         });
+
+      return () => controller.abort();
     }
   }, [userId, profileRefetchKey]);
 
@@ -1678,6 +1694,7 @@ export default function Profile() {
             {mediaUrl && (
               <div className="box-panel" style={panelStyle}>
                 <MediaEmbed
+                  key={`${profileUserId}:${mediaUrl}`}
                   mediaUrl={mediaUrl}
                   autoplay={autoplay}
                   collapsible


### PR DESCRIPTION
﻿## Summary
- Profile stays mounted when navigating `/user/:id`, so user A's media player kept playing on user B's page.
- Clear media immediately on `userId` change so the embed unmounts.
- Abort in-flight profile fetches so a late response cannot restore the previous track.
- Remount `MediaEmbed` with a user+url key so iframes actually restart.
- Same remount/abort pattern on family pages.

## Test plan
- [ ] Open a profile with music/autoplay, then click another user with different music. Only the second user's media should play.
- [ ] Open a profile with music, then click a user with no media. Audio should stop.
- [ ] Rapidly click several profiles; the player should match the last opened profile, not an earlier one.
- [ ] Repeat for family pages that have a music player.
