### PR TITLE
perf(profile): batch the profile fetch's 59 state updates into one render

### DIFF
--- a/react_main/src/components/Popover.jsx
+++ b/react_main/src/components/Popover.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext, useMemo } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import axios from "axios";
 
 import { GameStates } from "Constants";
@@ -74,12 +74,19 @@ export const InfoPopover = function ({
   icon,
   subTitle,
 }) {
+  // No hooks below this point, so the early return is safe.
+  //
+  // This used to call useMemo *after* the return, which changed the hook count
+  // whenever `content` flipped between null and non-null -- React rejects that
+  // with "rendered fewer hooks than expected". Its dependency list also left out
+  // popoverOpen, anchorEl and content, so it could hand back an element built
+  // from stale props. Dropping the memo fixes both; it was not saving anything
+  // worth the risk.
   if (content === null) {
     return <></>;
   }
 
-  return useMemo(
-    () => (
+  return (
       <Popover
         open={showPopover !== false && popoverOpen}
         sx={{ pointerEvents: openByClick ? "auto" : "none" }}
@@ -105,8 +112,6 @@ export const InfoPopover = function ({
       >
         <PopoverContent page={page} title={title} content={content} icon={icon} subTitle={subTitle} />
       </Popover>
-    ),
-    [openByClick, showPopover, Boolean(content !== null)]
   );
 };
 

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -1,3 +1,5 @@
+// React 17 does not batch state updates outside its own event handlers.
+import { unstable_batchedUpdates } from "react-dom";
 import React, { useState, useEffect, useContext, useRef, useMemo } from "react";
 import { Link, Navigate, useNavigate, useParams } from "react-router-dom";
 import axios from "axios";
@@ -341,6 +343,13 @@ export default function Profile() {
       axios
         .get(`/api/user/${userId}/profile`, { signal: controller.signal })
         .then((res) => {
+          // React 17 only batches state updates inside its own event handlers,
+          // not inside promise callbacks. This one runs 59 setState calls, so
+          // without batching the whole profile re-renders 59 times before it
+          // settles -- measured at ~3.4s of a ~4.3s profile load, roughly 80% of
+          // everything the page does. React 18 batches this automatically and
+          // this wrapper can go away with the upgrade.
+          unstable_batchedUpdates(() => {
           const resolvedId = res.data.id;
           setCanonicalUserId(resolvedId);
           setProfileLoaded(true);
@@ -425,6 +434,7 @@ export default function Profile() {
             loadUserFamily();
           }
           document.title = `${res.data.name}'s Profile | UltiMafia`;
+          });
         })
         .catch((e) => {
           if (


### PR DESCRIPTION
Loading a user profile took 1.1-1.7s, on every platform.

## Cause

Attributing each CPU sample to its owning component puts almost all of it in one
place:

```
(anon) [Profile.jsx:358]    3390ms of a 3996ms load   (~85%)
RoleCount [Roles.jsx:402]     70ms
Profile [Profile.jsx:188]     70ms
Setup [Setup.jsx:48]          56ms
```

`Profile.jsx:358` is the `.then()` of the profile fetch, and it runs **59
`setState` calls**. React 17 only batches updates inside its own event handlers,
not inside promise callbacks, so each one triggers a full synchronous re-render
of a page carrying roughly 150 role entries with their setups and hover cards.

The page rendered 59 times before it settled.

This is also why a file-level profile is misleading here: MUI and emotion
dominate the samples, but no component owns that time, because it is not one
expensive render -- it is the same render repeated.

## Measurements

Same build, same profile, before and after:

| | before | after |
| --- | --- | --- |
| owning frame (the `.then` callback) | 3390ms | **178ms** |
| longest task | 1670ms | **626ms** |
| tasks over 50ms, total | 8390ms | **3848ms** |

Traces captured with Chrome DevTools and attributed by walking each sample up to
its nearest application frame. Figures are from a development build, so the
absolute numbers are higher than production; a production trace of the unfixed
page showed the same shape, with three tasks of 1531/1234/1102ms.

## Changes

`unstable_batchedUpdates` around the fetch callback. React 18 batches this
automatically, so the wrapper can be removed with that upgrade -- there is a
comment saying so.

Also removes a broken `useMemo` in `InfoPopover`:

- It was called **after an early return**, so the hook count changed whenever
  `content` flipped between null and non-null. React rejects that with "rendered
  fewer hooks than expected".
- Its dependency list omitted `popoverOpen`, `anchorEl` and `content`, so it
  could return an element built from stale props.

Removed rather than corrected: it was not saving anything worth the risk. No
behaviour change.

## Notes for review

Only the fetch callback in Profile.jsx is batched. Other components have the same
pattern -- several `setState` calls in a promise callback -- and would benefit
the same way, but this is the one that showed up in the trace and the one that is
measured here.

`Roles.jsx` has two further conditional-`useMemo` violations (around lines 1202
and 1207) that predate this change and are untouched.

An earlier attempt at this fixed something else entirely: MUI `Popover`s are
mounted for every role on the page whether open or not, which looked like the
cause from a file-level profile. Gating them on `open` was worth about 20ms of
4000ms and is not included here.
