### PR TITLE
fix(site): refund competitive games without wiping gold hearts

### DIFF
--- a/react_main/src/data/changelog.js
+++ b/react_main/src/data/changelog.js
@@ -36,6 +36,19 @@ export const CHANGELOG_CATEGORIES = [
 /** @type {ChangelogRelease[]} */
 export const CHANGELOG = [
   {
+    id: "2026-08-19-comp-refund-gold-hearts",
+    date: "2026-08-19",
+    title: "Competitive refunds keep remaining gold hearts",
+    categories: {
+      bugfixes: [
+        "Refunding a competitive game returns the spent gold heart instead of setting gold hearts to 0",
+      ],
+      community: [
+        "Mod Refund Game no longer wipes a player's leftover gold hearts for that competitive round",
+      ],
+    },
+  },
+  {
     id: "2026-08-19-custom-stickers",
     date: "2026-08-19",
     title: "Purchasable custom stickers",

--- a/react_main/src/data/changelog.js
+++ b/react_main/src/data/changelog.js
@@ -39,6 +39,7 @@ export const CHANGELOG = [
     id: "2026-08-19-comp-refund-gold-hearts",
     date: "2026-08-19",
     title: "Competitive refunds keep remaining gold hearts",
+    prs: [2959],
     categories: {
       bugfixes: [
         "Refunding a competitive game returns the spent gold heart instead of setting gold hearts to 0",

--- a/routes/mod.js
+++ b/routes/mod.js
@@ -2230,6 +2230,7 @@ router.post("/refundGame", async (req, res) => {
     let skippedCount = 0;
     let lastPlayerCount = 0;
     let heartLabel = "red";
+    const goldHeartsRefundedUsers = new Set();
 
     for (const game of games) {
       if (!game.endTime) {
@@ -2444,8 +2445,10 @@ router.post("/refundGame", async (req, res) => {
             updateOps.$set.redHearts = redHeartCapacity;
           }
 
-          if (game.competitive) {
-            updateOps.$set.goldHearts = constants.initialGoldHeartCapacity;
+          // Restore the 1 gold heart charged at start, without wiping leftovers.
+          if (game.competitive && !goldHeartsRefundedUsers.has(userIdToRefund)) {
+            incOps.goldHearts = 1;
+            goldHeartsRefundedUsers.add(userIdToRefund);
           }
 
           // Revert fortune/misfortune points


### PR DESCRIPTION
## Summary

Fixes https://github.com/UltiMafia/Ultimafia/issues/2949

Refund Game set every competitive player's `goldHearts` to `initialGoldHeartCapacity` (0). That wiped leftover daily gold hearts instead of returning the 1 heart charged at game start.

- Restore 1 gold heart with `$inc` (same as start-of-game charge / veg refund)
- Only once per user if duplicate game documents share the same id
- Ranked red-heart refund behavior is unchanged

## Test plan

- Start a competitive game with a player who has more than 1 gold heart, complete it, then refund the game. Gold hearts should go up by 1, not drop to 0.
- Ranked refund should still restore red hearts to capacity as before.
- Refunding an unranked/non-competitive game should still be skipped.
