### PR TITLE
feat(game): Comic Sans custom font option for username

### DIFF
--- a/data/constants.js
+++ b/data/constants.js
@@ -357,6 +357,7 @@ module.exports = {
     "georgia",
     "trebuchet",
     "verdana",
+    "comic",
     "bettynoir",
     "autophobia",
     "spooky",

--- a/react_main/src/constants/nameCosmetics.js
+++ b/react_main/src/constants/nameCosmetics.js
@@ -7,6 +7,7 @@ export const NAME_FONT_STACKS = {
   georgia: "Georgia, 'Times New Roman', serif",
   trebuchet: "'Trebuchet MS', 'Segoe UI', sans-serif",
   verdana: "Verdana, Geneva, sans-serif",
+  comic: '"Comic Sans MS", "Comic Sans", "Chalkboard SE", cursive',
   bettynoir: "BettyNoir, Georgia, serif",
   autophobia: "Autophobia, cursive",
   spooky: "Spooky, cursive",

--- a/react_main/src/css/user.css
+++ b/react_main/src/css/user.css
@@ -329,6 +329,10 @@ iframe {
 .user-name.name-font-verdana .user-name-text {
   font-family: Verdana, Geneva, sans-serif !important;
 }
+.user-name.name-font-comic,
+.user-name.name-font-comic .user-name-text {
+  font-family: "Comic Sans MS", "Comic Sans", "Chalkboard SE", cursive !important;
+}
 .user-name.name-font-bettynoir,
 .user-name.name-font-bettynoir .user-name-text {
   font-family: BettyNoir, Georgia, serif !important;

--- a/react_main/src/pages/User/Settings.jsx
+++ b/react_main/src/pages/User/Settings.jsx
@@ -778,6 +778,11 @@ export default function Settings() {
           fontFamily: "Verdana, Geneva, sans-serif",
         },
         {
+          label: "Comic Sans",
+          value: "comic",
+          fontFamily: '"Comic Sans MS", "Comic Sans", "Chalkboard SE", cursive',
+        },
+        {
           label: "Betty Noir",
           value: "bettynoir",
           fontFamily: "BettyNoir, Georgia, serif",


### PR DESCRIPTION
Closes #2998

Adds **Comic Sans** to Custom Name Font (player list + chat nameplates).

Uses the system Comic Sans stack (`Comic Sans MS` / `Chalkboard SE` fallback), same pattern as Georgia / Trebuchet / Verdana. Anyone who already owns Custom Name Font can pick it in Settings.

**Test**
1. Own Custom Name Font (Shop).
2. Settings → Name Font → Comic Sans.
3. Confirm the dropdown preview and in-game player list / chat nameplate use Comic Sans.