### PR TITLE
fix(game): Meteor stalemate wipe, burden flip, and crash fixes

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -317,13 +317,13 @@ module.exports = class Game {
       delete this.obituaryQueue[playerId];
 
       const player = this.getPlayer(playerId);
+      if (!player || player.alive) {
+        continue;
+      }
 
       obituary.id = player.id;
       obituary.playerInfo = player.getPlayerInfo();
-
-      if (!player.alive) {
-        obituaries.push(obituary);
-      }
+      obituaries.push(obituary);
     }
 
     const obituariesMessage = {

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -10,6 +10,10 @@ const stateEventMessages = require("./templates/stateEvents");
 const roleData = require("../../../data/roles");
 const rolePriority = require("./const/RolePriority");
 const modifierData = require("../../../data/modifiers");
+const {
+  MAFIA_FACTIONS,
+  CULT_FACTIONS,
+} = require("./const/FactionList");
 
 module.exports = class MafiaGame extends Game {
   constructor(options) {
@@ -514,6 +518,16 @@ module.exports = class MafiaGame extends Game {
     return stateName === "Night" || stateName === "Dawn";
   }
 
+  hasLivingNightKillers() {
+    return this.alivePlayers().some((p) => {
+      if (!p.role) return false;
+      if (this.getRoleAlignment(p.role.name) === "Independent") return false;
+      return (
+        MAFIA_FACTIONS.includes(p.faction) || CULT_FACTIONS.includes(p.faction)
+      );
+    });
+  }
+
   inactivityCheck() {
     var stateName = this.getStateName();
 
@@ -525,14 +539,14 @@ module.exports = class MafiaGame extends Game {
           this.queueAlert("No one has died for a while, you must act.");
         }
       }
-      if (this.statesSinceLastDeath >= this.noDeathLimit - 1) {
-        const warnOnDay =
-          this.getGameSetting("Day Start") && stateName == "Day";
-        const warnOnNight =
-          !this.getGameSetting("Day Start") && stateName == "Night";
-
-        if (warnOnDay || warnOnNight) {
-          this.meteorWarningPhase = warnOnDay ? "Day" : "Night";
+      if (
+        this.statesSinceLastDeath >= this.noDeathLimit - 1 &&
+        !this.meteorWarningPhase
+      ) {
+        // Night killers get a night to NK. If none are alive, Village gets a day to condemn.
+        const actingPhase = this.hasLivingNightKillers() ? "Night" : "Day";
+        if (stateName === actingPhase) {
+          this.meteorWarningPhase = actingPhase;
           let event = this.createGameEvent(this.GameEndEvent);
           event.doEvent();
           event = null;
@@ -605,6 +619,12 @@ module.exports = class MafiaGame extends Game {
     var winQueue = new Queue();
     var winners = new Winners(this);
     var aliveCount = this.alivePlayers().length;
+
+    if (this.MeteorLanded == true) {
+      winners.addGroup("No one");
+      winners.determinePlayers();
+      return [true, winners];
+    }
 
     for (let player of this.players) {
       let alignment = player.role.winCount || player.role.alignment;

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -102,6 +102,7 @@ module.exports = class MafiaGame extends Game {
     this.statesSinceLastDeath = 0;
     this.resetLastDeath = false;
     this.meteorWarningPhase = null;
+    this.lastStalemateDeathKind = null;
     this.extensions = 0;
     this.extensionVotes = 0;
     this.hasBeenDay = false;
@@ -502,20 +503,19 @@ module.exports = class MafiaGame extends Game {
   }
 
   isMustCondemn() {
-    var mustCondemn = super.isMustCondemn();
-    mustCondemn |=
-      this.statesSinceLastDeath >= this.noDeathLimit &&
-      this.getStateName() != "Dusk" &&
-      this.getStateName() != "Dawn" &&
-      this.ForceMustAct == true;
-    return mustCondemn;
+    // Town is not forced to lynch on stalemate; meteor is the penalty.
+    return super.isMustCondemn();
   }
 
   shouldCountDeathForStalemate(killType) {
-    if (killType === "condemn") return true;
-
+    const isCondemn = killType === "condemn";
     const stateName = this.getStateName();
-    return stateName === "Night" || stateName === "Dawn";
+    const counts =
+      isCondemn || stateName === "Night" || stateName === "Dawn";
+    if (counts) {
+      this.lastStalemateDeathKind = isCondemn ? "condemn" : "night";
+    }
+    return counts;
   }
 
   hasLivingNightKillers() {
@@ -526,6 +526,22 @@ module.exports = class MafiaGame extends Game {
         MAFIA_FACTIONS.includes(p.faction) || CULT_FACTIONS.includes(p.faction)
       );
     });
+  }
+
+  getMeteorActingPhase() {
+    if (this.lastStalemateDeathKind === "night") {
+      return "Day";
+    }
+    if (this.lastStalemateDeathKind === "condemn") {
+      return this.hasLivingNightKillers() ? "Night" : "Day";
+    }
+    if (
+      this.getGameSetting("Must Condemn") &&
+      this.getGameSetting("Day Start")
+    ) {
+      return "Day";
+    }
+    return this.hasLivingNightKillers() ? "Night" : "Day";
   }
 
   inactivityCheck() {
@@ -543,8 +559,7 @@ module.exports = class MafiaGame extends Game {
         this.statesSinceLastDeath >= this.noDeathLimit - 1 &&
         !this.meteorWarningPhase
       ) {
-        // Night killers get a night to NK. If none are alive, Village gets a day to condemn.
-        const actingPhase = this.hasLivingNightKillers() ? "Night" : "Day";
+        const actingPhase = this.getMeteorActingPhase();
         if (stateName === actingPhase) {
           this.meteorWarningPhase = actingPhase;
           let event = this.createGameEvent(this.GameEndEvent);

--- a/Games/types/Mafia/effects/Meteor.js
+++ b/Games/types/Mafia/effects/Meteor.js
@@ -34,8 +34,11 @@ module.exports = class Meteor extends Effect {
         this.game.MeteorLanded = true;
         this.game.queueAlert("A giant meteor obliterates the town!");
 
+        // Non-instant: instant kill calls checkAllMeetingsReady -> gotoNextState
+        // mid-loop, which can end the game before remaining players are killed
+        // and drop their obituaries (bots look like they never died).
         for (let player of [...this.game.alivePlayers()]) {
-          player.kill("basic", null, true);
+          player.kill("basic", null, false);
         }
 
         var [, winners] = this.game.checkWinConditions();

--- a/Games/types/Mafia/effects/Meteor.js
+++ b/Games/types/Mafia/effects/Meteor.js
@@ -7,6 +7,10 @@ module.exports = class Meteor extends Effect {
 
     this.listeners = {
       death: function (player, killer, deathType, instant) {
+        if (this.game.MeteorLanded) {
+          return;
+        }
+
         const warningPhase = this.game.meteorWarningPhase || "Day";
 
         if (warningPhase === "Day" && deathType !== "condemn") {
@@ -24,17 +28,20 @@ module.exports = class Meteor extends Effect {
         }
 
         this.game.queueAlert("A giant meteor obliterates the town!");
+        this.game.MeteorLanded = true;
 
         for (let player of [...this.game.alivePlayers()]) {
           player.kill("basic", null, true);
         }
-        this.game.MeteorLanded = true;
-        this.remove();
 
-        var [finished, winners] = this.game.checkWinConditions();
-        if (!finished || winners.groupAmt() <= 0) {
-          winners.addGroup("No one");
+        var [, winners] = this.game.checkWinConditions();
+        for (let group of Object.keys(winners.groups)) {
+          if (group !== "No one") {
+            winners.removeGroup(group);
+          }
         }
+        winners.addGroup("No one");
+        this.remove();
         this.game.endGame(winners);
       },
       handleWinBlockers: function (winners) {

--- a/Games/types/Mafia/effects/Meteor.js
+++ b/Games/types/Mafia/effects/Meteor.js
@@ -20,6 +20,10 @@ module.exports = class Meteor extends Effect {
         this.remove();
       },
       afterActions: function () {
+        if (this.game.MeteorLanded) {
+          return;
+        }
+
         const stateName = this.game.getStateName();
         const warningPhase = this.game.meteorWarningPhase || "Day";
 
@@ -27,8 +31,8 @@ module.exports = class Meteor extends Effect {
           return;
         }
 
-        this.game.queueAlert("A giant meteor obliterates the town!");
         this.game.MeteorLanded = true;
+        this.game.queueAlert("A giant meteor obliterates the town!");
 
         for (let player of [...this.game.alivePlayers()]) {
           player.kill("basic", null, true);

--- a/Games/types/Mafia/events/Meteor.js
+++ b/Games/types/Mafia/events/Meteor.js
@@ -27,7 +27,11 @@ module.exports = class Meteor extends Event {
     if (this.game.MeteorLanded) {
       return;
     }
-    if (this.game.players.some((p) => p.hasEffect && p.hasEffect("Meteor"))) {
+    if (
+      this.game.players.filter(
+        (p) => p && p.hasEffect && p.hasEffect("Meteor")
+      ).length > 0
+    ) {
       return;
     }
 

--- a/Games/types/Mafia/events/Meteor.js
+++ b/Games/types/Mafia/events/Meteor.js
@@ -1,7 +1,5 @@
 const Event = require("../Event");
-const Action = require("../Action");
 const Random = require("../../../../lib/Random");
-const { PRIORITY_EFFECT_GIVER_DEFAULT } = require("../const/Priority");
 
 module.exports = class Meteor extends Event {
   constructor(modifiers, game) {
@@ -27,6 +25,9 @@ module.exports = class Meteor extends Event {
   doEvent() {
     super.doEvent();
     let victim = Random.randArrayVal(this.game.alivePlayers());
+    if (!victim) {
+      return;
+    }
 
     if (!this.game.meteorWarningPhase) {
       this.game.meteorWarningPhase = "Day";
@@ -34,20 +35,12 @@ module.exports = class Meteor extends Event {
 
     const alertMessage = this.getStalemateWarningMessage();
 
-    this.action = new Action({
-      actor: victim,
-      target: victim,
-      game: this.game,
-      priority: PRIORITY_EFFECT_GIVER_DEFAULT,
-      labels: ["hidden", "absolute"],
-      run: function () {
-        if (this.game.SilentEvents != false) {
-          this.game.queueAlert(alertMessage);
-        }
+    if (this.game.SilentEvents != false) {
+      this.game.queueAlert(alertMessage);
+    }
 
-        this.actor.giveEffect("Meteor", Infinity);
-      },
-    });
-    this.game.instantAction(this.action);
+    // Give the effect directly. instantAction would checkGameEnd and can
+    // award Village before the meteor is allowed to land.
+    victim.giveEffect("Meteor", Infinity);
   }
 };

--- a/Games/types/Mafia/events/Meteor.js
+++ b/Games/types/Mafia/events/Meteor.js
@@ -24,6 +24,13 @@ module.exports = class Meteor extends Event {
 
   doEvent() {
     super.doEvent();
+    if (this.game.MeteorLanded) {
+      return;
+    }
+    if (this.game.players.some((p) => p.hasEffect && p.hasEffect("Meteor"))) {
+      return;
+    }
+
     let victim = Random.randArrayVal(this.game.alivePlayers());
     if (!victim) {
       return;

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -288,7 +288,7 @@ var schemas = {
       gameStartPrompt: { type: String, default: undefined },
       EventsPerNight: Number,
       noDeathLimit: Number,
-      ForceMustAct: Boolean,
+      ForceMustAct: { type: Boolean, default: true },
       GameEndEvent: { type: String, default: "Meteor" },
       swapAmt: Number,
       roundAmt: Number,

--- a/react_main/src/data/changelog.js
+++ b/react_main/src/data/changelog.js
@@ -36,6 +36,20 @@ export const CHANGELOG_CATEGORIES = [
 /** @type {ChangelogRelease[]} */
 export const CHANGELOG = [
   {
+    id: "2026-08-22-meteor-no-one",
+    date: "2026-08-22",
+    title: "Meteor wipe is a draw, and the acting side gets a turn",
+    categories: {
+      bugfixes: [
+        "When a meteor lands, nobody wins (Village can no longer take the game after a total wipe)",
+        "Meteor warns on Night if Mafia/Cult can still kill, otherwise on Day so Village can condemn",
+      ],
+      game: [
+        "Stalemate Force Must Act and Meteor are the defaults for new Mafia setups",
+      ],
+    },
+  },
+  {
     id: "2026-08-19-graveyard-dead-name-color",
     date: "2026-08-19",
     title: "Dead names stay red in the graveyard",

--- a/react_main/src/data/changelog.js
+++ b/react_main/src/data/changelog.js
@@ -36,13 +36,14 @@ export const CHANGELOG_CATEGORIES = [
 /** @type {ChangelogRelease[]} */
 export const CHANGELOG = [
   {
-    id: "2026-08-22-meteor-no-one",
-    date: "2026-08-22",
-    title: "Meteor wipe is a draw, and the acting side gets a turn",
+    id: "2026-08-23-meteor-stalemate",
+    date: "2026-08-23",
+    title: "Meteor stalemate: nobody wins, burden flips after a kill",
     categories: {
       bugfixes: [
-        "When a meteor lands, nobody wins (Village can no longer take the game after a total wipe)",
+        "When a meteor lands, nobody wins and every living player dies (including bots, listed in the newspaper)",
         "After Mafia kills, meteor resets; if Town then no-lynches, meteor warns on Day. After a lynch, it warns on Night if Mafia/Cult can still kill",
+        "The obliterate alert only posts once",
       ],
       game: [
         "Stalemate Force Must Act and Meteor are the defaults for new Mafia setups",

--- a/react_main/src/data/changelog.js
+++ b/react_main/src/data/changelog.js
@@ -42,7 +42,7 @@ export const CHANGELOG = [
     categories: {
       bugfixes: [
         "When a meteor lands, nobody wins (Village can no longer take the game after a total wipe)",
-        "Meteor warns on Night if Mafia/Cult can still kill, otherwise on Day so Village can condemn",
+        "After Mafia kills, meteor resets; if Town then no-lynches, meteor warns on Day. After a lynch, it warns on Night if Mafia/Cult can still kill",
       ],
       game: [
         "Stalemate Force Must Act and Meteor are the defaults for new Mafia setups",

--- a/react_main/src/data/changelog.js
+++ b/react_main/src/data/changelog.js
@@ -39,6 +39,7 @@ export const CHANGELOG = [
     id: "2026-08-23-meteor-stalemate",
     date: "2026-08-23",
     title: "Meteor stalemate: nobody wins, burden flips after a kill",
+    prs: [2974],
     categories: {
       bugfixes: [
         "When a meteor lands, nobody wins and every living player dies (including bots, listed in the newspaper)",

--- a/react_main/src/pages/Play/CreateSetup/CreateMafiaSetup.jsx
+++ b/react_main/src/pages/Play/CreateSetup/CreateMafiaSetup.jsx
@@ -126,6 +126,7 @@ export default function CreateMafiaSetup() {
       label: "Game End Event",
       ref: "GameEndEvent",
       type: "select",
+      value: "Meteor",
       groupName: "Stalemate Prevention",
       options: [
         {

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -1007,7 +1007,10 @@ router.post("/create", async function (req, res) {
     //setup.PublicShare = Boolean(setup.PublicShare);
     setup.EventsPerNight = Number(setup.EventsPerNight || 0);
     setup.noDeathLimit = Number(setup.noDeathLimit || 6);
-    setup.ForceMustAct = Boolean(setup.ForceMustAct);
+    setup.ForceMustAct =
+      setup.ForceMustAct === undefined || setup.ForceMustAct === null
+        ? true
+        : Boolean(setup.ForceMustAct);
     setup.GameEndEvent = String(setup.GameEndEvent || "Meteor");
     //setup.AllExcessRoles = Boolean(setup.AllExcessRoles);
     //setup.HostileVsMafia = Boolean(setup.HostileVsMafia);

--- a/scripts/enableMeteorOnMafiaSetups.js
+++ b/scripts/enableMeteorOnMafiaSetups.js
@@ -1,0 +1,43 @@
+const path = require("path");
+require("dotenv").config({ path: path.join(__dirname, "../.env") });
+const db = require("../db/db");
+const models = require("../db/models");
+
+async function main() {
+  await db.promise;
+  console.log("Connected to database.");
+
+  const mustAct = await models.Setup.updateMany(
+    {
+      gameType: "Mafia",
+      $or: [{ ForceMustAct: { $exists: false } }, { ForceMustAct: false }],
+    },
+    { $set: { ForceMustAct: true } }
+  );
+
+  const meteor = await models.Setup.updateMany(
+    {
+      gameType: "Mafia",
+      $or: [
+        { GameEndEvent: { $exists: false } },
+        { GameEndEvent: null },
+        { GameEndEvent: "" },
+      ],
+    },
+    { $set: { GameEndEvent: "Meteor" } }
+  );
+
+  console.log(
+    `ForceMustAct enabled on ${mustAct.modifiedCount || mustAct.nModified || 0} mafia setups.`
+  );
+  console.log(
+    `GameEndEvent set to Meteor on ${meteor.modifiedCount || meteor.nModified || 0} mafia setups.`
+  );
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Error enabling meteor on mafia setups:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Fixes https://github.com/UltiMafia/Ultimafia/issues/2957

Stalemate meteor was scoring Village after a wipe, warning the wrong side after a kill, stacking four obliterate alerts, crashing Night 3, and dropping bot obituaries. This PR is **meteor-only**. Anarchist Timebomb work stays in https://github.com/UltiMafia/Ultimafia/pull/2973 (independent; neither PR needs the other).

### How meteor is supposed to work

- First stall: Night / Mafia (even on Day Start), unless the setup is **Must Condemn** (then Day / Town).
- Mafia NK: warning gone, stall clock reset. Next stall is **Day / Town**. Meteor does not have to have been on Mafia first; a normal NK is enough.
- Town no-lynches long enough: warn on **Day**. They can still vote no one; if they do, everyone loses.
- Town lynches: reset. Next stall is **Night** if Mafia/Cult can still kill.
- If meteor actually lands: **No one** wins, every living player dies (including bots), one obliterate alert.

### Fixes

1. **Wipe is No one** (`checkWinConditions` short-circuits on `MeteorLanded`). Village can no longer take the game after a total wipe (`91dSJ69RN`).
2. **Burden flips after a kill.** After a night kill, the next stall warns on Day. After a condemn, it warns on Night if Mafia/Cult can still kill (`i_Z8GxbT9`).
3. **One obliterate alert.** Empty event pools were stacking a Meteor effect every night plus the stalemate copy (`PwaoFrY4d`).
4. **Night 3 no longer locks up.** `game.players` is an ArrayHash and has no `.some`; that throw skipped Night meetings and the timer (`NTH9WQZJm`).
5. **Everyone dies, including bots.** Instant meteor kills were recursing into `gotoNextState` mid-loop, so the game could end after the first death and drop obituaries (`e9dupICgd`).
6. **Defaults for #2957.** New Mafia setups get Force Must Act + Meteor. `scripts/enableMeteorOnMafiaSetups.js` enables those on old Mafia setups that were missing them.

Town is not locked into a lynch when meteor is on Day; they can still vote no one, and that is the throw.

## Test plan

- 4p with Mafia, stall with no deaths: meteor warns on **Night**. Mafia NL → wipe, **No one**, one obliterate line, all names (bots too) in the newspaper.
- Same setup, Mafia NK once, then Town NL until stall: meteor warns on **Day** (`nobody is condemned today`), not Night again. Day NL → everyone loses.
- Town lynch after that, then stall: meteor back on **Night** if Mafia is alive.
- Anarchist / no Mafia: first stall is **Day**.
- Day Start + Must Condemn: first stall is **Day**.
- Night 3 with Mafia still in the game: timer and NK meeting still appear.
