### PR TITLE
fix(game): clear chat input after sending in anonymous meetings

### DIFF
--- a/react_main/src/data/changelog.js
+++ b/react_main/src/data/changelog.js
@@ -36,6 +36,17 @@ export const CHANGELOG_CATEGORIES = [
 /** @type {ChangelogRelease[]} */
 export const CHANGELOG = [
   {
+    id: "2026-08-23-chef-chat-clear",
+    date: "2026-08-23",
+    title: "Chef chat box clears after sending",
+    prs: [2975],
+    categories: {
+      bugfixes: [
+        "Sending a message in Chef banquet chat, and other anonymous meetings, now clears the chat box",
+      ],
+    },
+  },
+  {
     id: "2026-08-19-graveyard-dead-name-color",
     date: "2026-08-19",
     title: "Dead names stay red in the graveyard",

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -2983,7 +2983,8 @@ function SpeechInput(props) {
         } else {
           pendingSpeechRef.current = {
             content: speechInput,
-            anonymous: Boolean(abilityName),
+            anonymous:
+              Boolean(abilityName) || Boolean(meetings[selTab]?.anonymous),
           };
         }
 


### PR DESCRIPTION
Closes #2972

## Bug

Sending in Chef banquet chat left the typed text in the box. Enter sent the line, but the input did not clear.

Village chat was fine. Banquet is an anonymous speech meeting: the echo comes back as `senderId: "anonymous"`. The box only clears after that echo matches. The matcher treated a send as anonymous only when a speech ability was selected (Telepathic, Contact, Cry), so normal **Say** in Banquet never matched.

## Fix

When recording the pending send, treat the meeting as anonymous if either:

- a speech ability is in use, or
- the selected meeting has `anonymous` (Chef banquet, and other anonymous meetings)

Same last-message echo wait as before, so rejected spam still keeps the text.

## Tested

Local: Chef banquet, type, Enter. Message sends and the box clears. Village chat unchanged.

## Notes

Frontend only (`Game.jsx`). Independent of meteor (#2974) and Anarchist (#2973).
