### PR TITLE
perf(profile): trim the profile page's chunk group and drop dead reCAPTCHA

### DIFF
--- a/react_main/public/index.html
+++ b/react_main/public/index.html
@@ -160,7 +160,23 @@
     </script>
 
     <link rel="stylesheet" href="/css/fontawesome.min.css" />
-    <script src="https://www.google.com/recaptcha/api.js?render=%REACT_APP_RECAPTCHA_KEY%"></script>
+    <!--
+      reCAPTCHA is currently disabled: verifyRecaptcha() in src/utils.jsx returns
+      before it ever touches window.grecaptcha, so nothing consumed this script.
+      It was still loading parser-blocking on every page (~189ms network + ~96ms
+      of main-thread eval) with an invalid site key, because the placeholder it
+      used was Create React App syntax (percent-delimited) and stopped being
+      substituted when this project moved to rsbuild, which uses EJS delimiters
+      like the assetPrefix references above.
+
+      To re-enable, all three of these are needed:
+        1. drop the early "return;" in verifyRecaptcha (src/utils.jsx)
+        2. restore the script tag, writing the key with EJS delimiters rather
+           than percent signs, and register it via html.templateParameters in
+           rsbuild.config.ts from loadEnv().rawPublicVars.REACT_APP_RECAPTCHA_KEY
+        3. make verifyRecaptcha tolerate window.grecaptcha being absent if the
+           tag is restored with async
+    -->
   </head>
 
   <body>

