### PR TITLE
fix(game): clarify Caroler cannot repeat visits unless roleblocked

### DIFF
--- a/data/roles.js
+++ b/data/roles.js
@@ -1311,7 +1311,7 @@ const roleData = {
       ],
       description: [
         "Each night, you can choose to visit one player and if they didn't visit anybody, have them learn 3 players, at least one of whom is Evil.",
-        "You cannot choose to visit the same player consecutively.",
+        "You cannot choose to visit the same player consecutively (unless roleblocked).",
       ],
       nightOrder: [
         ["Sing Carol", PRIORITY_INVESTIGATIVE_AFTER_RESOLVE_DEFAULT - 10],

--- a/react_main/src/data/changelog.js
+++ b/react_main/src/data/changelog.js
@@ -36,6 +36,17 @@ export const CHANGELOG_CATEGORIES = [
 /** @type {ChangelogRelease[]} */
 export const CHANGELOG = [
   {
+    id: "2026-08-23-caroler-description",
+    date: "2026-08-23",
+    title: "Caroler visit restriction clarified",
+    prs: [2976],
+    categories: {
+      game: [
+        "Caroler description now notes you cannot visit the same player two nights in a row unless roleblocked",
+      ],
+    },
+  },
+  {
     id: "2026-08-19-graveyard-dead-name-color",
     date: "2026-08-19",
     title: "Dead names stay red in the graveyard",


### PR DESCRIPTION
Closes #2966

## Change

Caroler role sheet now says:

> You cannot choose to visit the same player consecutively (unless roleblocked).

Previously it omitted the roleblock exception.

## Notes

Copy only (`data/roles.js`). No mechanic change. Comedian still has the old consecutive-visit line; this issue is Caroler only.
