### PR TITLE
fix(site): scope stock dividends to shares actually held, and fix stock market bugs

### DIFF
--- a/db/schemas.js
+++ b/db/schemas.js
@@ -1533,6 +1533,9 @@ schemas.FamilyStock = new mongoose.Schema({
   isIpoed: { type: Boolean, default: false },
   shareSupply: { type: Number, default: 0 },
   treasuryCoins: { type: Number, default: 0 },
+  // Trade fees routed to the family treasury. Without this path declared here,
+  // Mongoose strict mode silently drops the $inc and the stat never accrues.
+  creatorFeesEarned: { type: Number, default: 0 },
   dividendsPaidOut: { type: Number, default: 0 },
 });
 

--- a/lib/StockMarket.js
+++ b/lib/StockMarket.js
@@ -7,6 +7,11 @@ const CREATOR_FEE_PCT = 0.015;
 const SYSTEM_FEE_PCT = 0.01;
 const DIVIDEND_RATE = 0.50; // Shareholders split 50% of the value of coins earned on top
 
+// Upper bound on a single trade. The buy-side pricing walk is O(shares), so an
+// unbounded count from a request body would block the event loop. The largest
+// trade ever recorded is 61 shares, so this leaves plenty of headroom.
+const MAX_SHARES_PER_TRADE = 1000;
+
 /**
  * Calculates the base price of the S-th share.
  * Supply (S) is 1-indexed.
@@ -23,6 +28,12 @@ function calculatePrice(supply) {
 function getBuyPrice(currentSupply, sharesToBuy) {
   if (sharesToBuy <= 0) {
     return { price: 0, creatorFee: 0, systemFee: 0, total: 0 };
+  }
+
+  // Backstop: callers are expected to validate first, but never let an
+  // out-of-range count reach the pricing walk below.
+  if (sharesToBuy > MAX_SHARES_PER_TRADE) {
+    throw new RangeError(`sharesToBuy exceeds MAX_SHARES_PER_TRADE (${MAX_SHARES_PER_TRADE})`);
   }
 
   let price = 0;
@@ -63,8 +74,37 @@ function getSellPrice(currentSupply, sharesToSell) {
 }
 
 /**
+ * Reads current share counts for the holders named in a snapshot.
+ * Returns a Map of holderId -> sharesOwned (absent holders are treated as 0).
+ */
+async function getCurrentShares(model, filter, holderIds) {
+  if (holderIds.length === 0) return new Map();
+
+  const current = await model
+    .find({ ...filter, holderId: { $in: holderIds } })
+    .select("holderId sharesOwned")
+    .lean()
+    .exec();
+
+  const shares = new Map();
+  for (const h of current) {
+    shares.set(h.holderId, h.sharesOwned || 0);
+  }
+  return shares;
+}
+
+/**
  * Distributes dividends based on game completion coin earnings.
- * Uses a snapshot taken at game start.
+ *
+ * Payout is based on min(shares at game start, shares at payout time). The
+ * snapshot half stops someone buying in once they can see the game is won —
+ * spectators are not in participantIds, so without it they could front-run the
+ * payout. The current-holdings half stops the reverse: selling out after the
+ * snapshot is taken and collecting anyway, which handed the seller the dividend
+ * while the buyer got a silently dividend-stripped share.
+ *
+ * The denominator stays snapshot.shareSupply so the pool can only shrink, never
+ * be inflated by supply moving during the game.
  */
 async function distributeDividends(subjectId, coinsEarned, snapshot, participantIds = []) {
   if (!snapshot || !snapshot.holders || snapshot.holders.length === 0 || snapshot.shareSupply <= 0) {
@@ -75,14 +115,27 @@ async function distributeDividends(subjectId, coinsEarned, snapshot, participant
   if (dividendPool <= 0) return [];
 
   const participantSet = new Set(participantIds);
+  const eligible = snapshot.holders.filter(
+    (h) => h.sharesOwned > 0 && !(participantSet.has(h.holderId) && h.holderId !== subjectId)
+  );
+
+  const currentShares = await getCurrentShares(
+    models.Shareholder,
+    { subjectId },
+    eligible.map((h) => h.holderId)
+  );
+
   const payouts = [];
   let totalDistributed = 0;
 
-  for (const holder of snapshot.holders) {
-    if (holder.sharesOwned <= 0) continue;
-    if (participantSet.has(holder.holderId) && holder.holderId !== subjectId) continue;
+  for (const holder of eligible) {
+    const heldThroughout = Math.min(
+      holder.sharesOwned,
+      currentShares.get(holder.holderId) || 0
+    );
+    if (heldThroughout <= 0) continue;
 
-    const shareFraction = holder.sharesOwned / snapshot.shareSupply;
+    const shareFraction = heldThroughout / snapshot.shareSupply;
     // Round to 2 decimals for precision
     const rawPayout = dividendPool * shareFraction;
     const payout = parseFloat(rawPayout.toFixed(2));
@@ -90,7 +143,7 @@ async function distributeDividends(subjectId, coinsEarned, snapshot, participant
     if (payout > 0) {
       payouts.push({
         holderId: holder.holderId,
-        sharesOwned: holder.sharesOwned,
+        sharesOwned: heldThroughout,
         payout
       });
       totalDistributed += payout;
@@ -135,7 +188,8 @@ async function distributeDividends(subjectId, coinsEarned, snapshot, participant
 
 /**
  * Distributes dividends for Family ETFs based on game completion coin earnings.
- * Uses a snapshot taken at game start.
+ * Payout is based on min(shares at game start, shares at payout time) — see
+ * distributeDividends for why both halves are needed.
  */
 async function distributeFamilyDividends(familyId, coinsEarned, snapshot, participantIds = [], winnerId) {
   if (!snapshot || !snapshot.holders || snapshot.holders.length === 0 || snapshot.shareSupply <= 0) {
@@ -147,21 +201,34 @@ async function distributeFamilyDividends(familyId, coinsEarned, snapshot, partic
   if (dividendPool <= 0) return [];
 
   const participantSet = new Set(participantIds);
+  const eligible = snapshot.holders.filter(
+    (h) => h.sharesOwned > 0 && !(participantSet.has(h.holderId) && h.holderId !== winnerId)
+  );
+
+  const currentShares = await getCurrentShares(
+    models.FamilyShareholder,
+    { familyId },
+    eligible.map((h) => h.holderId)
+  );
+
   const payouts = [];
   let totalDistributed = 0;
 
-  for (const holder of snapshot.holders) {
-    if (holder.sharesOwned <= 0) continue;
-    if (participantSet.has(holder.holderId) && holder.holderId !== winnerId) continue;
+  for (const holder of eligible) {
+    const heldThroughout = Math.min(
+      holder.sharesOwned,
+      currentShares.get(holder.holderId) || 0
+    );
+    if (heldThroughout <= 0) continue;
 
-    const shareFraction = holder.sharesOwned / snapshot.shareSupply;
+    const shareFraction = heldThroughout / snapshot.shareSupply;
     const rawPayout = dividendPool * shareFraction;
     const payout = parseFloat(rawPayout.toFixed(2));
 
     if (payout > 0) {
       payouts.push({
         holderId: holder.holderId,
-        sharesOwned: holder.sharesOwned,
+        sharesOwned: heldThroughout,
         payout
       });
       totalDistributed += payout;
@@ -207,6 +274,7 @@ async function distributeFamilyDividends(familyId, coinsEarned, snapshot, partic
 module.exports = {
   CREATOR_FEE_PCT,
   SYSTEM_FEE_PCT,
+  MAX_SHARES_PER_TRADE,
   calculatePrice,
   getBuyPrice,
   getSellPrice,

--- a/routes/stockMarket.js
+++ b/routes/stockMarket.js
@@ -41,10 +41,25 @@ async function acquireTradeLock(key) {
   };
 }
 
+/** Escapes regex metacharacters so user input cannot alter the pattern. */
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function isPositiveInteger(val) {
   const num = Number(val);
   return Number.isInteger(num) && num > 0;
 }
+
+/**
+ * Share counts drive an O(n) walk up the bonding curve, so they must be bounded
+ * before any pricing happens — not just checked for affordability afterwards.
+ */
+function isValidShareCount(val) {
+  return isPositiveInteger(val) && Number(val) <= stockMarket.MAX_SHARES_PER_TRADE;
+}
+
+const INVALID_SHARES_MSG = `Shares must be a positive integer no greater than ${stockMarket.MAX_SHARES_PER_TRADE}.`;
 
 /** Returns true if a MongoDB updateOne/findOneAndUpdate actually modified a document. */
 function wasModified(result) {
@@ -146,8 +161,8 @@ function createBuyHandler(config) {
       const entityId = req.body[config.requestIdField];
       const sharesToBuy = Number(req.body.shares);
 
-      if (!entityId || !isPositiveInteger(sharesToBuy)) {
-        return errors.badRequest(res, "Invalid buy data. Shares must be a positive integer.");
+      if (!entityId || !isValidShareCount(sharesToBuy)) {
+        return errors.badRequest(res, `Invalid buy data. ${INVALID_SHARES_MSG}`);
       }
 
       const releaseLock = await acquireTradeLock(`${config.lockPrefix}:${entityId}`);
@@ -258,8 +273,8 @@ function createSellHandler(config) {
       const entityId = req.body[config.requestIdField];
       const sharesToSell = Number(req.body.shares);
 
-      if (!entityId || !isPositiveInteger(sharesToSell)) {
-        return errors.badRequest(res, "Invalid sell data. Shares must be a positive integer.");
+      if (!entityId || !isValidShareCount(sharesToSell)) {
+        return errors.badRequest(res, `Invalid sell data. ${INVALID_SHARES_MSG}`);
       }
 
       const releaseLock = await acquireTradeLock(`${config.lockPrefix}:${entityId}`);
@@ -470,7 +485,7 @@ router.get("/transactions", async function (req, res) {
       }
 
       if (search) {
-        const matchingUsers = await models.User.find({ name: { $regex: search, $options: "i" } })
+        const matchingUsers = await models.User.find({ name: { $regex: escapeRegex(search), $options: "i" } })
           .select("id")
           .lean()
           .exec();
@@ -486,9 +501,9 @@ router.get("/transactions", async function (req, res) {
         ];
       }
 
-      const totalPromise = Object.keys(queryFilter).length > 0
-        ? models.StockTransaction.countDocuments(queryFilter).exec()
-        : models.StockTransaction.estimatedDocumentCount().exec();
+      // Always countDocuments: estimatedDocumentCount ignores the filter and can
+      // disagree with the rows actually returned, breaking the pager.
+      const totalPromise = models.StockTransaction.countDocuments(queryFilter).exec();
 
       const [total, txs] = await Promise.all([
         totalPromise,
@@ -548,8 +563,8 @@ router.get("/transactions", async function (req, res) {
 
       if (search) {
         const [matchingUsers, matchingFamilies] = await Promise.all([
-          models.User.find({ name: { $regex: search, $options: "i" } }).select("id").lean().exec(),
-          models.Family.find({ name: { $regex: search, $options: "i" } }).select("id").lean().exec()
+          models.User.find({ name: { $regex: escapeRegex(search), $options: "i" } }).select("id").lean().exec(),
+          models.Family.find({ name: { $regex: escapeRegex(search), $options: "i" } }).select("id").lean().exec()
         ]);
 
         const matchingUserIds = matchingUsers.map(u => u.id);
@@ -570,9 +585,7 @@ router.get("/transactions", async function (req, res) {
         queryFilter.$or = orConditions;
       }
 
-      const totalPromise = Object.keys(queryFilter).length > 0
-        ? models.FamilyStockTransaction.countDocuments(queryFilter).exec()
-        : models.FamilyStockTransaction.estimatedDocumentCount().exec();
+      const totalPromise = models.FamilyStockTransaction.countDocuments(queryFilter).exec();
 
       const [total, txs] = await Promise.all([
         totalPromise,
@@ -1016,7 +1029,7 @@ router.get("/families/prices/:familyId", async function (req, res) {
       marketCap,
       buyPrice1: buy1.total,
       sellPrice1: sell1.total,
-      treasuryCoins: f ? (f.treasury || 0) : 0,
+      treasuryCoins: family ? (family.treasury || 0) : 0,
       dividendsPaidOut: stock.dividendsPaidOut
     });
   } catch (e) {

--- a/test/stockMarket.test.js
+++ b/test/stockMarket.test.js
@@ -39,14 +39,25 @@ describe("lib/StockMarket", function () {
     it("calculates buy price and 1.5% / 1% fees", function () {
       // Current supply = 9, buy 1 share.
       // 10th share base price: calculatePrice(10) = 1
-      // Creator fee: 1.5% of 1 is 0.015, rounded to 0.02.
+      // Creator fee: 1.5% of 1 is 0.015, which toFixed(2) renders as 0.01.
       // System fee: 1% of 1 is 0.01.
-      // total = 1 + 0.02 + 0.01 = 1.03
+      // total = 1 + 0.01 + 0.01 = 1.02
       const result = stockMarket.getBuyPrice(9, 1);
       result.price.should.equal(1);
       result.creatorFee.should.equal(0.01);
       result.systemFee.should.equal(0.01);
       result.total.should.equal(1.02);
+    });
+
+    it("throws rather than walking the curve for an out-of-range share count", function () {
+      // An unbounded count from a request body would block the event loop:
+      // the pricing walk is O(shares).
+      (function () {
+        stockMarket.getBuyPrice(1, stockMarket.MAX_SHARES_PER_TRADE + 1);
+      }).should.throw(RangeError);
+
+      // The cap itself is still priced normally.
+      stockMarket.getBuyPrice(1, stockMarket.MAX_SHARES_PER_TRADE).total.should.be.above(0);
     });
 
     it("calculates buy price for multiple shares", function () {
@@ -101,9 +112,30 @@ describe("lib/StockMarket", function () {
     let originalFamilyShareholderBulkWrite;
     let originalUpdateOne;
     let originalFamilyUpdateOne;
+    let originalShareholderFind;
+    let originalFamilyShareholderFind;
     let bulkWriteCalls = [];
     let updateOneCalls = [];
     let familyUpdateOneCalls = [];
+
+    // Current on-chain holdings the mocked find() will report, as
+    // holderId -> sharesOwned. Defaults to matching the snapshot exactly.
+    let currentHoldings = {};
+
+    function mockFind() {
+      return function (filter) {
+        const ids = (filter.holderId && filter.holderId.$in) || [];
+        const rows = ids
+          .filter((id) => currentHoldings[id] !== undefined)
+          .map((id) => ({ holderId: id, sharesOwned: currentHoldings[id] }));
+        const chain = {
+          select: () => chain,
+          lean: () => chain,
+          exec: async () => rows,
+        };
+        return chain;
+      };
+    }
 
     before(function () {
       originalBulkWrite = models.User.bulkWrite;
@@ -111,6 +143,11 @@ describe("lib/StockMarket", function () {
       originalFamilyShareholderBulkWrite = models.FamilyShareholder.bulkWrite;
       originalUpdateOne = models.PlayerStock.updateOne;
       originalFamilyUpdateOne = models.FamilyStock.updateOne;
+      originalShareholderFind = models.Shareholder.find;
+      originalFamilyShareholderFind = models.FamilyShareholder.find;
+
+      models.Shareholder.find = mockFind();
+      models.FamilyShareholder.find = mockFind();
 
       models.User.bulkWrite = async function (ops) {
         bulkWriteCalls.push(ops);
@@ -142,13 +179,23 @@ describe("lib/StockMarket", function () {
       models.FamilyShareholder.bulkWrite = originalFamilyShareholderBulkWrite;
       models.PlayerStock.updateOne = originalUpdateOne;
       models.FamilyStock.updateOne = originalFamilyUpdateOne;
+      models.Shareholder.find = originalShareholderFind;
+      models.FamilyShareholder.find = originalFamilyShareholderFind;
     });
 
     beforeEach(function () {
       bulkWriteCalls = [];
       updateOneCalls = [];
       familyUpdateOneCalls = [];
+      currentHoldings = {};
     });
+
+    /** Marks every snapshot holder as still holding the same amount. */
+    function stillHolding(snapshot) {
+      for (const h of snapshot.holders) {
+        currentHoldings[h.holderId] = h.sharesOwned;
+      }
+    }
 
     describe("distributeDividends", function () {
       it("returns empty array and does not hit DB if no snapshot or zero supply", async function () {
@@ -168,6 +215,7 @@ describe("lib/StockMarket", function () {
             { holderId: "h2", sharesOwned: 4 }
           ]
         };
+        stillHolding(snapshot);
 
         // coinsEarned = 20. Dividend pool = 20 * 0.5 = 10.
         // h1 (6/10 shares) -> gets 6 coins
@@ -199,6 +247,7 @@ describe("lib/StockMarket", function () {
             { holderId: "subject1", sharesOwned: 4 }
           ]
         };
+        stillHolding(snapshot);
 
         // coinsEarned = 20. Dividend pool = 20 * 0.5 = 10.
         // Participants are ["h1", "subject1"].
@@ -218,6 +267,72 @@ describe("lib/StockMarket", function () {
         updateOneCalls.length.should.equal(1);
         updateOneCalls[0].filter.userId.should.equal("subject1");
         updateOneCalls[0].update.$inc.dividendsPaidOut.should.equal(4);
+      });
+
+      it("pays nothing to a holder who sold out after the snapshot was taken", async function () {
+        const snapshot = {
+          shareSupply: 10,
+          holders: [
+            { holderId: "h1", sharesOwned: 6 },
+            { holderId: "h2", sharesOwned: 4 }
+          ]
+        };
+        // h1 dumped the whole position mid-game; h2 held.
+        currentHoldings = { h1: 0, h2: 4 };
+
+        const res = await stockMarket.distributeDividends("subject1", 20, snapshot);
+
+        res.length.should.equal(1);
+        res[0].holderId.should.equal("h2");
+        res[0].payout.should.equal(4);
+
+        // h1's 6 coins are simply not minted — the pool shrinks, it does not
+        // get redistributed to the remaining holders.
+        updateOneCalls[0].update.$inc.dividendsPaidOut.should.equal(4);
+      });
+
+      it("pays on the reduced amount when a holder partially sold", async function () {
+        const snapshot = {
+          shareSupply: 10,
+          holders: [{ holderId: "h1", sharesOwned: 6 }]
+        };
+        currentHoldings = { h1: 2 };
+
+        // Pool is 10; h1 is paid on 2/10, not the snapshot's 6/10.
+        const res = await stockMarket.distributeDividends("subject1", 20, snapshot);
+
+        res.length.should.equal(1);
+        res[0].sharesOwned.should.equal(2);
+        res[0].payout.should.equal(2);
+      });
+
+      it("caps at the snapshot when a holder bought more during the game", async function () {
+        const snapshot = {
+          shareSupply: 10,
+          holders: [{ holderId: "h1", sharesOwned: 6 }]
+        };
+        // Buying in mid-game must not increase the payout — this is the half
+        // that stops a spectator front-running a win they can already see.
+        currentHoldings = { h1: 10 };
+
+        const res = await stockMarket.distributeDividends("subject1", 20, snapshot);
+
+        res.length.should.equal(1);
+        res[0].sharesOwned.should.equal(6);
+        res[0].payout.should.equal(6);
+      });
+
+      it("pays nothing when the holder has no shareholder record at payout time", async function () {
+        const snapshot = {
+          shareSupply: 10,
+          holders: [{ holderId: "h1", sharesOwned: 6 }]
+        };
+        currentHoldings = {}; // record absent entirely
+
+        const res = await stockMarket.distributeDividends("subject1", 20, snapshot);
+
+        res.length.should.equal(0);
+        bulkWriteCalls.length.should.equal(0);
       });
     });
 
@@ -239,6 +354,7 @@ describe("lib/StockMarket", function () {
             { holderId: "h2", sharesOwned: 4 }
           ]
         };
+        stillHolding(snapshot);
 
         // coinsEarned = 40. Dividend pool = 40 * 0.25 = 10.
         // h1 (6/10 shares) -> gets 6 coins
@@ -270,6 +386,7 @@ describe("lib/StockMarket", function () {
             { holderId: "winner1", sharesOwned: 4 }
           ]
         };
+        stillHolding(snapshot);
 
         // coinsEarned = 40. Dividend pool = 40 * 0.25 = 10.
         // Participants are ["h1", "winner1"], but winnerId is "winner1".
@@ -288,6 +405,23 @@ describe("lib/StockMarket", function () {
         familyUpdateOneCalls.length.should.equal(1);
         familyUpdateOneCalls[0].filter.familyId.should.equal("familyA");
         familyUpdateOneCalls[0].update.$inc.dividendsPaidOut.should.equal(4);
+      });
+
+      it("pays nothing to a family holder who sold out after the snapshot", async function () {
+        const snapshot = {
+          shareSupply: 10,
+          holders: [
+            { holderId: "h1", sharesOwned: 6 },
+            { holderId: "h2", sharesOwned: 4 }
+          ]
+        };
+        currentHoldings = { h1: 0, h2: 4 };
+
+        const res = await stockMarket.distributeFamilyDividends("familyA", 40, snapshot);
+
+        res.length.should.equal(1);
+        res[0].holderId.should.equal("h2");
+        res[0].payout.should.equal(4);
       });
     });
   });

--- a/test/stockMarketRoute.test.js
+++ b/test/stockMarketRoute.test.js
@@ -56,18 +56,18 @@ describe("routes/stockMarket - /transactions", function () {
       handler = layer.route.stack[0].handle;
     }
 
-    originalStockTxCount = models.StockTransaction.estimatedDocumentCount;
+    originalStockTxCount = models.StockTransaction.countDocuments;
     originalStockTxFind = models.StockTransaction.find;
-    originalFamilyStockTxCount = models.FamilyStockTransaction.estimatedDocumentCount;
+    originalFamilyStockTxCount = models.FamilyStockTransaction.countDocuments;
     originalFamilyStockTxFind = models.FamilyStockTransaction.find;
     originalUserFind = models.User.find;
     originalFamilyFind = models.Family.find;
   });
 
   after(function () {
-    models.StockTransaction.estimatedDocumentCount = originalStockTxCount;
+    models.StockTransaction.countDocuments = originalStockTxCount;
     models.StockTransaction.find = originalStockTxFind;
-    models.FamilyStockTransaction.estimatedDocumentCount = originalFamilyStockTxCount;
+    models.FamilyStockTransaction.countDocuments = originalFamilyStockTxCount;
     models.FamilyStockTransaction.find = originalFamilyStockTxFind;
     models.User.find = originalUserFind;
     models.Family.find = originalFamilyFind;
@@ -78,7 +78,9 @@ describe("routes/stockMarket - /transactions", function () {
   });
 
   it("handles player stock transactions list with pagination", async function () {
-    models.StockTransaction.estimatedDocumentCount = () => {
+    models.StockTransaction.countDocuments = (filter) => {
+      // Unfiltered listing still passes a filter object, just an empty one.
+      Object.keys(filter).should.have.lengthOf(0);
       return {
         exec: async () => 100
       };
@@ -151,7 +153,7 @@ describe("routes/stockMarket - /transactions", function () {
   });
 
   it("handles family stock transactions list with pagination", async function () {
-    models.FamilyStockTransaction.estimatedDocumentCount = () => {
+    models.FamilyStockTransaction.countDocuments = () => {
       return {
         exec: async () => 50
       };
@@ -311,6 +313,5 @@ describe("routes/stockMarket - /transactions", function () {
 
     res.body.total.should.equal(5);
     res.body.transactions.should.have.lengthOf(1);
-    delete models.StockTransaction.countDocuments;
   });
 });


### PR DESCRIPTION
## Dividend scope

Dividends were paid from a snapshot taken at game start, with no check against holdings at payout time.

The snapshot is deliberate and load-bearing, so this keeps it. `allParticipantIds` is built from `this.players` plus `playersGone` (`Games/core/Game.js:3994`), which means **spectators are not in it** — and in mafia, spectators and dead players see everything. Without the snapshot, a spectator could watch a game resolve and buy the winner's stock seconds before the payout landed.

The problem was that it only worked in one direction. It capped *acquiring* exposure but not *shedding* it, so a holder could sell their entire position after the game started and still collect the dividend. The person who bought those shares got a silently dividend-stripped share, with nothing in the UI to indicate a game was in progress.

Payout is now based on `min(shares at snapshot, shares at payout)`:

- capped by the snapshot → buying in mid-game still gains nothing, so the front-running protection is unchanged
- capped by current holdings → selling out mid-game no longer pays

The denominator stays `snapshot.shareSupply`, so an unclaimed portion is simply not minted rather than being redistributed — the pool can only shrink, never inflate from supply moving during the game. This matches how the existing participant exclusion already behaves.

This costs one extra indexed `find` per payout, on the `{subjectId, holderId}` / `{familyId, holderId}` unique indexes that already exist.

## Other fixes

All in the stock market, found while reading through it:

| | |
|---|---|
| **Undefined variable → 500** | `GET /api/stocks/families/prices/:familyId` referenced `f` instead of `family`. Every request to it threw a `ReferenceError`, got swallowed by the route's catch, and returned a 500. The identical line in the `/families` list handler is fine because `f` is defined there. |
| **Unbounded loop** | Buy requests took an unvalidated share count straight into the O(n) walk up the bonding curve, *before* the affordability check. `shares=1e15` blocks the event loop for weeks and holds that stock's trade lock while doing it. Counts are now bounded by `MAX_SHARES_PER_TRADE` (1000 — the largest trade on record is 61), with a `RangeError` backstop inside `getBuyPrice` for any future caller. The sell path was already safe, since it checks holdings first. |
| **Regex injection** | `/transactions` passed raw user input to `$regex`, letting a crafted pattern alter the query or hang the matcher. Now escaped with the same helper `routes/family.js` already uses. |
| **Silently dropped `$inc`** | `FamilyStock` had no `creatorFeesEarned` path, so Mongoose strict mode stripped it from the update and the stat never accrued. Coins still reached the family treasury via the separate `Family.treasury` write, so **no balances were ever wrong** — only the stat. |
| **Pagination count** | `/transactions` used `estimatedDocumentCount` when unfiltered, which ignores the filter and can disagree with the rows actually returned. Always `countDocuments` now. |

## Tests

`npm test` runs the suite in parallel and several files need Redis/Mongo, so counts vary between runs depending on which workers die. Comparing the deterministic non-infra subset on the same machine:

- **master:** 135 passing, 2 failing
- **this branch:** 141 passing, 2 failing

Same 2 failures both times (`modules/fortunePoints`, pre-existing and unrelated). The 6 new tests cover: sold out after the snapshot, partial sale, bought more during the game (must stay capped), no shareholder record at payout, the family-side equivalent, and the share-count guard.

Also corrected a stale comment in `test/stockMarket.test.js` that claimed a fee rounds to `0.02` while the assertion three lines down correctly expected `0.01`.

## Not addressed here

Deliberately out of scope, happy to file separately:

- The dividend **yield curve** still falls off as roughly 1/S³ while price grows as S². At the current median supply of 32 a share costs ~10 coins and returns ~0.076/win; at supply 86 the payback is in the thousands of wins. This PR makes the dividend correctly *scoped*; it does not make it meaningfully *sized*.
- The bonding curve is reimplemented in `TradeDialog.jsx` with `PRICE_SCALE` hardcoded, so `MAX_SHARES_PER_TRADE` is not enforced client-side — an over-cap trade gets a clean 400 rather than being blocked in the UI.
- Account and family deletion leave `PlayerStock` / `FamilyStock` rows behind, so a disbanded family's ETF keeps trading as a zombie and its treasury-fee write matches nothing.