### PR TITLE
fix(site): play animated avatars on mobile and in % chat

### DIFF
--- a/react_main/src/components/Basic.jsx
+++ b/react_main/src/components/Basic.jsx
@@ -9,7 +9,7 @@ import { Slang } from "./Slang";
 import { Typography } from "@mui/material";
 import { SiteInfoContext } from "../Contexts";
 import { InlineRoleMention } from "./Roles";
-import { useAvatarImageUrl } from "utils/avatarUrl";
+import { useAvatarImageUrl, AvatarPhoto } from "utils/avatarUrl";
 
 export function ItemList(props) {
   const itemRows = props.items.map(props.map);
@@ -359,8 +359,9 @@ export function iconUsername(text, players) {
 
             words[j] = (
               <InlineAvatar
-              userId={matchedPlayer.userId}
-              username={matchedPlayer.name}
+                key={matchedPlayer.userId || matchedPlayer.name}
+                userId={matchedPlayer.userId}
+                username={matchedPlayer.name}
               />
             );
           } else {
@@ -390,15 +391,20 @@ export function iconUsername(text, players) {
 
 function InlineAvatar(props) {
   const siteInfo = useContext(SiteInfoContext);
-  const frozenSrc = useAvatarImageUrl(props.userId, {
+  const photoSrc = useAvatarImageUrl(props.userId, {
     cacheVal: siteInfo?.cacheVal,
   });
-  let style = {};
-  if (props.userId && frozenSrc) {
-    style.backgroundImage = `url(${frozenSrc})`;
+  let style = {
+    position: "relative",
+  };
+  let src = photoSrc;
+  if (props.userId && photoSrc) {
+    style.backgroundImage = "none";
   } else if (props.url) {
+    src = null;
     style.backgroundImage = props.url;
   } else {
+    src = null;
     // Same as the list in react_main/src/pages/User/User.jsx
     const colors = [
       "#fff59d",
@@ -430,6 +436,7 @@ function InlineAvatar(props) {
       title={props.username}
       style={style}
     >
+      <AvatarPhoto src={src} />
       &#8203;
     </div>
   );

--- a/react_main/src/css/user.css
+++ b/react_main/src/css/user.css
@@ -4,6 +4,7 @@
 
 .avatar {
   flex-shrink: 0;
+  position: relative;
 
   box-sizing: border-box;
 
@@ -13,6 +14,16 @@
   background-image: url("/src/images/avatar.webp");
   background-size: 100%;
   background-color: var(--scheme-color);
+}
+
+img.avatar-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+  pointer-events: none;
 }
 
 /*SANTA CHANGES: In December, uncomment the below lines*/

--- a/react_main/src/pages/User/User.jsx
+++ b/react_main/src/pages/User/User.jsx
@@ -31,7 +31,7 @@ import { useIsPhoneDevice } from "hooks/useIsPhoneDevice";
 import ImageViewer from "components/ImageViewer";
 import Miniprofile from "components/Miniprofile";
 import { usePopoverOpen } from "hooks/usePopoverOpen";
-import { useAvatarImageUrl } from "utils/avatarUrl";
+import { useAvatarImageUrl, AvatarPhoto } from "utils/avatarUrl";
 
 import santaDir from "images/holiday/santahat.png";
 
@@ -468,18 +468,19 @@ export function Avatar(props) {
     style.transform = "translateX(5px) translateY(5px)";
   }
 
+  let photoSrc = null;
   if (hasImage && !imageUrl && id && avatarId) {
     if (id === avatarId) {
       if (!deckProfile && userFileUrl) {
-        style.backgroundImage = `url(${userFileUrl})`;
+        photoSrc = userFileUrl;
       } else if (deckProfile) {
-        style.backgroundImage = `url(/uploads/decks/${avatarId}.webp?t=${siteInfo.cacheVal})`;
+        photoSrc = `/uploads/decks/${avatarId}.webp?t=${siteInfo.cacheVal}`;
       }
     }
   } else if (hasImage && !imageUrl && id && userFileUrl) {
-    style.backgroundImage = `url(${userFileUrl})`;
+    photoSrc = userFileUrl;
   } else if (hasImage && imageUrl) {
-    style.backgroundImage = `url(${imageUrl})`;
+    photoSrc = imageUrl;
   } else if (name) {
     var rand = 0;
 
@@ -495,9 +496,12 @@ export function Avatar(props) {
   }
   if (typeof hasImage == "string") {
     if (hasImage.includes("decks")) {
-      style.backgroundImage = `url(/uploads${hasImage}?t=${siteInfo.cacheVal})`;
+      photoSrc = `/uploads${hasImage}?t=${siteInfo.cacheVal}`;
       style.backgroundColor = "#00000000";
     }
+  }
+  if (photoSrc) {
+    style.backgroundImage = "none";
   }
 
   // Santa hat: Only show during December (turns off on January 1)
@@ -537,6 +541,7 @@ export function Avatar(props) {
         border: border,
       }}
     >
+      <AvatarPhoto src={photoSrc} />
       {edit && (
         <div className="edit avatar-edit-overlay">
           <AvatarUpload

--- a/react_main/src/pages/User/UserNavSection.jsx
+++ b/react_main/src/pages/User/UserNavSection.jsx
@@ -25,7 +25,6 @@ export default function UserNavSection({
   user,
   useUnreadNotifications,
 }) {
-  const now = useNow(200);
   const navigate = useNavigate();
   const isMobile = useIsPhoneDevice();
   const unreadCount = useUnreadNotifications();
@@ -123,39 +122,6 @@ export default function UserNavSection({
     },
   ];
 
-  function timeToGo(timestamp) {
-    // Utility to add leading zero
-    function z(n) {
-      return (n < 10 ? "0" : "") + n;
-    }
-
-    var diff = timestamp - now;
-    if (diff < 0) diff = 0;
-
-    // Get time components
-    var hours = (diff / 3.6e6) | 0;
-    var mins = ((diff % 3.6e6) / 6e4) | 0;
-    var secs = Math.round((diff % 6e4) / 1e3);
-
-    // Return formatted string
-    return z(hours) + ":" + z(mins) + ":" + z(secs);
-  }
-
-  function getHeartRefreshMessage(user, type) {
-    var timestamp = null;
-
-    if (type === "red") timestamp = user.redHeartRefreshTimestamp;
-    else if (type === "gold") timestamp = user.goldHeartRefreshTimestamp;
-
-    if (timestamp && timestamp > 0) {
-      const timeToGoString = timeToGo(timestamp);
-      //console.log(type, timestamp, timeToGoString, user)
-      return `Your ${type} hearts will replenish in: ${timeToGoString}`;
-    } else {
-      return `Your ${type} hearts are at full capacity. Go play some games!`;
-    }
-  }
-
   return (
     <Stack direction="row" spacing={0.5} divider={<Divider orientation="vertical" flexItem />} sx={{
       px: 1,
@@ -174,12 +140,12 @@ export default function UserNavSection({
           <Typography variant="body2">
             {user.redHearts ?? 0}
           </Typography>
-          <Tooltip title={getHeartRefreshMessage(user, "red")}>
+          <HeartRefreshTooltip user={user} type="red">
             <i
               className="fas fa-heart"
               style={{ color: "#e23b3b", marginLeft: "auto" }}
             />
-          </Tooltip>
+          </HeartRefreshTooltip>
           <Typography variant="body2">
             {user.goldHearts ?? 0}
           </Typography>
@@ -197,5 +163,41 @@ export default function UserNavSection({
         customTrigger={<Avatar id={user.id} name={user.name} hasImage={user.avatar} />}
       />
     </Stack>
+  );
+}
+
+function timeToGo(timestamp, now) {
+  function z(n) {
+    return (n < 10 ? "0" : "") + n;
+  }
+
+  var diff = timestamp - now;
+  if (diff < 0) diff = 0;
+
+  var hours = (diff / 3.6e6) | 0;
+  var mins = ((diff % 3.6e6) / 6e4) | 0;
+  var secs = Math.round((diff % 6e4) / 1e3);
+
+  return z(hours) + ":" + z(mins) + ":" + z(secs);
+}
+
+function getHeartRefreshMessage(user, type, now) {
+  var timestamp = null;
+
+  if (type === "red") timestamp = user.redHeartRefreshTimestamp;
+  else if (type === "gold") timestamp = user.goldHeartRefreshTimestamp;
+
+  if (timestamp && timestamp > 0) {
+    return `Your ${type} hearts will replenish in: ${timeToGo(timestamp, now)}`;
+  }
+  return `Your ${type} hearts are at full capacity. Go play some games!`;
+}
+
+function HeartRefreshTooltip({ user, type, children }) {
+  const now = useNow(1000);
+  return (
+    <Tooltip title={getHeartRefreshMessage(user, type, now)}>
+      {children}
+    </Tooltip>
   );
 }

--- a/react_main/src/utils/avatarUrl.js
+++ b/react_main/src/utils/avatarUrl.js
@@ -137,6 +137,13 @@ export function useAvatarUrlMap(ids, { cacheVal, family = false } = {}) {
   }, [listKey, freeze, frozenIds, family, cacheVal]);
 }
 
+export function AvatarPhoto({ src, alt = "" }) {
+  if (!src) return null;
+  return (
+    <img className="avatar-img" src={src} alt={alt} draggable={false} />
+  );
+}
+
 export function FamilyAvatarImage({
   id,
   size = 40,
@@ -153,11 +160,12 @@ export function FamilyAvatarImage({
         height: size,
         borderRadius: "50%",
         flexShrink: 0,
-        backgroundSize: "cover",
-        backgroundPosition: "center",
-        ...(src ? { backgroundImage: `url(${src})` } : {}),
+        overflow: "hidden",
+        position: "relative",
         ...extraStyle,
       }}
-    />
+    >
+      <AvatarPhoto src={src} />
+    </div>
   );
 }


### PR DESCRIPTION
Closes #2965
Closes #2960

## Bugs

Animated profile pictures (WebP) were drawn with CSS `background-image`. Safari and Brave on iPhone show that as a still frame, so GIFs looked static on profile, donors, nav, and in-game `%Name` chat.

The nav heart countdown also called `useNow(200)`, so the whole user menu (avatar plus the heart `Typography`) re-rendered five times a second. That matches the inspector flicker and the Safari lockup on #2960.

## Fix

- Render avatar photos with `<img>` (object-fit cover) instead of CSS backgrounds. Letter avatars are unchanged.
- `%Name` in chat uses the same `<img>` path, at the previous 40px size.
- "Disable animated avatars" still uses the static still-frame file.
- Heart replenish tooltip ticks once a second in its own component, so the nav avatar is not on that timer.

## Tested

Local: `%Name` in game chat animates and is the old size. Profile/nav avatars use `<img>`. Nav heart counts no longer thrash in the inspector.
