### PR TITLE
fix(game): Anarchist timebomb kills and reveals after inventory drop

### DIFF
--- a/Games/types/Mafia/items/Timebomb.js
+++ b/Games/types/Mafia/items/Timebomb.js
@@ -32,16 +32,15 @@ module.exports = class Timebomb extends Item {
           }
 
           this.clearTimers();
+          // drop() nulls this.holder (inventory fix #2885); keep the victim.
+          const holder = this.holder;
           this.drop();
-          if (!this.holder.alive) {
+          if (!holder || !holder.alive) {
             return;
           }
 
-          // reveal role of anarchist
-          if (
-            this.holder == this.killer &&
-            this.holder.role.name == "Anarchist"
-          ) {
+          // Exploding on the Anarchist reveals them. No kill, no point, no win.
+          if (holder == this.killer && holder.role.name == "Anarchist") {
             let action = new Action({
               actor: this.killer,
               item: this,
@@ -63,8 +62,8 @@ module.exports = class Timebomb extends Item {
 
           let action = new Action({
             actor: this.killer,
-            target: this.holder,
-            game: this.holder.game,
+            target: holder,
+            game: holder.game,
             labels: ["kill", "bomb"],
             run: function () {
               if (this.dominates()) this.target.kill("bomb", this.actor, true);
@@ -76,7 +75,7 @@ module.exports = class Timebomb extends Item {
 
         let toDetonateSound = toDetonate - 1800;
         this.soundTimer = setTimeout(() => {
-          if (!this.holder.alive) {
+          if (!this.holder || !this.holder.alive) {
             return;
           }
           this.game.broadcast("explosion");
@@ -146,7 +145,7 @@ module.exports = class Timebomb extends Item {
     }
 
     this.tickInterval = setInterval(() => {
-      if (this.game.finished || !this.holder?.alive) {
+      if (this.game.finished || !this.holder || !this.holder.alive) {
         this.stopBombTick();
         return;
       }

--- a/Games/types/Mafia/roles/cards/TimebombGiver.js
+++ b/Games/types/Mafia/roles/cards/TimebombGiver.js
@@ -14,6 +14,9 @@ module.exports = class TimebombGiver extends Card {
           labels: ["giveItem", "bomb"],
           priority: PRIORITY_ITEM_GIVER_DEFAULT,
           run: function () {
+            if (!this.target || !this.target.holdItem) {
+              return;
+            }
             this.target.holdItem("Timebomb", this.actor);
             this.target.queueGetItemAlert("Timebomb");
           },

--- a/react_main/src/data/changelog.js
+++ b/react_main/src/data/changelog.js
@@ -36,6 +36,19 @@ export const CHANGELOG_CATEGORIES = [
 /** @type {ChangelogRelease[]} */
 export const CHANGELOG = [
   {
+    id: "2026-08-22-anarchist-timebomb",
+    date: "2026-08-22",
+    title: "Anarchist timebomb kills and reveals again",
+    categories: {
+      bugfixes: [
+        "Anarchist Timebombs explode on the holder again: they kill other players, and reveal the Anarchist if it blows up on them",
+      ],
+      game: [
+        "A Timebomb exploding on the Anarchist does not kill them, does not award a point, and does not win the game",
+      ],
+    },
+  },
+  {
     id: "2026-08-19-graveyard-dead-name-color",
     date: "2026-08-19",
     title: "Dead names stay red in the graveyard",

--- a/react_main/src/data/changelog.js
+++ b/react_main/src/data/changelog.js
@@ -39,6 +39,7 @@ export const CHANGELOG = [
     id: "2026-08-22-anarchist-timebomb",
     date: "2026-08-22",
     title: "Anarchist timebomb kills and reveals again",
+    prs: [2973],
     categories: {
       bugfixes: [
         "Anarchist Timebombs explode on the holder again: they kill other players, and reveal the Anarchist if it blows up on them",


### PR DESCRIPTION
## Summary

Fixes https://github.com/UltiMafia/Ultimafia/issues/2967

Anarchist Timebombs stopped doing their job after the inventory fix in #2885. `Item.drop()` now sets `this.holder = null`, and the bomb timer still did:

```js
this.drop();
if (!this.holder.alive) return;
```

That throws, so the explosion never ran.

### What was broken

- Timebomb on another player: no kill
- Timebomb on the Anarchist: no reveal
- Night "no one" should not plant a bomb or win the game

### Intended role (from #2967)

- Kill someone with the bomb: Anarchist gets a point
- Bomb explodes on the Anarchist: reveal only. No kill, no point, no win
- Win from last two (alive) or enough bomb-kills on **other** players, not from bombing yourself

### What changed

- Keep a local `holder` before `drop()`, then kill that player
- If the holder is the Anarchist: reveal, do not kill, do not score, do not win
- Night "no one" / invalid target: do not plant a bomb

## Test plan

- Give a Timebomb to another player and let it explode: they die, Anarchist gets a point
- Let it explode on the Anarchist: they are revealed, they live, no point, no win from that
- Night vote "no one": no bomb, no win
- Anarchist still wins in the final two, or at the bomb-kill threshold on other players
