### PR TITLE
fix(markdown): restore paragraph spacing lost when <p> became <div>

### DIFF
--- a/react_main/src/components/CustomMarkdown.jsx
+++ b/react_main/src/components/CustomMarkdown.jsx
@@ -6,6 +6,11 @@ import { MediaEmbed } from "pages/User/UserWidgets";
 import { SiteInfoContext } from "../Contexts";
 import { InlineRoleMention } from "./Roles";
 
+// The component that renders markdown owns the stylesheet for it. It was
+// previously imported only by Form.jsx, so after the route-level code splitting
+// it was not guaranteed to be loaded on every page that renders markdown.
+import "css/markdown.css";
+
 // Spoiler component that hides content until clicked
 function Spoiler({ children }) {
   const [revealed, setRevealed] = useState(false);
@@ -333,12 +338,20 @@ export default function CustomMarkdown(props) {
           return <MediaEmbed mediaUrl={properties.src} />;
         },
         p(properties) {
-          const { node, ...rest } = properties;
+          const { node, className, ...rest } = properties;
           // div, not p: MediaEmbed and {center} render block divs.
           // <p><div> is invalid HTML; Safari/Chrome repair it and React
           // puts it back, which flashes p tags and can lock the donor page.
+          //
+          // Carries md-paragraph so the .md-content paragraph rules still apply.
+          // Switching the tag silently dropped them, and the `margin: 1em 0`
+          // that replaced them was not equivalent: the stylesheet asks for no
+          // top margin, 15px below, and none at all on the last paragraph.
           return (
-            <div {...rest} style={{ margin: "1em 0", ...(rest.style || {}) }}>
+            <div
+              {...rest}
+              className={["md-paragraph", className].filter(Boolean).join(" ")}
+            >
               {roleifyMarkdown(
                 emotify(
                   mentionify(

--- a/react_main/src/css/markdown.css
+++ b/react_main/src/css/markdown.css
@@ -42,13 +42,19 @@
   color: var(--scheme-color-text);
 }
 
-.md-content p {
+/* CustomMarkdown renders paragraphs as div.md-paragraph rather than <p>, because
+   a paragraph may contain block content (media embeds, {center}) and <p><div> is
+   invalid HTML that browsers silently repair. Both selectors are kept so the
+   rules survive either representation. */
+.md-content p,
+.md-content .md-paragraph {
   margin: 0px 0px 15px 0px;
 
   white-space: pre-wrap;
 }
 
-.md-content p:last-child {
+.md-content p:last-child,
+.md-content .md-paragraph:last-child {
   margin-bottom: 0px;
 }
 


### PR DESCRIPTION
Comments, bios and anything else rendering markdown gained vertical space above
and below every paragraph.

## Cause

#2981 changed `CustomMarkdown`'s paragraph renderer from `<p>` to `<div>`, for a
good reason: a paragraph can contain a media embed or a `{center}` block, and
`<p><div>` is invalid HTML that browsers silently repair.

The tag change also took the element out of `.md-content p`, and the inline
`margin: 1em 0` added in its place is not what that rule says:

| | top | bottom |
| --- | --- | --- |
| `.md-content p` | 0 | 15px |
| `.md-content p:last-child` | 0 | 0 |
| inline replacement | 16px | 16px |

So every paragraph gained a 16px top margin it never had, and the last paragraph
gained a trailing 16px.

The same rule sets `white-space: pre-wrap`, which went with it -- so single
newlines inside a paragraph stopped being preserved. That is the less visible
half of the regression.

## Fix

The div carries `md-paragraph`, and both rules match either representation:

```css
.md-content p,
.md-content .md-paragraph { ... }
```

Keeping the `p` selector means the rules still apply if the tag ever changes
back.

`markdown.css` is now imported by `CustomMarkdown` itself. It was imported only
by `Form.jsx`, so after the route-level code splitting in #3003 the stylesheet
was not guaranteed to be loaded on every page that renders markdown -- a
paragraph in a bio could be styled or not depending on what else the route
pulled in.

## Checking it

Any markdown surface -- a comment, a profile bio, a forum post. A multi-paragraph
one shows it most clearly: paragraphs should sit 15px apart with no gap above the
first or below the last, and a single newline inside a paragraph should stay a
line break.
