### PR TITLE
fix(game): keep dead names red over animated name colors

### DIFF
--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -326,9 +326,18 @@
   -moz-background-clip: text !important;
   -webkit-text-fill-color: transparent !important;
 }
-.game .user-name.dead {
+.game .user-name.dead,
+.game .user-name.dead .user-name-text {
+  animation: none !important;
+  background-image: none !important;
+  -webkit-background-clip: unset !important;
+  background-clip: unset !important;
+  -webkit-text-fill-color: #bd4c4c !important;
   color: #bd4c4c !important;
   opacity: 1;
+  text-shadow: none !important;
+  filter: none !important;
+  transform: none !important;
 }
 
 .game .message .content a {

--- a/react_main/src/data/changelog.js
+++ b/react_main/src/data/changelog.js
@@ -36,6 +36,19 @@ export const CHANGELOG_CATEGORIES = [
 /** @type {ChangelogRelease[]} */
 export const CHANGELOG = [
   {
+    id: "2026-08-19-graveyard-dead-name-color",
+    date: "2026-08-19",
+    title: "Dead names stay red in the graveyard",
+    categories: {
+      bugfixes: [
+        "Graveyard names stay red when dead, even if you have an animated name color",
+      ],
+      game: [
+        "Animated name colors no longer show on dead names in the graveyard player list or graveyard chat",
+      ],
+    },
+  },
+  {
     id: "2026-08-19-custom-stickers",
     date: "2026-08-19",
     title: "Purchasable custom stickers",

--- a/react_main/src/data/changelog.js
+++ b/react_main/src/data/changelog.js
@@ -39,6 +39,7 @@ export const CHANGELOG = [
     id: "2026-08-19-graveyard-dead-name-color",
     date: "2026-08-19",
     title: "Dead names stay red in the graveyard",
+    prs: [2958],
     categories: {
       bugfixes: [
         "Graveyard names stay red when dead, even if you have an animated name color",

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -2478,9 +2478,7 @@ function Message(props) {
             )}
             {player && (
               <NameWithAvatar
-                dead={
-                  playerDead && props.stateViewing > 0 && !isGraveyardMessage
-                }
+                dead={playerDead && props.stateViewing > 0}
                 ripAvatar={isGraveyardMessage}
                 id={player.userId}
                 avatarId={avatarId}
@@ -3437,6 +3435,7 @@ export function PlayerRows({ players, className = "", renderMarker, renderRowEnd
           avatarId={avatarId}
           name={player.name}
           avatar={player.avatar}
+          dead={className === "dead"}
           color={resolveDisplayNameColor({
             accessibleNameColors,
             ignoreTextColor: user.settings?.ignoreTextColor,

--- a/react_main/src/pages/User/User.jsx
+++ b/react_main/src/pages/User/User.jsx
@@ -625,17 +625,19 @@ export function NameWithAvatar(props) {
   const autoColor = user.autoContrastColor(color);
   const nameFontClass =
     nameFont && nameFont !== "default" ? `name-font-${nameFont}` : "";
+  // Dead names stay red; skip cosmetics that would override .user-name.dead
   const nameAnimClass =
-    animatedNameColor && animatedNameColor !== "none"
+    !dead && animatedNameColor && animatedNameColor !== "none"
       ? `name-anim-${animatedNameColor}`
       : "";
   // Rainbow/patriotic/gradient/tricolor use background-clip
   const usesClipText =
-    animatedNameColor === "rainbow" ||
-    animatedNameColor === "patriotic" ||
-    animatedNameColor === "gradient" ||
-    animatedNameColor === "tricolor";
-  const useSolidNameColor = autoColor && !usesClipText;
+    !dead &&
+    (animatedNameColor === "rainbow" ||
+      animatedNameColor === "patriotic" ||
+      animatedNameColor === "gradient" ||
+      animatedNameColor === "tricolor");
+  const useSolidNameColor = !dead && autoColor && !usesClipText;
   const nameStyle = {
     ...(useSolidNameColor ? { color: autoColor } : {}),
     display: "inline",
@@ -713,7 +715,7 @@ export function NameWithAvatar(props) {
           style={nameStyle}
         >
           <Stack direction="row" spacing={0.5} alignItems="center">
-            {nameColorSwatch && (
+            {nameColorSwatch && !dead && (
               <span
                 className={`name-color-swatch ${
                   small ? "name-color-swatch-small" : "name-color-swatch-regular"


### PR DESCRIPTION
## Summary

Fixes https://github.com/UltiMafia/Ultimafia/issues/2956

Dead names should stay red. Animated name colors paint with `background-clip` and `color: transparent`, so they overrode `.user-name.dead`.

- Skip name-color animations and custom name color when a player is dead
- Mark graveyard / underworld player-list rows as dead (same red name as dead chat)
- Apply dead styling to graveyard chat nameplates (tombstone avatar is unchanged)
- CSS fallback so dead name text stays `#bd4c4c` even if an animation class is present

## Test plan

- In a game, die with an animated name color (rainbow / gradient / pulse / glow). The Graveyard player-list name should be red, not animated.
- Check graveyard chat: your name should be red; living players should still show their name cosmetics.
- Check a death in day chat: dead names stay red.
- Alive players with animated name colors should be unchanged.
