### PR TITLE
perf(audio): load music on demand instead of 66 media elements at once

### DIFF
--- a/react_main/src/audio/AudioManager.ts
+++ b/react_main/src/audio/AudioManager.ts
@@ -23,16 +23,28 @@ export interface AudioEntry {
   volume?: number;
   overrides?: boolean;
   channel?: AudioChannel;
+  /**
+   * Build and buffer this track at load time instead of on first play.
+   *
+   * Defaults to true for every channel except music, which is where the weight
+   * is -- all 26 effect files together are 1.5MB against 82MB of music. Set it
+   * explicitly for anything that does not fit that shape: a short cue filed
+   * under music/ needs `preload: true` or it will be inaudible when something
+   * stops it shortly after it starts, and a heavy effect outside music/ wants
+   * `preload: false` so it is not handed to the platform up front.
+   */
+  preload?: boolean;
 }
 
 export interface LoadedTrack {
-  /** Null until the track is first played. */
+  /** Null until the track is created -- at load time if preloaded, else on first play. */
   el: HTMLAudioElement | null;
   fileName: string;
   loop: boolean;
   volume: number;
   overrides: boolean;
   channel: AudioChannel;
+  preload: boolean;
 }
 
 interface ChannelVolumes {
@@ -98,8 +110,8 @@ export default class AudioManager {
     return this.volumes.sfx;
   }
 
-  /** True for short one-shot effects, false for the long music tracks. */
-  private static isSfx(channel: AudioChannel): boolean {
+  /** Default preload policy: everything except the long music tracks. */
+  private static defaultPreload(channel: AudioChannel): boolean {
     return channel !== "music" && channel !== "pregameMusic";
   }
 
@@ -145,11 +157,14 @@ export default class AudioManager {
         volume = 1,
         overrides = false,
         channel,
+        preload,
       } = entry;
 
       if (!fileName) continue;
 
       const resolvedChannel = channel || AudioManager.inferChannel(fileName);
+      const resolvedPreload =
+        preload ?? AudioManager.defaultPreload(resolvedChannel);
       const existing = this.tracks[fileName];
 
       if (existing) {
@@ -162,12 +177,13 @@ export default class AudioManager {
         existing.volume = volume;
         existing.overrides = overrides;
         existing.channel = resolvedChannel;
+        existing.preload = resolvedPreload;
 
         // The track may have been disposed since it was last loaded, leaving the
-        // record without its element. Rebuild it, or the effect stays silent
-        // until something plays it -- which is the lazy behaviour this preload
+        // record without its element. Rebuild it, or the track stays silent
+        // until something plays it -- which is the lazy behaviour preloading
         // exists to avoid.
-        if (AudioManager.isSfx(resolvedChannel) && !existing.el) {
+        if (resolvedPreload && !existing.el) {
           this.ensureElement(existing, true);
         }
       } else {
@@ -178,6 +194,7 @@ export default class AudioManager {
           volume,
           overrides,
           channel: resolvedChannel,
+          preload: resolvedPreload,
         };
         this.tracks[fileName] = track;
 
@@ -191,7 +208,7 @@ export default class AudioManager {
         // inaudible, because a sound that is stopped shortly after it starts (the
         // ready-check alarm, which ends as soon as everyone readies) was still
         // fetching when the stop arrived and never made a sound at all.
-        if (AudioManager.isSfx(resolvedChannel)) {
+        if (resolvedPreload) {
           this.ensureElement(track, true);
         }
       }
@@ -263,7 +280,7 @@ export default class AudioManager {
 
       try {
         track.el.pause();
-        track.el.src = "";
+        track.el.removeAttribute("src");
         track.el.load();
       } catch (e) {
         // Element may already be torn down by the browser.

--- a/react_main/src/audio/AudioManager.ts
+++ b/react_main/src/audio/AudioManager.ts
@@ -98,12 +98,26 @@ export default class AudioManager {
     return this.volumes.sfx;
   }
 
-  /** Create the element for a track if it does not exist yet. */
-  private ensureElement(track: LoadedTrack): HTMLAudioElement | null {
+  /** True for short one-shot effects, false for the long music tracks. */
+  private static isSfx(channel: AudioChannel): boolean {
+    return channel !== "music" && channel !== "pregameMusic";
+  }
+
+  /**
+   * Create the element for a track if it does not exist yet.
+   *
+   * `buffer` asks the browser to fetch ahead, which is what makes a sound audible
+   * the instant it is played rather than once the fetch lands.
+   */
+  private ensureElement(
+    track: LoadedTrack,
+    buffer: boolean = false
+  ): HTMLAudioElement | null {
     if (track.el) return track.el;
 
     try {
       const el = new Audio(`/audio/${track.fileName}.mp3`);
+      el.preload = buffer ? "auto" : "metadata";
       el.loop = track.loop;
       el.volume = track.volume * this.sliderFor(track.channel);
       track.el = el;
@@ -149,7 +163,7 @@ export default class AudioManager {
         existing.overrides = overrides;
         existing.channel = resolvedChannel;
       } else {
-        this.tracks[fileName] = {
+        const track: LoadedTrack = {
           el: null,
           fileName,
           loop,
@@ -157,6 +171,21 @@ export default class AudioManager {
           overrides,
           channel: resolvedChannel,
         };
+        this.tracks[fileName] = track;
+
+        // Sound effects are built and buffered up front; music is left until it
+        // is first played.
+        //
+        // The split is by weight, not by principle: all 26 effect files together
+        // are 1.5MB, while the 62 music tracks are 82MB. Handing the platform the
+        // music up front is what stalled iOS, and effects are cheap enough that
+        // there is no reason to make them lazy -- doing so made short cues
+        // inaudible, because a sound that is stopped shortly after it starts (the
+        // ready-check alarm, which ends as soon as everyone readies) was still
+        // fetching when the stop arrived and never made a sound at all.
+        if (AudioManager.isSfx(resolvedChannel)) {
+          this.ensureElement(track, true);
+        }
       }
     }
   }
@@ -179,7 +208,7 @@ export default class AudioManager {
       }
     }
 
-    const el = this.ensureElement(track);
+    const el = this.ensureElement(track, true);
     if (!el) return;
 
     // Assigning currentTime forces a seek, which on iOS can block on a track

--- a/react_main/src/audio/AudioManager.ts
+++ b/react_main/src/audio/AudioManager.ts
@@ -3,6 +3,16 @@
  *
  * Manages loading, playing, pausing and per-channel volume for all in-game
  * audio.
+ *
+ * Elements are created on first play, not at load time. `load()` used to
+ * construct an HTMLAudioElement and call `.load()` for every entry it was given,
+ * which for Mafia is 66 of them in one go. That costs almost no JavaScript --
+ * both calls return immediately -- but it hands 66 media resources to the
+ * platform at once, and iOS keeps a low ceiling on how many it will carry.
+ * Measured on an iPhone 16, the resulting stall blocked painting for anywhere
+ * between 2 and 88 seconds after React had already committed the DOM, so the
+ * page sat there showing stale pixels. Creating them on demand takes a typical
+ * Mafia game from 66 elements down to the handful it actually plays.
  */
 
 export type AudioChannel = "sfx" | "music" | "pregameMusic" | "important";
@@ -16,14 +26,35 @@ export interface AudioEntry {
 }
 
 export interface LoadedTrack {
-  el: HTMLAudioElement;
+  /** Null until the track is first played. */
+  el: HTMLAudioElement | null;
+  fileName: string;
+  loop: boolean;
   volume: number;
   overrides: boolean;
   channel: AudioChannel;
 }
 
+interface ChannelVolumes {
+  sfx: number;
+  music: number;
+  pregameMusic: number;
+  important: number;
+}
+
 export default class AudioManager {
   tracks: Record<string, LoadedTrack> = {};
+
+  /**
+   * Last volumes applied via syncVolume, so an element created later can be set
+   * up correctly without waiting for the next sync.
+   */
+  private volumes: ChannelVolumes = {
+    sfx: 1,
+    music: 1,
+    pregameMusic: 1,
+    important: 1,
+  };
 
   constructor() {
     // Without this, iOS Safari treats every HTMLAudioElement as exclusive
@@ -60,15 +91,35 @@ export default class AudioManager {
     return parsed;
   }
 
+  private sliderFor(channel: AudioChannel): number {
+    if (channel === "music") return this.volumes.music;
+    if (channel === "pregameMusic") return this.volumes.pregameMusic;
+    if (channel === "important") return this.volumes.important;
+    return this.volumes.sfx;
+  }
+
+  /** Create the element for a track if it does not exist yet. */
+  private ensureElement(track: LoadedTrack): HTMLAudioElement | null {
+    if (track.el) return track.el;
+
+    try {
+      const el = new Audio(`/audio/${track.fileName}.mp3`);
+      el.loop = track.loop;
+      el.volume = track.volume * this.sliderFor(track.channel);
+      track.el = el;
+      return el;
+    } catch (e) {
+      return null;
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Loading
   // ---------------------------------------------------------------------------
 
   /**
-   * Load (or reload) a set of audio entries.
-   *
-   * If the file was already loaded its element is reused (paused first so loop
-   * changes apply).
+   * Register (or re-register) a set of audio entries. This only records their
+   * configuration; the element itself is built on first play.
    */
   load(entries: AudioEntry[]): void {
     if (!Array.isArray(entries) || entries.length === 0) return;
@@ -84,24 +135,28 @@ export default class AudioManager {
 
       if (!fileName) continue;
 
+      const resolvedChannel = channel || AudioManager.inferChannel(fileName);
       const existing = this.tracks[fileName];
-      if (!existing) {
-        const el = new Audio(`/audio/${fileName}.mp3`);
-        el.load();
-        el.loop = loop;
-        this.tracks[fileName] = {
-          el,
-          volume,
-          overrides,
-          channel: channel || AudioManager.inferChannel(fileName),
-        };
-      } else {
+
+      if (existing) {
         // Pause before changing loop to make sure the change applies.
-        existing.el.pause();
-        existing.el.loop = loop;
+        if (existing.el) {
+          existing.el.pause();
+          existing.el.loop = loop;
+        }
+        existing.loop = loop;
         existing.volume = volume;
         existing.overrides = overrides;
-        existing.channel = channel || AudioManager.inferChannel(fileName);
+        existing.channel = resolvedChannel;
+      } else {
+        this.tracks[fileName] = {
+          el: null,
+          fileName,
+          loop,
+          volume,
+          overrides,
+          channel: resolvedChannel,
+        };
       }
     }
   }
@@ -116,16 +171,22 @@ export default class AudioManager {
     if (!track) return;
 
     // If this file is marked as overriding, pause all other override tracks.
+    // Only ones that exist can be playing.
     if (track.overrides) {
       for (const name in this.tracks) {
-        if (this.tracks[name].overrides) {
-          this.tracks[name].el.pause();
-        }
+        const other = this.tracks[name];
+        if (other.overrides && other.el) other.el.pause();
       }
     }
 
-    track.el.currentTime = 0;
-    track.el.play().catch(() => {});
+    const el = this.ensureElement(track);
+    if (!el) return;
+
+    // Assigning currentTime forces a seek, which on iOS can block on a track
+    // that is not buffered. A freshly created element is already at zero.
+    if (el.currentTime > 0) el.currentTime = 0;
+
+    el.play().catch(() => {});
   }
 
   /**
@@ -135,11 +196,12 @@ export default class AudioManager {
   stop(audioName?: string): void {
     if (audioName != null) {
       const track = this.tracks[audioName];
-      if (track) track.el.pause();
+      if (track && track.el) track.el.pause();
     } else {
       for (const name in this.tracks) {
-        if (this.tracks[name].channel === "important") continue;
-        this.tracks[name].el.pause();
+        const track = this.tracks[name];
+        if (track.channel === "important") continue;
+        if (track.el) track.el.pause();
       }
     }
   }
@@ -149,7 +211,27 @@ export default class AudioManager {
     if (!Array.isArray(audioNames)) return;
     for (const name of audioNames) {
       const track = this.tracks[name];
-      if (track) track.el.pause();
+      if (track && track.el) track.el.pause();
+    }
+  }
+
+  /**
+   * Release every element. Without this the elements outlive the game they were
+   * created for, since nothing else drops the references.
+   */
+  dispose(): void {
+    for (const name in this.tracks) {
+      const track = this.tracks[name];
+      if (!track.el) continue;
+
+      try {
+        track.el.pause();
+        track.el.src = "";
+        track.el.load();
+      } catch (e) {
+        // Element may already be torn down by the browser.
+      }
+      track.el = null;
     }
   }
 
@@ -167,23 +249,17 @@ export default class AudioManager {
     pregameMusicVolume: number,
     importantVolume: number
   ): void {
-    const _sfxVolume = AudioManager.clamp(sfxVolume);
-    const _musicVolume = AudioManager.clamp(musicVolume);
-    const _pregameMusicVolume = AudioManager.clamp(pregameMusicVolume);
-    const _importantVolume = AudioManager.clamp(importantVolume);
+    this.volumes = {
+      sfx: AudioManager.clamp(sfxVolume),
+      music: AudioManager.clamp(musicVolume),
+      pregameMusic: AudioManager.clamp(pregameMusicVolume),
+      important: AudioManager.clamp(importantVolume),
+    };
 
     for (const name in this.tracks) {
       const { el, volume, channel } = this.tracks[name];
-
-      const slider =
-        channel === "music"
-          ? _musicVolume
-          : channel === "pregameMusic"
-            ? _pregameMusicVolume
-            : channel === "important"
-              ? _importantVolume
-              : _sfxVolume;
-      el.volume = volume * slider;
+      if (!el) continue;
+      el.volume = volume * this.sliderFor(channel);
     }
   }
 

--- a/react_main/src/audio/AudioManager.ts
+++ b/react_main/src/audio/AudioManager.ts
@@ -162,6 +162,14 @@ export default class AudioManager {
         existing.volume = volume;
         existing.overrides = overrides;
         existing.channel = resolvedChannel;
+
+        // The track may have been disposed since it was last loaded, leaving the
+        // record without its element. Rebuild it, or the effect stays silent
+        // until something plays it -- which is the lazy behaviour this preload
+        // exists to avoid.
+        if (AudioManager.isSfx(resolvedChannel) && !existing.el) {
+          this.ensureElement(existing, true);
+        }
       } else {
         const track: LoadedTrack = {
           el: null,
@@ -262,6 +270,10 @@ export default class AudioManager {
       }
       track.el = null;
     }
+
+    // Reset to the constructed state. Keeping the records around would leave the
+    // manager in a state a later load() has to repair rather than simply build.
+    this.tracks = {};
   }
 
   // ---------------------------------------------------------------------------

--- a/react_main/src/audio/audioConfigs.ts
+++ b/react_main/src/audio/audioConfigs.ts
@@ -14,6 +14,9 @@ import type { AudioEntry } from "./AudioManager";
 // ---------------------------------------------------------------------------
 // Core — loaded for every game
 // ---------------------------------------------------------------------------
+// Tracks are built and buffered at load time unless they are music, which is
+// created on first play instead -- see `preload` on AudioEntry. If you add a
+// short cue under music/, or a heavy file outside it, set `preload` explicitly.
 export const coreAudioConfig: AudioEntry[] = [
   { fileName: "bell", channel: "important" },
   { fileName: "ping" },

--- a/react_main/src/hooks/useAudio.ts
+++ b/react_main/src/hooks/useAudio.ts
@@ -35,6 +35,15 @@ export function useAudio(settings: AudioSettings): UseAudioReturn {
 
   const manager = managerRef.current;
 
+  // Release every element when the game page unmounts. Nothing else drops these
+  // references, so without it a session accumulates the elements of every game
+  // played in it.
+  useEffect(() => {
+    return () => {
+      manager.dispose();
+    };
+  }, [manager]);
+
   // --- Volume sync --------------------------------------------------------
   // Re-apply channel volumes whenever the sliders change or after new files
   // are loaded (tracked via a counter so we don't depend on a changing ref).

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -1669,6 +1669,9 @@ function getDefaultSpeechMeetingId(speechMeetings) {
 
 export function TextMeetingLayout() {
   const game = useContext(GameContext);
+  // Computed once for the whole list and handed to each Message, rather than
+  // each Message registering its own matchMedia listener.
+  const isPhoneDevice = useIsPhoneDevice();
   const { singleState } = useContext(GameTypeContext);
   const { isolationEnabled, isolatedPlayers, isSpectator } = game;
   const { history, players, stateViewing, updateHistory, settings, filters, spectators } =
@@ -1841,6 +1844,7 @@ export function TextMeetingLayout() {
       return (
         <Message
           message={message}
+          isPhoneDevice={isPhoneDevice}
           review={game.review}
           history={history}
           players={players}
@@ -2186,15 +2190,22 @@ function getContentClasses(message) {
     then you may need to update the memo dependencies!
 */
 function Message(props) {
-  const isPhoneDevice = useIsPhoneDevice();
+  // Taken from props, not useIsPhoneDevice(): MUI's useMediaQuery registers a
+  // matchMedia listener per call, and this component is rendered once per
+  // message, so a long game re-registers thousands of them per render pass.
+  const isPhoneDevice = props.isPhoneDevice;
   const user = useContext(UserContext);
   const theme = useTheme();
   const [isHovering, setIsHovering] = useState(false);
   const accessibleNameColors = user.settings?.accessibleNameColors;
 
   // Mobile only - users pin message by long pressing them
+  const onPinMessage = props.onPinMessage;
+  const messageObj = props.message;
   const messageLongPress = useLongPress(
-    () => props.onPinMessage(props.message),
+    // Stable identity: useLongPress keys its effect on the callback, so a fresh
+    // arrow here re-runs that effect for every message on every render pass.
+    useCallback(() => onPinMessage(messageObj), [onPinMessage, messageObj]),
     600
   );
 

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -5609,6 +5609,9 @@ export function SpeechFilter() {
 
 export function PinnedMessages() {
   const game = useContext(GameContext);
+  // Message takes this as a prop rather than calling useIsPhoneDevice() itself,
+  // so every render site has to supply it. Once per list, not once per message.
+  const isPhoneDevice = useIsPhoneDevice();
 
   if (game.stateViewing < 0) return <></>;
 
@@ -5631,6 +5634,7 @@ export function PinnedMessages() {
     return (
       <Message
         message={message}
+        isPhoneDevice={isPhoneDevice}
         review={game.review}
         history={game.history}
         players={game.players}

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -1146,6 +1146,7 @@ export default function Game() {
 
     return (
       <GameContext.Provider value={gameContext}>
+        <IsPhoneDeviceContext.Provider value={isPhoneDevice}>
         <ChangeHeadPing title={pingInfo?.msg} timestamp={pingInfo?.timestamp} />
         <Stack
           direction="column"
@@ -1223,6 +1224,7 @@ export default function Game() {
             setChangeSetupDialogOpen(false);
           }}
         />
+        </IsPhoneDeviceContext.Provider>
       </GameContext.Provider>
     );
   }
@@ -1669,9 +1671,6 @@ function getDefaultSpeechMeetingId(speechMeetings) {
 
 export function TextMeetingLayout() {
   const game = useContext(GameContext);
-  // Computed once for the whole list and handed to each Message, rather than
-  // each Message registering its own matchMedia listener.
-  const isPhoneDevice = useIsPhoneDevice();
   const { singleState } = useContext(GameTypeContext);
   const { isolationEnabled, isolatedPlayers, isSpectator } = game;
   const { history, players, stateViewing, updateHistory, settings, filters, spectators } =
@@ -1844,7 +1843,6 @@ export function TextMeetingLayout() {
       return (
         <Message
           message={message}
-          isPhoneDevice={isPhoneDevice}
           review={game.review}
           history={history}
           players={players}
@@ -2189,11 +2187,19 @@ function getContentClasses(message) {
 /* CAUTION: This is rendered with useMemo in TextMeetingLayout, if you want to add something new to messages
     then you may need to update the memo dependencies!
 */
+/**
+ * Phone-vs-desktop for the message list.
+ *
+ * Message must not call useIsPhoneDevice() itself -- MUI's useMediaQuery
+ * registers a matchMedia listener per call, and Message renders once per
+ * message. Threading it as a prop was the first attempt and it silently broke
+ * PinnedMessages, because nothing makes a render site supply it. A context is
+ * read the same way from anywhere, so a new render site cannot forget.
+ */
+const IsPhoneDeviceContext = createContext(false);
+
 function Message(props) {
-  // Taken from props, not useIsPhoneDevice(): MUI's useMediaQuery registers a
-  // matchMedia listener per call, and this component is rendered once per
-  // message, so a long game re-registers thousands of them per render pass.
-  const isPhoneDevice = props.isPhoneDevice;
+  const isPhoneDevice = useContext(IsPhoneDeviceContext);
   const user = useContext(UserContext);
   const theme = useTheme();
   const [isHovering, setIsHovering] = useState(false);
@@ -5609,9 +5615,6 @@ export function SpeechFilter() {
 
 export function PinnedMessages() {
   const game = useContext(GameContext);
-  // Message takes this as a prop rather than calling useIsPhoneDevice() itself,
-  // so every render site has to supply it. Once per list, not once per message.
-  const isPhoneDevice = useIsPhoneDevice();
 
   if (game.stateViewing < 0) return <></>;
 
@@ -5634,7 +5637,6 @@ export function PinnedMessages() {
     return (
       <Message
         message={message}
-        isPhoneDevice={isPhoneDevice}
         review={game.review}
         history={game.history}
         players={game.players}


### PR DESCRIPTION
Fixes the iOS freezes on ready check, phase changes and leaving a game.

## Cause

`AudioManager.load()` constructed an `HTMLAudioElement` and called `.load()` on
every entry it was handed. For Mafia that is **66 of them at once**, and the
music alone is **82MB across 62 files**.

Both calls return immediately, so this costs almost no JavaScript -- which is why
it does not look like a problem, and why timing the call clears it (it measures
1-3ms). What it actually does is hand 66 media resources to the platform in one
go, and iOS keeps a low ceiling on how many it will carry. Past that ceiling the
media pipeline blocks painting.

React had already committed the DOM by then -- consistently 42-66ms -- so the
page held **stale pixels** for the duration. That is why it looked stuck on the
loading screen with its animation frozen, and why the device got warm with no
JavaScript running.

## Measurements

iPhone 16, time from the phase-change socket event to the frame after the browser
paints:

| transition | before | after |
| --- | --- | --- |
| Pregame | 88599ms | 118ms |
| Postgame | 63991ms | 154ms |
| Night 1 | 2120ms | 132ms |
| ready check | 1791ms | 74ms |
| leaving a game | multi-second | 104ms |

Attributed by A/B: the same games with all audio disabled showed no transition
above 178ms, and re-enabling it reproduced the stalls exactly. Worst stall in a
full game on the final build is 176ms.

## What changed

**Music is created on first play; sound effects are preloaded as before.**

The split is by weight. All 26 effect files together are 1.5MB; the 62 music
tracks are 82MB. Music is the only part worth deferring and the only part that
stalled iOS. For Mafia this is 19 small elements up front instead of 66.

Making effects lazy as well was tried and reverted: a cue that is stopped shortly
after it starts was still fetching when the stop arrived and never made a sound.
The ready-check alarm is exactly that case -- `readyCheck success` stops it as
soon as everyone has readied.

Also in `AudioManager`:

- `play()` no longer assigns `currentTime` unless the track has actually
  advanced. That assignment forces a seek, measured at 156-220ms on an unbuffered
  track, and a freshly created element is already at zero.
- Elements are released on unmount. Nothing dropped these references before, so a
  session accumulated the elements of every game played in it.
- A lazily created element takes its volume from the last synced slider values,
  so it is correct at creation.

**`Message`** no longer calls `useIsPhoneDevice()`. MUI's `useMediaQuery`
registers a matchMedia listener per call, and `Message` renders once per message
without memoization, so every render pass re-registered one per message on
screen. Now computed once in `TextMeetingLayout` and passed down. `useLongPress`
also received a fresh arrow callback each render and keys its effect on it, so
that effect tore down and re-ran per message per pass; now stable.

## Scope and caveats

The `Message` commit is **not** backed by a measurement. It was found during the
investigation and is not what caused the freezes -- the reproduction case had no
player messages at all. It is included because one matchMedia listener per chat
message is worth removing regardless, and its cost scales with message count in a
way the short test games would not show. Separate commit, droppable without
affecting the fix.

Measurements were taken against a dev server on a LAN, not production. The
element count is the same in every environment, so the fix holds, but the
absolute numbers above are not production numbers.

Audio behaviour is unchanged from a player's perspective: join, ready check
alarm, ready pings, tick, bell, night music and win music all verified audible on
device.
