### PR TITLE
Update Action.js

### DIFF
--- a/Games/types/Mafia/Action.js
+++ b/Games/types/Mafia/Action.js
@@ -568,8 +568,7 @@ module.exports = class MafiaAction extends Action {
   isVanillaRole(player) {
     player = player || this.target;
     if (
-      player.role.name === this.getVanillaRole(player) &&
-      player.role.modifier === ""
+      player.role.name === this.getVanillaRole(player)
     ) {
       return true;
     }


### PR DESCRIPTION
The check for isVanillaRole has been updated to only check the role and not check modifiers, to better fit the logic of the description.

There is only one instance of isVanillaRole being called and it's from InheritFirstDeadAligned.js AKA Versatile modifier. This follows the behaviour of "isVanilla" which is defined and ran within other files in multiple instances.

I don't know what the best practice w/r/t defining these functions or merging them or whatever. I leave that to those more knowledgeable than I.