--- a/react_main/src/components/EmotePicker.jsx
+++ b/react_main/src/components/EmotePicker.jsx
@@ -1,5 +1,5 @@
-import React, { useContext, useState } from "react";
-import EmojiPicker from "emoji-picker-react";
+import React, { useContext, useState, Suspense, lazy } from "react";
+
 import {
   Box,
   Button,
@@ -18,6 +18,10 @@ import { usePopoverOpen } from "hooks/usePopoverOpen";
 import "css/emotes.css";
 
 import happy from "images/emotes/happy.webp";
+
+// emoji-picker-react is large and only ever renders inside the popover below,
+// so keep it out of the chunk every page with a comment box has to download.
+const EmojiPicker = lazy(() => import("emoji-picker-react"));
 
 function StickerPanel({ stickers, onSelect }) {
   if (!stickers.length) {
@@ -222,6 +226,7 @@ function EmotePicker({ onEmoteSelected, className = "", players }) {
           {panel === "stickers" ? (
             <StickerPanel stickers={stickers} onSelect={selectSticker} />
           ) : (
+            <Suspense fallback={null}>
             <EmojiPicker
               width="100%"
               height="80vh"
@@ -240,6 +245,7 @@ function EmotePicker({ onEmoteSelected, className = "", players }) {
                 "--epr-search-border-color": "var(--mui-palette-divider)",
               }}
             />
+            </Suspense>
           )}
         </Box>
       </Popover>

--- a/react_main/src/components/Setup.jsx
+++ b/react_main/src/components/Setup.jsx
@@ -71,31 +71,40 @@ export default function Setup(props) {
     !useRoleGroups &&
     props.setup.roles.length > 1;
 
-  // Prevent overflow
+  // Prevent overflow.
+  //
+  // This measures synchronously before paint, and a profile renders one Setup
+  // per game in the history list, so it is worth keeping cheap. offsetLeft /
+  // offsetWidth read the same layout information as getBoundingClientRect()
+  // without allocating a DOMRect per call, and all reads below happen with no
+  // interleaved writes so they resolve against a single layout pass.
   useLayoutEffect(() => {
-    if (!iconContainerRef.current.lastChild) {
+    const container = iconContainerRef.current;
+    if (!container || !container.lastChild) {
       return;
     }
 
-    const rContainer = iconContainerRef.current.getBoundingClientRect();
-    const rLastChild =
-      iconContainerRef.current.lastChild.getBoundingClientRect();
+    // Offsets are relative to the same offsetParent, so they are directly
+    // comparable and no absolute positioning is needed.
+    const containerRightOffset = container.offsetLeft + container.offsetWidth;
+    const lastChild = container.lastChild;
+    const lastChildRightOffset = lastChild.offsetLeft + lastChild.offsetWidth;
 
-    const containerRightOffset = rContainer.x + rContainer.width;
-    const lastChildRightOffset = rLastChild.x + rLastChild.width;
-
-    if (lastChildRightOffset > containerRightOffset) {
-      // If true, then component is overflowing. Determine the last child that fits and prune the rest.
-      var numFittingIcons = 0;
-      for (let child of iconContainerRef.current.children) {
-        const rChild = child.getBoundingClientRect();
-        const childRightOffset = rChild.x + rChild.width;
-        if (childRightOffset <= containerRightOffset) {
-          numFittingIcons++;
-        }
-      }
-      setMaxIconsPerRow(numFittingIcons);
+    if (lastChildRightOffset <= containerRightOffset) {
+      return; // Not overflowing — nothing to prune.
     }
+
+    // Children are laid out left to right, so the first one that overflows ends
+    // the run; no need to measure the remainder.
+    let numFittingIcons = 0;
+    for (const child of container.children) {
+      if (child.offsetLeft + child.offsetWidth > containerRightOffset) break;
+      numFittingIcons++;
+    }
+
+    // Skip the state update (and the extra render plus layout pass it forces)
+    // when the answer has not changed.
+    setMaxIconsPerRow((prev) => (prev === numFittingIcons ? prev : numFittingIcons));
   }, [iconContainerRef]);
 
   // Extract events from all setup types

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -1,6 +1,6 @@
 // React 17 does not batch state updates outside its own event handlers.
 import { unstable_batchedUpdates } from "react-dom";
-import React, { useState, useEffect, useContext, useRef, useMemo } from "react";
+import React, { useState, useEffect, useContext, useRef, useMemo, Suspense, lazy } from "react";
 import { Link, Navigate, useNavigate, useParams } from "react-router-dom";
 import axios from "axios";
 import update from "immutability-helper";
@@ -39,8 +39,6 @@ import Comments from "../Community/Comments";
 import "css/user.css";
 import { Modal } from "components/Modal";
 import CustomMarkdown from "components/CustomMarkdown";
-import ModerationSideDrawer from "components/ModerationSideDrawer";
-import ReportDialog from "../../components/ReportDialog";
 import RapSheet from "../../components/RapSheet";
 import TrophyCase from "components/TrophyCase";
 import { AchievementPanel } from "components/Achievements";
@@ -50,7 +48,6 @@ import Sparkline from "components/Sparkline";
 import PendingTradeConfirmations from "components/PendingTradeConfirmations";
 import CasePanel from "components/CasePanel";
 import { RoleCount } from "components/Roles";
-import { PieChart } from "./PieChart";
 import AdminVisuals from "./AdminVisuals";
 import { Loading } from "components/Loading";
 import { GameRow } from "pages/Play/LobbyBrowser/GameRow";
@@ -101,6 +98,17 @@ export {
 import { TIER_ICONS, getConservativeRank } from "utils/skillRating";
 
 
+
+
+// Each of these renders only behind a flag, but importing them statically put
+// their whole dependency tree in the chunk every profile view downloads:
+// ModerationSideDrawer drags in the Moderation page (commands.js alone is 40KB)
+// and RapSheet, and PieChart drags in d3.
+const ModerationSideDrawer = lazy(() => import("components/ModerationSideDrawer"));
+const ReportDialog = lazy(() => import("../../components/ReportDialog"));
+const PieChart = lazy(() =>
+  import("./PieChart").then((m) => ({ default: m.PieChart }))
+);
 
 function FavoritedRolesPanel({
   favoriteRoles = [],
@@ -1265,11 +1273,15 @@ export default function Profile() {
               >
                 <i className="fas fa-flag" />
               </IconButton>
-              <ReportDialog
-                open={reportDialogOpen}
-                onClose={() => setReportDialogOpen(false)}
-                prefilledArgs={{ userId: profileUserId, userName: name }}
-              />
+              {reportDialogOpen && (
+                <Suspense fallback={null}>
+                  <ReportDialog
+                    open={reportDialogOpen}
+                    onClose={() => setReportDialogOpen(false)}
+                    prefilledArgs={{ userId: profileUserId, userName: name }}
+                  />
+                </Suspense>
+              )}
               {isFriend && !pokesDisabled && !user.settings?.disablePokes && (
                 <>
                   {pokeStatus.status === "none" && (
@@ -1610,11 +1622,15 @@ export default function Profile() {
           setShow={setShowStatsModal}
         />
       )}
-      <ModerationSideDrawer
-        open={moderationDrawerOpen}
-        setOpen={setModerationDrawerOpen}
-        prefilledArgs={{ userId: profileUserId }}
-      />
+      {moderationDrawerOpen && (
+        <Suspense fallback={null}>
+          <ModerationSideDrawer
+            open={moderationDrawerOpen}
+            setOpen={setModerationDrawerOpen}
+            prefilledArgs={{ userId: profileUserId }}
+          />
+        </Suspense>
+      )}
       <Grid container rowSpacing={1} columnSpacing={1} className="profile">
         <Grid item xs={12}>
           <Stack
@@ -1964,11 +1980,13 @@ export default function Profile() {
                             Win/Loss Distribution
                           </Typography>
                           <Box sx={{ my: 1, display: "flex", justifyContent: "center" }}>
-                            <PieChart
-                              wins={getWins(mafiaStats)}
-                              losses={getLosses(mafiaStats)}
-                              abandons={getAbandons(mafiaStats)}
-                            />
+                            <Suspense fallback={null}>
+                              <PieChart
+                                wins={getWins(mafiaStats)}
+                                losses={getLosses(mafiaStats)}
+                                abandons={getAbandons(mafiaStats)}
+                              />
+                            </Suspense>
                           </Box>
                           <Typography variant="body2" sx={{ mt: 1, fontWeight: "bold" }}>
                             Wins: {Math.round((getWins(mafiaStats) / totalGames) * 100)}% ({getWins(mafiaStats)}W / {getLosses(mafiaStats)}L)

--- a/react_main/src/pages/User/User.jsx
+++ b/react_main/src/pages/User/User.jsx
@@ -1,31 +1,42 @@
-import React, { useContext } from "react";
+import React, { useContext, Suspense } from "react";
 
 import { Route, Routes, Navigate } from "react-router-dom";
 
-import Profile from "./Profile";
-import Settings from "./Settings";
-import Shop from "./Shop";
-import Inbox from "./Inbox";
-import Family from "./Family";
+import { lazyWithRetry } from "lib/lazyWithRetry";
+import { Loading } from "components/Loading";
 import { UserContext } from "Contexts";
 
 // Shared user widgets (Avatar, NameWithAvatar, MediaEmbed, ...) live in
 // ./UserWidgets so that importing them does not drag this route's page tree
 // (Profile/Settings/Shop/Inbox/Family and their deps) into the initial bundle.
 
+// These five are siblings behind a router, so importing them statically meant
+// viewing a profile also downloaded and evaluated Settings (and firebase/auth
+// with it), Shop, Inbox and Family. Declared at module scope, not in render, so
+// the component identities stay stable across re-renders.
+const Profile = lazyWithRetry(() => import("./Profile"));
+const Settings = lazyWithRetry(() => import("./Settings"));
+const Shop = lazyWithRetry(() => import("./Shop"));
+const Inbox = lazyWithRetry(() => import("./Inbox"));
+const Family = lazyWithRetry(() => import("./Family"));
+
 export default function User(props) {
   const user = useContext(UserContext);
 
   if (user.loaded && !user.loggedIn) return <Navigate to="/" />;
 
+  // Local boundary: without it the nearest fallback is the one in Main, which
+  // would blank the whole page (header and all) on every sub-route switch.
   return (
-    <Routes>
-      <Route path="/" element={<Profile />} />
-      <Route path="settings/*" element={<Settings />} />
-      <Route path="shop" element={<Shop />} />
-      <Route path="inbox" element={<Inbox />} />
-      <Route path="family/:familyId" element={<Family />} />
-      <Route path=":userId" element={<Profile />} />
-    </Routes>
+    <Suspense fallback={<Loading />}>
+      <Routes>
+        <Route path="/" element={<Profile />} />
+        <Route path="settings/*" element={<Settings />} />
+        <Route path="shop" element={<Shop />} />
+        <Route path="inbox" element={<Inbox />} />
+        <Route path="family/:familyId" element={<Family />} />
+        <Route path=":userId" element={<Profile />} />
+      </Routes>
+    </Suspense>
   );
 }

--- a/routes/user.js
+++ b/routes/user.js
@@ -761,19 +761,22 @@ router.get("/:id/profile", async function (req, res) {
         .select("userId user")
         .populate("user", "id name avatar");
 
-      // Add vanity URLs to friend requests
-      user.friendRequests = await Promise.all(
-        friendRequests.map(async (req) => {
-          const vanityUrl = await models.VanityUrl.findOne({
-            userId: req.user.id,
-          }).select("url -_id");
+      // Add vanity URLs to friend requests — one indexed $in lookup rather than
+      // one query per request.
+      const requestVanityUrls = await models.VanityUrl.find({
+        userId: { $in: friendRequests.map((req) => req.user.id) },
+      })
+        .select("url userId -_id")
+        .lean();
 
-          return {
-            ...req.user.toJSON(),
-            vanityUrl: vanityUrl?.url,
-          };
-        })
+      const requestVanityUrlByUserId = new Map(
+        requestVanityUrls.map((vanityUrl) => [vanityUrl.userId, vanityUrl.url])
       );
+
+      user.friendRequests = friendRequests.map((req) => ({
+        ...req.user.toJSON(),
+        vanityUrl: requestVanityUrlByUserId.get(req.user.id),
+      }));
     } else user.friendRequests = [];
 
     for (let game of user.games)
@@ -1175,27 +1178,25 @@ router.get("/:id/friends", async function (req, res) {
       ["friend", "id name avatar -_id"]
     );
 
-    friends = await Promise.all(
-      friends.map(async (friend) => {
-        friend = friend.toJSON();
+    friends = friends.map((friend) => friend.toJSON());
 
-        // Get vanity URL for friend
-        const vanityUrlObj = await models.VanityUrl.findOne({
-          userId: friend.friendId,
-        }).select("url -_id");
+    // One query for every friend's vanity URL rather than one query per friend.
+    // The userId index already exists, so this is a single indexed $in lookup.
+    const vanityUrls = await models.VanityUrl.find({
+      userId: { $in: friends.map((friend) => friend.friendId) },
+    })
+      .select("url userId -_id")
+      .lean();
 
-        let vanityUrl = null;
-        if (vanityUrlObj) {
-          vanityUrl = vanityUrlObj.url;
-        }
-
-        return {
-          ...friend.friend,
-          lastActive: friend.lastActive,
-          vanityUrl: vanityUrl,
-        };
-      })
+    const vanityUrlByUserId = new Map(
+      vanityUrls.map((vanityUrl) => [vanityUrl.userId, vanityUrl.url])
     );
+
+    friends = friends.map((friend) => ({
+      ...friend.friend,
+      lastActive: friend.lastActive,
+      vanityUrl: vanityUrlByUserId.get(friend.friendId) ?? null,
+    }));
 
     res.send(friends);
   } catch (e) {


### PR DESCRIPTION
Profiling a fresh profile load found the profile's *own* data request not starting until **1805 ms**, stuck behind a four-stage serial chain, with first meaningful paint at 2224 ms:

```
0–785ms     bundle download + eval
785–1104ms  10 bootstrap APIs
1042–1163ms route chunk requested (gated by the loading flag)
1184–1456ms ~20 more async chunks (304ms to evaluate)
1805ms      /api/user/:id/profile  ← finally
```

## Changes

### 1. Remove the reCAPTCHA script

`verifyRecaptcha()` in `src/utils.jsx` has a bare `return;` on its first line, so the `window.grecaptcha` calls below it are unreachable — **reCAPTCHA is already disabled**. It is the only consumer (`Auth.jsx` calls it six times, all no-ops), and `setCaptchaVisible` already guards with `if (el)`.

The script was nevertheless loading parser-blocking in `<head>` on **every page**: ~189 ms network plus ~96 ms of main-thread eval, making it the second-largest task in the trace. It was also initialising with an invalid site key, because `%REACT_APP_RECAPTCHA_KEY%` is Create React App placeholder syntax that silently stopped being substituted when this project moved to rsbuild — the rest of `index.html` correctly uses EJS. The tag is removed and a comment records the three things re-enabling would need.

Worth flagging separately: if captcha is meant to be active in production, it has been broken there on both counts.

### 2. Split the User sub-routes

`User.jsx` routes between Profile/Settings/Shop/Inbox/Family but imported all five statically, so viewing a profile also downloaded and evaluated `Settings.jsx` (67 KB) and `firebase/auth` with it. Now `lazyWithRetry` at module scope with a local Suspense boundary, so switching sub-routes doesn't blank the header.

| User route shell | Before | After |
|---|---|---|
| Modules / source | 135 / 1245 KB | **14 / 67 KB** |
| Heavy deps | `firebase/auth` | **none** |

### 3. Defer the profile's on-demand pieces

`ModerationSideDrawer`, `ReportDialog` and `PieChart` each render behind a flag but were imported statically. Now lazy and mounted only when open. `EmojiPicker` gets the same treatment inside `EmotePicker`, where it already only rendered inside the popover — just the import was eager.

| Profile.jsx static graph | Before | After |
|---|---|---|
| Modules / source | 125 / 1097 KB | **111 / 990 KB** |
| `d3` | static | **lazy** |
| Policy tree (`commands.js` 40 KB, ModActions, GroupPanels, RapSheet) | static | **gone** |

### 4. Batch the vanity URL lookups

`/:id/friends` issued one `VanityUrl.findOne()` per friend inside a `.map(async …)` — the slowest request on the page at 387 ms. The identical pattern sat in the `/profile` handler for friend requests. Both are now a single indexed `$in` (the `userId` index already exists).

Measured against the running Redis/Mongo: **387 ms → 201 ms**.

### 5. Make Setup's overflow measurement cheaper

`Setup.jsx`'s `useLayoutEffect` measures synchronously before paint, and a profile renders one `<Setup>` per game in the history list — the trace showed 175 ms across 46 layout passes, with 47 ms of self time in this one function. It now uses `offsetLeft`/`offsetWidth` instead of allocating a `DOMRect` per child, returns early when nothing overflows, stops at the first child that does rather than measuring all of them, and skips the state update — and the render plus layout pass it forces — when the count is unchanged.

## Results

Profile page, dev build before → production build after:

| | Before | After |
|---|---|---|
| FCP | 158.9 ms | 125.5 ms |
| LCP | 1124.9 ms | 558.5 ms |
| loadEventStart | 1717.2 ms | 697.3 ms |
| **FMP** | **2223.9 ms** | **1008.0 ms** |
| Main thread busy | 2370 ms | 1137 ms |
| `/profile` requested at | 1805 ms | **785 ms** |

**These two traces are not a clean comparison** — the "after" is a production build and the "before" was the dev server, so minification does a large share of that. The one change isolated cleanly is the `/friends` N+1 (387 ms → 201 ms), since minification doesn't touch the backend. The reCAPTCHA removal and change 5 landed after that trace and are not reflected in it at all.

## Testing

- Production build clean; `npm run lint` at baseline (0 errors).
- Headless Chrome across `/user/:id`, `/play`, `/policy/moderation`, `/community/forums`: **0 exceptions**, all render. Remaining console output is pre-existing and unrelated (`stampTrades` 500s, a `modCommands` warning).
- Verified no reCAPTCHA script tag remains in the built HTML, and the three legitimate `assetPrefix` EJS substitutions still resolve.
- Verified `d3` and the Policy tree are absent from Profile's static graph.

## Notes for reviewers

- **Change 5 is the one I'd scrutinise.** The 175 ms comes from ~46 layout passes across many `<Setup>` rows, and the reads inside a single effect were already batched against one layout, so the win may be modest — it needs a trace to confirm rather than reasoning. The overflow-pruning is also visual, so it's worth a look on a profile with a long game history, and on mobile where `wrapIcons` takes over.
- **`react-mde` is still static in Profile**, via `TextEditor` for bio and comment input. It renders visibly, so deferring it trades load time for a blank editor box — left alone deliberately.
- The remaining serial chain is untouched: first render still waits on all ten bootstrap APIs (`loading = isUserLoading || isSiteInfoLoading` in `Main.jsx`), which is what keeps the route chunk from being requested earlier. That is the next structural win and wants its own PR.

