### PR TITLE
fix(site): per-avatar version cache busting and 24h uploads cache TTL

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -865,6 +865,7 @@ module.exports = class Game {
       userId: player.user.id,
       name: player.name,
       avatar: player.user.avatar,
+      avatarVersion: player.user.avatarVersion,
       emojis: player.user.emojis,
       textColor: player.user.textColor,
       nameColor: player.user.nameColor,

--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -956,6 +956,7 @@ module.exports = class Player {
       name: this.name,
       userId: this.user.id,
       avatar: this.user.avatar,
+      avatarVersion: this.user.avatarVersion,
       textColor: this.user.textColor,
       nameColor: this.user.nameColor,
       nameFont: this.user.nameFont,

--- a/Games/core/User.js
+++ b/Games/core/User.js
@@ -7,6 +7,7 @@ module.exports = class User {
     this.socket = props.socket;
     this.name = props.name;
     this.avatar = props.avatar;
+    this.avatarVersion = props.avatarVersion || 0;
     this.deathSound = props.deathSound;
     this.deathSoundExt = props.deathSoundExt || "ogg";
     this.dev = props.dev;

--- a/Games/games.js
+++ b/Games/games.js
@@ -109,7 +109,7 @@ var deprecated = false;
               deleted: false,
             })
               .select(
-                "id name avatar deathSound deathSoundExt settings customEmotes customStickers dev itemsOwned rankedCount competitiveCount stats achievements playedGame birthday referrer dailyChallenges dailyChallengesCompleted"
+                "id name avatar avatarVersion deathSound deathSoundExt settings customEmotes customStickers dev itemsOwned rankedCount competitiveCount stats achievements playedGame birthday referrer dailyChallenges dailyChallengesCompleted"
               )
               .populate([
                 {
@@ -174,6 +174,7 @@ var deprecated = false;
               user.id = shortid.generate();
               user.name = null;
               user.avatar = false;
+              user.avatarVersion = 0;
             }
 
             if (!game || !(await redis.gameExists(gameId))) {

--- a/Games/types/LiarsDice/Game.js
+++ b/Games/types/LiarsDice/Game.js
@@ -971,6 +971,7 @@ module.exports = class LiarsDiceGame extends Game {
           userId: player.user.id,
           playerName: player.name,
           avatar: player.user.avatar,
+          avatarVersion: player.user.avatarVersion,
           rolledDice: player.rolledDice,
           previousRolls: player.previousRolls,
         });

--- a/db/schemas.js
+++ b/db/schemas.js
@@ -63,6 +63,8 @@ var schemas = {
     discordName: String,
     discordUsername: String,
     avatar: Boolean,
+    // Timestamp of last avatar change; used for per-avatar cache busting
+    avatarVersion: { type: Number, default: 0 },
     deathSound: Boolean,
     // File extension for custom death sound (mp3, ogg, wav, webm)
     deathSoundExt: { type: String, default: "ogg" },
@@ -920,6 +922,8 @@ var schemas = {
     id: { type: String, index: true, unique: true },
     name: { type: String, required: true, maxlength: 20 },
     avatar: { type: Boolean, default: false },
+    // Timestamp of last avatar change; used for per-avatar cache busting
+    avatarVersion: { type: Number, default: 0 },
     // Family page header banner (3:1, like profile banners)
     banner: { type: Boolean, default: false },
     bannerExt: { type: String, default: "webp" },

--- a/modules/chat.js
+++ b/modules/chat.js
@@ -64,7 +64,7 @@ const channelMembers = {};
               .select("name public memberIds members -_id")
               .populate(
                 "members",
-                "id name avatar settings.nameColor settings.textColor -_id"
+                "id name avatar avatarVersion settings.nameColor settings.textColor -_id"
               );
 
             if (!channel) return;
@@ -325,7 +325,7 @@ const channelMembers = {};
               name: new RegExp(query, "i"),
               deleted: false,
             })
-              .select("id name avatar -_id")
+              .select("id name avatar avatarVersion -_id")
               .limit(constants.chatUserSearchAmt)
               .sort("name");
             users = users.map((user) => user.toJSON());

--- a/modules/hallOfFame.js
+++ b/modules/hallOfFame.js
@@ -245,7 +245,7 @@ async function buildRows() {
     playedGame: true,
   })
     .select(
-      "id name avatar stats winRate kudos karma points championshipPoints achievementCount achievements settings skillRating"
+      "id name avatar avatarVersion stats winRate kudos karma points championshipPoints achievementCount achievements settings skillRating"
     )
     .lean();
 
@@ -289,6 +289,7 @@ async function buildRows() {
       userId: user.id,
       username: user.name,
       avatar: Boolean(user.avatar),
+      avatarVersion: user.avatarVersion || 0,
       vanityUrl: vanityUrlMap[user.id] || "",
       trophies: trophyData.trophies,
       trophyScore: trophyData.trophyScore,
@@ -367,6 +368,7 @@ function buildResponseRows(rows) {
       userId: row.userId,
       username: row.username,
       avatar: row.avatar,
+      avatarVersion: row.avatarVersion,
       vanityUrl: row.vanityUrl,
       rank: row.rank,
       trophies: row.trophies,

--- a/modules/redis.js
+++ b/modules/redis.js
@@ -183,7 +183,7 @@ async function cacheUserInfo(userId, reset) {
 
     var user = await models.User.findOne({ id: userId, deleted: false })
       .select(
-        "_id id name avatar deathSound deathSoundExt banner forumBanner profileBackground blockedUsers settings customEmotes customStickers itemsOwned nameChanged bdayChanged birthday pronouns achievements redHearts goldHearts points dailyChallengesCompleted dailyChallenges joined lastActive"
+        "_id id name avatar avatarVersion deathSound deathSoundExt banner forumBanner profileBackground blockedUsers settings customEmotes customStickers itemsOwned nameChanged bdayChanged birthday pronouns achievements redHearts goldHearts points dailyChallengesCompleted dailyChallenges joined lastActive"
       )
       .populate([
         {
@@ -235,6 +235,10 @@ async function cacheUserInfo(userId, reset) {
     await client.setAsync(`user:${userId}:info:id`, userId);
     await client.setAsync(`user:${userId}:info:name`, user.name);
     await client.setAsync(`user:${userId}:info:avatar`, user.avatar || false);
+    await client.setAsync(
+      `user:${userId}:info:avatarVersion`,
+      user.avatarVersion || 0
+    );
     await client.setAsync(
       `user:${userId}:info:deathSound`,
       user.deathSound || false
@@ -307,6 +311,7 @@ async function cacheUserInfo(userId, reset) {
   client.expire(`user:${userId}:info:id`, 3600);
   client.expire(`user:${userId}:info:name`, 3600);
   client.expire(`user:${userId}:info:avatar`, 3600);
+  client.expire(`user:${userId}:info:avatarVersion`, 3600);
   client.expire(`user:${userId}:info:deathSound`, 3600);
   client.expire(`user:${userId}:info:deathSoundExt`, 3600);
   client.expire(`user:${userId}:info:forumBanner`, 3600);
@@ -337,6 +342,7 @@ async function deleteUserInfo(userId) {
   await client.delAsync(`user:${userId}:info:id`);
   await client.delAsync(`user:${userId}:info:name`);
   await client.delAsync(`user:${userId}:info:avatar`);
+  await client.delAsync(`user:${userId}:info:avatarVersion`);
   await client.delAsync(`user:${userId}:info:deathSound`);
   await client.delAsync(`user:${userId}:info:deathSoundExt`);
   await client.delAsync(`user:${userId}:info:forumBanner`);
@@ -372,6 +378,7 @@ async function getUserInfo(userId) {
       `user:${userId}:info:id`,
       `user:${userId}:info:name`,
       `user:${userId}:info:avatar`,
+      `user:${userId}:info:avatarVersion`,
       `user:${userId}:info:deathSound`,
       `user:${userId}:info:deathSoundExt`,
       `user:${userId}:info:forumBanner`,
@@ -403,6 +410,7 @@ async function getUserInfo(userId) {
     id,
     name,
     avatar,
+    avatarVersion,
     deathSound,
     deathSoundExt,
     forumBanner,
@@ -433,6 +441,7 @@ async function getUserInfo(userId) {
   info.id = id;
   info.name = name;
   info.avatar = avatar === "true";
+  info.avatarVersion = Number(avatarVersion || 0);
   info.deathSound = deathSound === "true";
   info.deathSoundExt = deathSoundExt || "ogg";
   info.forumBanner = forumBanner === "true";
@@ -496,6 +505,7 @@ async function getBasicUserInfo(userId, delTemplate) {
       id: userId,
       name: "[deleted]",
       avatar: false,
+      avatarVersion: 0,
       status: "offline",
       groups: [],
       settings: {},
@@ -506,6 +516,9 @@ async function getBasicUserInfo(userId, delTemplate) {
   info.id = await client.getAsync(`user:${userId}:info:id`);
   info.name = await client.getAsync(`user:${userId}:info:name`);
   info.avatar = (await client.getAsync(`user:${userId}:info:avatar`)) == "true";
+  info.avatarVersion = Number(
+    (await client.getAsync(`user:${userId}:info:avatarVersion`)) || 0
+  );
   info.forumBanner =
     (await client.getAsync(`user:${userId}:info:forumBanner`)) == "true";
   info.joined = Number((await client.getAsync(`user:${userId}:info:joined`)) || 0);
@@ -605,7 +618,7 @@ async function getLeaderBoardStat(field) {
     // Query the top 100 users for a given field
     const leadingUsers = await models.User.find({ deleted: false })
       .select(
-        "id name avatar kudos karma championshipPoints achievementCount winRate dailyChallengesCompleted _id"
+        "id name avatar avatarVersion kudos karma championshipPoints achievementCount winRate dailyChallengesCompleted _id"
       )
       .sort(sortBy)
       .limit(100);
@@ -668,7 +681,7 @@ async function getFeaturedSetup(featuredCategory) {
         .select(
           "id gameType name roles closed useRoleGroups roleGroupSizes count total featured -_id"
         )
-        .populate("creator", "id name avatar tag -_id");
+        .populate("creator", "id name avatar avatarVersion tag -_id");
 
       const hoursSinceEpoch = Math.floor(Date.now() / (1000 * 60 * 60));
       const index = hoursSinceEpoch % setups.length;
@@ -1060,6 +1073,7 @@ async function getGameInfo(gameId, idsOnly) {
           name: "[Guest]",
           id: "",
           avatar: false,
+          avatarVersion: 0,
         });
       }
     }
@@ -1076,6 +1090,7 @@ async function getGameInfo(gameId, idsOnly) {
           name: "[Guest]",
           id: "",
           avatar: false,
+          avatarVersion: 0,
         });
       }
     }

--- a/react_main/nginx.conf
+++ b/react_main/nginx.conf
@@ -39,7 +39,7 @@ server {
 	
 	location ^~ /uploads/ {
 		alias /uploads/;
-		expires 30d;
+		expires 24h;
 		add_header Cache-Control "public, no-transform";
 	}
 

--- a/react_main/src/components/Basic.jsx
+++ b/react_main/src/components/Basic.jsx
@@ -398,6 +398,7 @@ function InlineAvatar(props) {
   const siteInfo = useContext(SiteInfoContext);
   const photoSrc = useAvatarImageUrl(props.userId, {
     cacheVal: siteInfo?.cacheVal,
+    avatarVersion: props.avatarVersion,
   });
   let style = {
     position: "relative",

--- a/react_main/src/components/EmoteReactions.jsx
+++ b/react_main/src/components/EmoteReactions.jsx
@@ -202,6 +202,7 @@ export function EmoteReactions(props) {
                   name={reactor.name}
                   vanityUrl={reactor.vanityUrl}
                   avatar={reactor.avatar}
+                  avatarVersion={reactor.avatarVersion}
                 />
               ))
             ) : (

--- a/react_main/src/components/Miniprofile.jsx
+++ b/react_main/src/components/Miniprofile.jsx
@@ -134,6 +134,7 @@ function Miniprofile(props) {
                 hasImage={avatar}
                 id={id}
                 avatarId={avatarId}
+                avatarVersion={user.avatarVersion}
                 name={name}
               />
               <div

--- a/react_main/src/components/PendingTradeConfirmations.jsx
+++ b/react_main/src/components/PendingTradeConfirmations.jsx
@@ -275,6 +275,7 @@ export default function PendingTradeConfirmations({
                       id={t.other.id}
                       name={t.other.name}
                       avatar={t.other.avatar}
+                      avatarVersion={t.other.avatarVersion}
                       small
                     />
                   ) : (

--- a/react_main/src/components/Popover.jsx
+++ b/react_main/src/components/Popover.jsx
@@ -265,6 +265,7 @@ export function parseSetupPopover(setup, siteInfo, gameTypeOptions = {}) {
         id={setup.creator.id}
         name={setup.creator.name}
         avatar={setup.creator.avatar}
+        avatarVersion={setup.creator.avatarVersion}
       />
     );
     result.push(<InfoRow title="Created By" content={name} key="createdBy" />);
@@ -595,6 +596,7 @@ export function parseDeckPopover(deck) {
         id={deck.creator.id}
         name={deck.creator.name}
         avatar={deck.creator.avatar}
+        avatarVersion={deck.creator.avatarVersion}
       />
     );
     result.push(<InfoRow title="Created By" content={name} key="createdBy" />);
@@ -624,6 +626,7 @@ export function parseDeckPopover(deck) {
             name={profile.name}
             avatar={profile.avatar !== undefined}
             avatarId={profile.id}
+            avatarVersion={profile.avatarVersion}
           />
         );
       })}
@@ -700,6 +703,7 @@ export function parseGamePopover(game) {
         id: player.id,
         name: player.name,
         avatar: player.avatar,
+        avatarVersion: player.avatarVersion,
       };
     } else {
       // Guest

--- a/react_main/src/components/RapSheet.jsx
+++ b/react_main/src/components/RapSheet.jsx
@@ -206,6 +206,7 @@ function VerdictDialog({
                   id={report.reportedUserId}
                   name={report.reportedUserName}
                   avatar={report.reportedUserAvatar}
+                  avatarVersion={report.reportedUserAvatarVersion}
                 />
               </Box>
             </Box>

--- a/react_main/src/components/RecentForumReplies.jsx
+++ b/react_main/src/components/RecentForumReplies.jsx
@@ -100,6 +100,7 @@ export function RecentForumReplies() {
                   hasImage={item.user?.avatar}
                   id={item.user?.id}
                   name={item.user?.name}
+                  avatarVersion={item.user?.avatarVersion}
                 />
                 <Box
                   sx={{
@@ -151,6 +152,7 @@ export function RecentForumReplies() {
                   hasImage={item.user?.avatar}
                   id={item.user?.id}
                   name={item.user?.name}
+                  avatarVersion={item.user?.avatarVersion}
                 />
                 <Box
                   sx={{

--- a/react_main/src/components/RecentTradesFeed.jsx
+++ b/react_main/src/components/RecentTradesFeed.jsx
@@ -164,6 +164,7 @@ export default function RecentTradesFeed() {
                         id={t.initiator?.id}
                         name={t.initiator?.name}
                         avatar={t.initiator?.avatar}
+                        avatarVersion={t.initiator?.avatarVersion}
                         small
                       />
                     </Box>
@@ -221,6 +222,7 @@ export default function RecentTradesFeed() {
                         id={t.initiator?.id}
                         name={t.initiator?.name}
                         avatar={t.initiator?.avatar}
+                        avatarVersion={t.initiator?.avatarVersion}
                         small
                       />
                     </Box>
@@ -259,6 +261,7 @@ export default function RecentTradesFeed() {
                         id={t.recipient?.id}
                         name={t.recipient?.name}
                         avatar={t.recipient?.avatar}
+                        avatarVersion={t.recipient?.avatarVersion}
                         small
                       />
                     </Box>
@@ -278,6 +281,7 @@ export default function RecentTradesFeed() {
               id={respondingTo?.initiator?.id}
               name={respondingTo?.initiator?.name}
               avatar={respondingTo?.initiator?.avatar}
+              avatarVersion={respondingTo?.initiator?.avatarVersion}
               small
             />
             <Typography variant="body1">'s</Typography>

--- a/react_main/src/components/ReportDetail.jsx
+++ b/react_main/src/components/ReportDetail.jsx
@@ -296,6 +296,7 @@ export default function ReportDetail({
                           id={r.id}
                           name={r.name || r.id}
                           avatar={r.avatar}
+                          avatarVersion={r.avatarVersion}
                         />
                         {(r.rule || r.description) && (
                           <Box sx={{ mt: 1, pl: 0 }}>
@@ -335,6 +336,7 @@ export default function ReportDetail({
                       id={report.reporterId}
                       name={report.reporterName || report.reporterId}
                       avatar={report.reporterAvatar}
+                      avatarVersion={report.reporterAvatarVersion}
                     />
                   </>
                 )}
@@ -347,6 +349,7 @@ export default function ReportDetail({
                   id={report.reportedUserId}
                   name={report.reportedUserName || report.reportedUserId}
                   avatar={report.reportedUserAvatar}
+                  avatarVersion={report.reportedUserAvatarVersion}
                 />
               </Box>
               <RapSheet userId={report.reportedUserId} />
@@ -709,6 +712,7 @@ export default function ReportDetail({
                       id={assigneeId}
                       name={assigneeName}
                       avatar={assigneeAvatar}
+                      avatarVersion={assignee.avatarVersion}
                     />
                   );
                 })}

--- a/react_main/src/components/StampTradeModal.jsx
+++ b/react_main/src/components/StampTradeModal.jsx
@@ -188,6 +188,7 @@ export default function StampTradeModal({
                       id={t.initiator?.id}
                       name={t.initiator?.name}
                       avatar={t.initiator?.avatar}
+                      avatarVersion={t.initiator?.avatarVersion}
                       noLink
                       small
                     />
@@ -241,6 +242,7 @@ export default function StampTradeModal({
                         id={f.id}
                         name={f.name}
                         avatar={f.avatar}
+                        avatarVersion={f.avatarVersion}
                         noLink
                         small
                       />

--- a/react_main/src/components/Strategies.jsx
+++ b/react_main/src/components/Strategies.jsx
@@ -351,6 +351,7 @@ function StrategiesBase({
                   <NameWithAvatar
                     small
                     id={strategy.author.id}
+                    avatarVersion={strategy.author.avatarVersion}
                     name=" "
                     avatar={strategy.author.avatar}
                     groups={strategy.author.groups}

--- a/react_main/src/components/TradeDialog.jsx
+++ b/react_main/src/components/TradeDialog.jsx
@@ -119,11 +119,12 @@ export default function TradeDialog({ open, onClose, stock, initialType = "buy",
       <DialogTitle sx={{ fontWeight: "bold", borderBottom: 1, borderColor: "divider", pb: 2 }}>
         <Stack direction="row" spacing={1.5} alignItems="center">
           {stock.targetType === "player" ? (
-            <Avatar id={stock.id} name={stock.name} hasImage={stock.avatar} size={40} />
+            <Avatar id={stock.id} name={stock.name} hasImage={stock.avatar} avatarVersion={stock.avatarVersion} size={40} />
           ) : (
             stock.avatar ? (
               <FamilyAvatarImage
                 id={stock.id}
+                avatarVersion={stock.avatarVersion}
                 size={40}
                 cacheVal={siteInfo?.cacheVal}
                 extraStyle={{ border: "1px solid rgba(255, 255, 255, 0.12)" }}

--- a/react_main/src/components/VoteWidget.jsx
+++ b/react_main/src/components/VoteWidget.jsx
@@ -171,6 +171,7 @@ export function VoteWidget(props) {
               name={e.voter.name}
               vanityUrl={e.voter.vanityUrl}
               avatar={e.voter.avatar}
+              avatarVersion={e.voter.avatarVersion}
             />
           ))}
           {upvoters.length === 0 && (
@@ -184,6 +185,7 @@ export function VoteWidget(props) {
               name={e.voter.name}
               vanityUrl={e.voter.vanityUrl}
               avatar={e.voter.avatar}
+              avatarVersion={e.voter.avatarVersion}
             />
           ))}
           {downvoters.length === 0 && (

--- a/react_main/src/components/gameComponents/Newspaper.jsx
+++ b/react_main/src/components/gameComponents/Newspaper.jsx
@@ -70,6 +70,7 @@ export default function Newspaper(props) {
                     id={players[0].id}
                     hasImage={players[0].avatar}
                     avatarId={players[0].avatarId}
+                    avatarVersion={players[0].avatarVersion}
                     name={players[0].name}
                     large
                     isSquare
@@ -152,6 +153,7 @@ export default function Newspaper(props) {
                       id={player.id}
                       hasImage={player.avatar}
                       avatarId={player.avatarId}
+                      avatarVersion={player.avatarVersion}
                       name={player.name}
                       isSquare
                       mediumlarge={avatarSizeProp === "mediumlarge"}
@@ -196,6 +198,7 @@ export default function Newspaper(props) {
             id={death.id}
             hasImage={death.avatar}
             avatarId={death.avatarId}
+            avatarVersion={death.avatarVersion}
             name={death.name}
             large
             isSquare

--- a/react_main/src/pages/Activity/ActivityRow.jsx
+++ b/react_main/src/pages/Activity/ActivityRow.jsx
@@ -137,6 +137,7 @@ export default function ActivityRow({ item, last }) {
             id={item.actorId}
             name={item.actorName}
             avatar={item.actorAvatar}
+            avatarVersion={item.actorAvatarVersion}
           />
         ) : (
           <Typography

--- a/react_main/src/pages/Chat/Chat.jsx
+++ b/react_main/src/pages/Chat/Chat.jsx
@@ -787,6 +787,7 @@ function Message(props) {
           id={message.sender.id}
           name={message.sender.name}
           avatar={message.sender.avatar}
+          avatarVersion={message.sender.avatarVersion}
           color={nameColorOverride || ""}
           nameColorSwatch={
             accessibleNameColors && rawNameColor ? rawNameColor : undefined
@@ -889,6 +890,7 @@ function ChannelName(props) {
                 id={m.id}
                 name={m.name}
                 avatar={m.avatar}
+                avatarVersion={m.avatarVersion}
                 vanityUrl={m.vanityUrl}
                 key={m.id}
               />
@@ -905,6 +907,7 @@ function ChannelName(props) {
             id={channel.id}
             name={channel.name}
             avatar={channel.avatar}
+            avatarVersion={channel.avatarVersion}
             vanityUrl={channel.vanityUrl}
           />
           <StatusIcon status={channel.status} />

--- a/react_main/src/pages/Community/Comment.jsx
+++ b/react_main/src/pages/Community/Comment.jsx
@@ -67,6 +67,7 @@ export const Comment = (props) => {
                   id={comment.author.id}
                   name={comment.author.name}
                   avatar={comment.author.avatar}
+                  avatarVersion={comment.author.avatarVersion}
                   groups={comment.author.groups}
                   vanityUrl={comment.author.vanityUrl}
                   color={theme.palette.text.primary}

--- a/react_main/src/pages/Community/FamilyDiscovery.jsx
+++ b/react_main/src/pages/Community/FamilyDiscovery.jsx
@@ -56,6 +56,7 @@ function FamilyAvatar({ family }) {
     return (
       <FamilyAvatarImage
         id={family.id}
+        avatarVersion={family.avatarVersion}
         size={64}
         cacheVal={siteInfo.cacheVal}
         extraStyle={{
@@ -131,6 +132,7 @@ function FamilyCard({ family }) {
                   id={family.leader.id}
                   name={family.leader.name}
                   avatar={family.leader.avatar}
+                  avatarVersion={family.leader.avatarVersion}
                   vanityUrl={family.leader.vanityUrl}
                 />
               </Typography>

--- a/react_main/src/pages/Community/Forums/Board.jsx
+++ b/react_main/src/pages/Community/Forums/Board.jsx
@@ -96,6 +96,7 @@ export default function Board(props) {
           id={reply.author.id}
           name={reply.author.name}
           avatar={reply.author.avatar}
+          avatarVersion={reply.author.avatarVersion}
           vanityUrl={reply.author.vanityUrl}
         />
         <Link
@@ -134,6 +135,7 @@ export default function Board(props) {
             small
             id={thread.author.id}
             avatar={thread.author.avatar}
+            avatarVersion={thread.author.avatarVersion}
             name={thread.author.name}
             groups={thread.author.groups}
             vanityUrl={thread.author.vanityUrl}

--- a/react_main/src/pages/Community/Forums/Categories.jsx
+++ b/react_main/src/pages/Community/Forums/Categories.jsx
@@ -53,6 +53,7 @@ export default function Categories(props) {
             id={thread.author.id}
             name={thread.author.name}
             avatar={thread.author.avatar}
+            avatarVersion={thread.author.avatarVersion}
             vanityUrl={thread.author.vanityUrl}
           />
           <div className="thread-counts">
@@ -78,6 +79,7 @@ export default function Categories(props) {
             id={reply.author.id}
             name={reply.author.name}
             avatar={reply.author.avatar}
+            avatarVersion={reply.author.avatarVersion}
             vanityUrl={reply.author.vanityUrl}
           />
           <div className="reply-age">

--- a/react_main/src/pages/Community/Forums/SearchResults.jsx
+++ b/react_main/src/pages/Community/Forums/SearchResults.jsx
@@ -286,6 +286,7 @@ export default function SearchResults(props) {
                         name={result.author.name}
                         vanityUrl={result.author.vanityUrl}
                         avatar={result.author.avatar}
+                        avatarVersion={result.author.avatarVersion}
                       />
 
                       <Typography variant="caption" color="text.secondary">

--- a/react_main/src/pages/Community/Forums/Thread.jsx
+++ b/react_main/src/pages/Community/Forums/Thread.jsx
@@ -754,6 +754,7 @@ function onAddTag(targetUserId) {
                       id={entry.user.id}
                       name={entry.user.name}
                       avatar={entry.user.avatar}
+                      avatarVersion={entry.user.avatarVersion}
                       vanityUrl={entry.user.vanityUrl}
                     />
                     <div className="roster-tags">
@@ -941,6 +942,7 @@ function onAddTag(targetUserId) {
                         id={signer.id}
                         name=" "
                         avatar={signer.avatar}
+                        avatarVersion={signer.avatarVersion}
                         vanityUrl={signer.vanityUrl}
                       />
                     </div>
@@ -1210,6 +1212,7 @@ function Post(props) {
                   id={postInfo.author.id}
                   name={postInfo.author.name}
                   avatar={postInfo.author.avatar}
+                  avatarVersion={postInfo.author.avatarVersion}
                   groups={postInfo.author.groups}
                   vanityUrl={postInfo.author.vanityUrl}
                   includeMiniprofile

--- a/react_main/src/pages/Community/UserSearch.jsx
+++ b/react_main/src/pages/Community/UserSearch.jsx
@@ -59,6 +59,7 @@ export default function UserSearch(props) {
             id={user.id}
             name={user.name}
             avatar={user.avatar}
+            avatarVersion={user.avatarVersion}
             vanityUrl={user.vanityUrl}
           />
           <Box sx={{ width: "8px" }} />
@@ -163,6 +164,7 @@ function NewestUsers(props) {
           id={user.id}
           name={user.name}
           avatar={user.avatar}
+          avatarVersion={user.avatarVersion}
           vanityUrl={user.vanityUrl}
         />
         <Typography variant="caption" sx={{ marginTop: "4px" }}>

--- a/react_main/src/pages/Fame/Competitive.jsx
+++ b/react_main/src/pages/Fame/Competitive.jsx
@@ -145,6 +145,7 @@ function Overview({ roundInfo, seasonInfo }) {
                         id={user.id}
                         name={user.name}
                         avatar={user.avatar}
+                        avatarVersion={user.avatarVersion}
                       />
                     </Box>
                     <Typography
@@ -229,6 +230,7 @@ function Overview({ roundInfo, seasonInfo }) {
                         id={user.id}
                         name={user.name}
                         avatar={user.avatar}
+                        avatarVersion={user.avatarVersion}
                       />
                     </Box>
                     <Typography
@@ -439,6 +441,7 @@ function GameHistory({ roundInfo, canManageCompetitive, reloadRoundInfo }) {
                             id={userId}
                             name={user.name}
                             avatar={user.avatar}
+                            avatarVersion={user.avatarVersion}
                           />
                           <Typography sx={{ marginLeft: "auto !important" }}>
                             {Math.trunc(pointsEarnedByPlayer.points)}
@@ -717,6 +720,7 @@ export default function Competitive() {
                 id={user.id}
                 hasImage={user.avatar}
                 name={user.name}
+                avatarVersion={user.avatarVersion}
                 isSquare
               />
               <Stack direction="column" spacing={0}>

--- a/react_main/src/pages/Fame/Contributors.jsx
+++ b/react_main/src/pages/Fame/Contributors.jsx
@@ -171,6 +171,7 @@ export default function Contributors(props) {
                     large
                     hasImage={contributor.avatar}
                     id={contributor.id}
+                    avatarVersion={contributor.avatarVersion}
                     name={contributor.name}
                   />
                 </Box>

--- a/react_main/src/pages/Fame/Donors.jsx
+++ b/react_main/src/pages/Fame/Donors.jsx
@@ -213,6 +213,7 @@ export default function Donors(props) {
                     large
                     hasImage={donor.avatar}
                     id={donor.id}
+                    avatarVersion={donor.avatarVersion}
                     name={donor.name}
                   />
                 </Box>

--- a/react_main/src/pages/Fame/HallOfFame.jsx
+++ b/react_main/src/pages/Fame/HallOfFame.jsx
@@ -213,6 +213,7 @@ const StandingsTable = React.memo(function StandingsTable({
                 id={user.userId}
                 name={user.username}
                 avatar={user.avatar}
+                avatarVersion={user.avatarVersion}
                 vanityUrl={user.vanityUrl}
               />
             </Box>

--- a/react_main/src/pages/Fame/StockMarket.jsx
+++ b/react_main/src/pages/Fame/StockMarket.jsx
@@ -46,15 +46,16 @@ import TradeDialog from "../../components/TradeDialog";
 import Sparkline from "../../components/Sparkline";
 
 // Custom Avatar component that handles both Player and Family ETF avatars
-function StockAvatar({ targetType, id, name, avatar, siteInfo }) {
+function StockAvatar({ targetType, id, name, avatar, avatarVersion, siteInfo }) {
   if (targetType === "player") {
-    return <Avatar hasImage={avatar} id={id} name={name} />;
+    return <Avatar hasImage={avatar} id={id} name={name} avatarVersion={avatarVersion} />;
   }
 
   if (avatar) {
     return (
       <FamilyAvatarImage
         id={id}
+        avatarVersion={avatarVersion}
         size={40}
         cacheVal={siteInfo?.cacheVal}
         extraStyle={{ border: "1px solid rgba(255, 255, 255, 0.12)" }}
@@ -638,6 +639,7 @@ export default function StockMarket() {
                             id={marketMode === "player" ? stock.userId : stock.familyId}
                             name={name}
                             avatar={stock.avatar}
+                            avatarVersion={stock.avatarVersion}
                             siteInfo={siteInfo}
                           />
                           <Box>
@@ -780,6 +782,7 @@ export default function StockMarket() {
                               id={key}
                               name={name}
                               avatar={stock.avatar}
+                              avatarVersion={stock.avatarVersion}
                               siteInfo={siteInfo}
                             />
                             {marketMode === "player" ? (
@@ -897,7 +900,7 @@ export default function StockMarket() {
                       <Card key={holding.subjectId} variant="outlined" sx={{ backgroundColor: theme.palette.mode === "light" ? "rgba(0, 0, 0, 0.02)" : "rgba(0, 0, 0, 0.2)" }}>
                         <CardContent sx={{ p: 2, "&:last-child": { pb: 2 } }}>
                           <Stack direction="row" spacing={1.5} alignItems="center" mb={1.5}>
-                            <StockAvatar targetType="player" id={holding.subjectId} name={holding.username} avatar={holding.avatar} siteInfo={siteInfo} />
+                            <StockAvatar targetType="player" id={holding.subjectId} name={holding.username} avatar={holding.avatar} avatarVersion={holding.avatarVersion} siteInfo={siteInfo} />
                             <Typography
                               component="a"
                               href={holding.vanityUrl ? `/user/${holding.vanityUrl}` : `/user/${holding.subjectId}`}
@@ -963,7 +966,7 @@ export default function StockMarket() {
                       <Card key={holding.familyId} variant="outlined" sx={{ backgroundColor: theme.palette.mode === "light" ? "rgba(0, 0, 0, 0.02)" : "rgba(0, 0, 0, 0.2)" }}>
                         <CardContent sx={{ p: 2, "&:last-child": { pb: 2 } }}>
                           <Stack direction="row" spacing={1.5} alignItems="center" mb={1.5}>
-                            <StockAvatar targetType="family" id={holding.familyId} name={holding.familyName} avatar={holding.avatar} siteInfo={siteInfo} />
+                            <StockAvatar targetType="family" id={holding.familyId} name={holding.familyName} avatar={holding.avatar} avatarVersion={holding.avatarVersion} siteInfo={siteInfo} />
                             <Typography
                               component="a"
                               href={`/user/family/${holding.familyId}`}
@@ -1061,6 +1064,7 @@ export default function StockMarket() {
                               id={holding.subjectId}
                               name={holding.username}
                               avatar={holding.avatar}
+                              avatarVersion={holding.avatarVersion}
                               siteInfo={siteInfo}
                             />
                              <Typography
@@ -1147,6 +1151,7 @@ export default function StockMarket() {
                               id={holding.familyId}
                               name={holding.familyName}
                               avatar={holding.avatar}
+                              avatarVersion={holding.avatarVersion}
                               siteInfo={siteInfo}
                             />
                             <Typography
@@ -1414,6 +1419,7 @@ export default function StockMarket() {
                               id={targetId}
                               name={targetName}
                               avatar={targetAvatar}
+                              avatarVersion={marketMode === "player" ? tx.subjectAvatarVersion : tx.familyAvatarVersion}
                               siteInfo={siteInfo}
                             />
                             <Box>
@@ -1557,6 +1563,7 @@ export default function StockMarket() {
                               <Avatar
                                 hasImage={tx.buyerAvatar}
                                 id={tx.userId}
+                                avatarVersion={tx.buyerAvatarVersion}
                                 name={tx.buyerName}
                               />
                               <Typography
@@ -1594,6 +1601,7 @@ export default function StockMarket() {
                                 id={targetId}
                                 name={targetName}
                                 avatar={targetAvatar}
+                                avatarVersion={marketMode === "player" ? tx.subjectAvatarVersion : tx.familyAvatarVersion}
                                 siteInfo={siteInfo}
                               />
                               {marketMode === "player" ? (
@@ -1669,6 +1677,7 @@ export default function StockMarket() {
           id: selectedStock.targetType === "player" ? selectedStock.userId : selectedStock.familyId,
           name: selectedStock.targetType === "player" ? selectedStock.username : selectedStock.familyName,
           avatar: selectedStock.avatar,
+          avatarVersion: selectedStock.avatarVersion,
           shareSupply: selectedStock.shareSupply,
           sharesOwned: ownedSharesCount
         } : null}

--- a/react_main/src/pages/Game/ConnectFourGame.jsx
+++ b/react_main/src/pages/Game/ConnectFourGame.jsx
@@ -279,6 +279,7 @@ function PlayerAvatar(props) {
         id={player.userId}
         avatarId={avatarId}
         hasImage={player.avatar}
+        avatarVersion={player.avatarVersion}
         name={player.name}
         mediumlarge
         ConnectFour

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -525,6 +525,9 @@ export default function Game() {
               name: data.names[i],
               userId: data.users[i] ? data.users[i].id : "",
               avatar: data.users[i] ? data.users[i].avatar : false,
+              avatarVersion: data.users[i]
+                ? data.users[i].avatarVersion
+                : 0,
               textColor: data.users[i] && data.users[i].settings.textColor,
               nameColor: data.users[i] && data.users[i].settings.nameColor,
               customEmotes:
@@ -550,6 +553,9 @@ export default function Game() {
               name: data.spectatorNames[i],
               userId: data.spectatorsUsers[i] ? data.spectatorsUsers[i].id : "",
               avatar: data.spectatorsUsers[i] ? data.spectatorsUsers[i].avatar : false,
+              avatarVersion: data.spectatorsUsers[i]
+                ? data.spectatorsUsers[i].avatarVersion
+                : 0,
               textColor: data.spectatorsUsers[i] && data.spectatorsUsers[i].settings.textColor,
               nameColor: data.spectatorsUsers[i] && data.spectatorsUsers[i].settings.nameColor,
               customEmotes:
@@ -2513,6 +2519,7 @@ function Message(props) {
                 avatarId={avatarId}
                 name={player.name}
                 avatar={player.avatar}
+                avatarVersion={player.avatarVersion}
                 color={resolveDisplayNameColor({
                   accessibleNameColors,
                   ignoreTextColor: user.settings?.ignoreTextColor,
@@ -2670,6 +2677,7 @@ function WinnersMessage(props) {
           id: player.userId || player.id,
           name: player.name,
           avatar: player.avatar !== undefined ? player.avatar : true,
+          avatarVersion: player.avatarVersion || 0,
           avatarId:
             player.anonId === undefined
               ? player.userId || player.id
@@ -2704,6 +2712,7 @@ function WinnersMessage(props) {
           id: player.userId || player.id,
           name: player.name,
           avatar: player.avatar,
+          avatarVersion: player.avatarVersion || 0,
           avatarId:
             player.anonId === undefined
               ? player.userId || player.id
@@ -3466,6 +3475,7 @@ export function PlayerRows({ players, className = "", renderMarker, renderRowEnd
           avatarId={avatarId}
           name={player.name}
           avatar={player.avatar}
+          avatarVersion={player.avatarVersion}
           dead={className === "dead"}
           color={resolveDisplayNameColor({
             accessibleNameColors,

--- a/react_main/src/pages/Game/JottoGame.jsx
+++ b/react_main/src/pages/Game/JottoGame.jsx
@@ -407,6 +407,7 @@ function JottoHistoryPanel({
             <Avatar
               id={player.userId}
               name={player.name}
+              avatarVersion={player.avatarVersion}
               hasImage={player.avatar}
               small
             />

--- a/react_main/src/pages/Game/LiarsDiceGame.jsx
+++ b/react_main/src/pages/Game/LiarsDiceGame.jsx
@@ -179,6 +179,7 @@ function LiarsDiceBoard({ history, stateViewing, self }) {
             userId={player.userId}
             playerName={player.playerName}
             avatar={player.avatar}
+            avatarVersion={player.avatarVersion}
             diceValues={player.rolledDice}
             previousRolls={player.previousRolls}
             isCurrentPlayer={player.playerId === self}
@@ -579,6 +580,7 @@ function LiarsDicePlayerRow({
   userId,
   playerName,
   avatar,
+  avatarVersion,
   diceValues,
   previousRolls,
   isCurrentPlayer,
@@ -593,7 +595,12 @@ function LiarsDicePlayerRow({
         className="ld-player-avatar"
         onClick={() => window.open(`/user/${userId}`, "_blank")}
       >
-        <Avatar id={userId} name={playerName} hasImage={avatar} />
+        <Avatar
+          id={userId}
+          name={playerName}
+          hasImage={avatar}
+          avatarVersion={avatarVersion}
+        />
         <div
           className={`ld-player-name-small ${
             isCurrentPlayer ? "current-player" : ""

--- a/react_main/src/pages/Game/PokerHandHistory.jsx
+++ b/react_main/src/pages/Game/PokerHandHistory.jsx
@@ -22,7 +22,7 @@ function HandHistoryEntry({ entry, players, cacheVal }) {
   const winnerPlayer = players?.[entry.winnerId];
   const avatarUrl = useAvatarImageUrl(
     winnerPlayer?.avatar && entry.winnerId ? entry.winnerId : null,
-    { cacheVal }
+    { cacheVal, avatarVersion: winnerPlayer?.avatarVersion }
   );
   const initial = entry.winnerName
     ? entry.winnerName.charAt(0).toUpperCase()

--- a/react_main/src/pages/Game/PokerTable.jsx
+++ b/react_main/src/pages/Game/PokerTable.jsx
@@ -164,7 +164,7 @@ function PokerSeat({
   const livePlayer = players?.[seat.playerId];
   const avatarUrl = useAvatarImageUrl(
     livePlayer?.avatar && seat.userId ? seat.userId : null,
-    { cacheVal }
+    { cacheVal, avatarVersion: livePlayer?.avatarVersion }
   );
 
   const initial = seat.playerName

--- a/react_main/src/pages/Game/ReviewOld.jsx
+++ b/react_main/src/pages/Game/ReviewOld.jsx
@@ -67,6 +67,7 @@ export default function Review() {
             id={player.id}
             name={game.names[i]}
             avatar={player.avatar}
+            avatarVersion={player.avatarVersion}
           />
         </div>
       );

--- a/react_main/src/pages/Game/SDPlayerCircle.jsx
+++ b/react_main/src/pages/Game/SDPlayerCircle.jsx
@@ -6,7 +6,7 @@ import { useAvatarImageUrl } from "utils/avatarUrl";
 function SdPlayerAvatar({ player, cacheVal }) {
   const avatarUrl = useAvatarImageUrl(
     player.avatar && player.userId ? player.userId : null,
-    { cacheVal }
+    { cacheVal, avatarVersion: player?.avatarVersion }
   );
   if (avatarUrl) {
     return (

--- a/react_main/src/pages/Game/SnakeGameDisplay.jsx
+++ b/react_main/src/pages/Game/SnakeGameDisplay.jsx
@@ -39,8 +39,14 @@ export default function SnakeGameDisplay({ player, players, gameSocket, extraInf
   const snakeUserIds = Object.values(players || {})
     .map((p) => (p && p.avatar && p.userId ? p.userId : null))
     .filter(Boolean);
+  const snakeVersions = {};
+  Object.values(players || {}).forEach((p) => {
+    if (p && p.userId && p.avatarVersion)
+      snakeVersions[p.userId] = p.avatarVersion;
+  });
   const avatarUrls = useAvatarUrlMap(snakeUserIds, {
     cacheVal: siteInfo?.cacheVal,
+    versions: snakeVersions,
   });
 
   const wallsTransparent = gameState?.ifWallsAreTransparent !== false;

--- a/react_main/src/pages/Game/WackyWordsGame.jsx
+++ b/react_main/src/pages/Game/WackyWordsGame.jsx
@@ -445,6 +445,7 @@ function AcrotopiaResponses({ responseHistory, players }) {
                     small
                     id={author.userId}
                     hasImage={author.avatar}
+                    avatarVersion={author.avatarVersion}
                     name={author.name}
                   />
                 )}

--- a/react_main/src/pages/Learn/Setup/SetupPage.jsx
+++ b/react_main/src/pages/Learn/Setup/SetupPage.jsx
@@ -679,6 +679,7 @@ export function SetupPage() {
                   id={setup.creator.id}
                   name={setup.creator.name}
                   avatar={setup.creator.avatar}
+                  avatarVersion={setup.creator.avatarVersion}
                 />
                 {canArchive && !setup.creator.name && (
                   <Button

--- a/react_main/src/pages/Learn/role/RolePage.jsx
+++ b/react_main/src/pages/Learn/role/RolePage.jsx
@@ -386,6 +386,7 @@ export function RoleThings() {
           id={artist.user?.id}
           name={artist.user?.name}
           avatar={artist.user?.avatar}
+          avatarVersion={artist.user?.avatarVersion}
         />
       </Box>
     ));

--- a/react_main/src/pages/Policy/Moderation/FlaggedIntake.jsx
+++ b/react_main/src/pages/Policy/Moderation/FlaggedIntake.jsx
@@ -162,6 +162,7 @@ export default function FlaggedIntake() {
                 id={flaggedUser.id}
                 name={flaggedUser.name}
                 avatar={flaggedUser.avatar}
+                avatarVersion={flaggedUser.avatarVersion}
               />
             </Box>
             <Stack direction="column" spacing={0.5}>

--- a/react_main/src/pages/Policy/Moderation/GroupPanels.jsx
+++ b/react_main/src/pages/Policy/Moderation/GroupPanels.jsx
@@ -96,6 +96,7 @@ export function GroupPanels({ user }) {
             id={member.id}
             name={member.name}
             avatar={member.avatar}
+            avatarVersion={member.avatarVersion}
           />
           <StatusIcon status={member.status} />
           {canManageGroup && (

--- a/react_main/src/pages/Policy/Moderation/ModActions.jsx
+++ b/react_main/src/pages/Policy/Moderation/ModActions.jsx
@@ -144,6 +144,7 @@ export function ModActions(props) {
             id={action.mod?.id || action.modId}
             name={action.mod?.name || `[not found: ${action.modId}]`}
             avatar={action.mod?.avatar || false}
+            avatarVersion={action.mod?.avatarVersion}
           />
           <Typography
             variant="caption"
@@ -282,6 +283,7 @@ function ModActionArg({ label, arg }) {
           id={userInfo.id}
           name={userInfo.name}
           avatar={userInfo.avatar}
+          avatarVersion={userInfo.avatarVersion}
           small
         />
       </Box>

--- a/react_main/src/pages/Policy/Reports.jsx
+++ b/react_main/src/pages/Policy/Reports.jsx
@@ -299,6 +299,7 @@ export default function Reports({ basePath = "/policy" }) {
                       id={report.reportedUserId}
                       name={report.reportedUserName || report.reportedUserId}
                       avatar={report.reportedUserAvatar}
+                      avatarVersion={report.reportedUserAvatarVersion}
                     />
                   </TableCell>
                   <TableCell>
@@ -310,6 +311,7 @@ export default function Reports({ basePath = "/policy" }) {
                             id={r.id}
                             name={r.name || r.id}
                             avatar={r.avatar}
+                            avatarVersion={r.avatarVersion}
                             size="small"
                           />
                         ))}
@@ -324,6 +326,7 @@ export default function Reports({ basePath = "/policy" }) {
                         id={report.reporterId}
                         name={report.reporterName || report.reporterId}
                         avatar={report.reporterAvatar}
+                        avatarVersion={report.reporterAvatarVersion}
                       />
                     )}
                   </TableCell>
@@ -352,6 +355,7 @@ export default function Reports({ basePath = "/policy" }) {
                                 id={assigneeId}
                                 name={assigneeName}
                                 avatar={assigneeAvatar}
+                                avatarVersion={assignee.avatarVersion}
                                 size="small"
                               />
                             );

--- a/react_main/src/pages/User/Family.jsx
+++ b/react_main/src/pages/User/Family.jsx
@@ -270,6 +270,7 @@ export default function Family() {
           id={member.id}
           name={member.name}
           avatar={member.avatar}
+          avatarVersion={member.avatarVersion}
           vanityUrl={member.vanityUrl}
         />
       </Box>
@@ -384,6 +385,7 @@ export default function Family() {
                 {family.avatar && (
                   <FamilyAvatarImage
                     id={family.id}
+                    avatarVersion={family.avatarVersion}
                     size={100}
                     cacheVal={siteInfo.cacheVal}
                   />
@@ -398,6 +400,7 @@ export default function Family() {
                       id={family.founder.id}
                       name={family.founder.name}
                       avatar={family.founder.avatar}
+                      avatarVersion={family.founder.avatarVersion}
                       vanityUrl={family.founder.vanityUrl}
                     />
                   </Typography>

--- a/react_main/src/pages/User/FamilyExtras.jsx
+++ b/react_main/src/pages/User/FamilyExtras.jsx
@@ -271,6 +271,7 @@ export function FamilyApplications({ familyId, family, refreshFamilyTools }) {
               id={application.applicant.id}
               name={application.applicant.name}
               avatar={application.applicant.avatar}
+              avatarVersion={application.applicant.avatarVersion}
               vanityUrl={application.applicant.vanityUrl}
             />
             {application.message && (
@@ -619,6 +620,7 @@ export function FamilyStockCard({ stockInfo, family, familyId, refreshFamilyTool
                 id: familyId,
                 name: family.name,
                 avatar: family.avatar,
+                avatarVersion: family.avatarVersion,
                 shareSupply: stockInfo.shareSupply,
                 sharesOwned: stockInfo.sharesOwned,
               }

--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -183,6 +183,7 @@ export default function Profile() {
   const [profileLoaded, setProfileLoaded] = useState(false);
   const [name, setName] = useState();
   const [avatar, setAvatar] = useState();
+  const [avatarVersion, setAvatarVersion] = useState(0);
   const [banner, setBanner] = useState();
   const [bannerExt, setBannerExt] = useState("webp");
   const [profileBackground, setProfileBackground] = useState(false);
@@ -377,6 +378,7 @@ export default function Profile() {
           setProfileTotalGames(res.data.totalGames ?? 0);
           setName(res.data.name);
           setAvatar(res.data.avatar);
+          setAvatarVersion(res.data.avatarVersion || 0);
           setBanner(res.data.banner);
           setBannerExt(res.data.bannerExt || "webp");
           setProfileBackground(res.data.profileBackground || false);
@@ -1163,6 +1165,7 @@ export default function Profile() {
         id={user.id}
         name={user.name}
         avatar={user.avatar}
+        avatarVersion={user.avatarVersion}
         vanityUrl={user.vanityUrl}
       />
       <div className="btns">
@@ -1179,6 +1182,7 @@ export default function Profile() {
           id={friend.id}
           name={friend.name}
           avatar={friend.avatar}
+          avatarVersion={friend.avatarVersion}
           vanityUrl={friend.vanityUrl}
         />
         {showDelete && (
@@ -1494,7 +1498,7 @@ export default function Profile() {
               <Typography variant="italicRelation">
                 {getLoveTitle(love.type)}
               </Typography>
-              <Avatar hasImage={love.avatar} id={love.id} name={love.name} mediumlarge={!isPhoneDevice} />
+              <Avatar hasImage={love.avatar} id={love.id} name={love.name} avatarVersion={love.avatarVersion} mediumlarge={!isPhoneDevice} />
               <Typography>{love.name}</Typography>
             </Stack>
           </Stack>
@@ -1535,6 +1539,7 @@ export default function Profile() {
               {profileFamily.avatar && (
                 <FamilyAvatarImage
                   id={profileFamily.id}
+                  avatarVersion={profileFamily.avatarVersion}
                   size={isPhoneDevice ? 40 : 60}
                   cacheVal={siteInfo.cacheVal}
                 />
@@ -1609,6 +1614,7 @@ export default function Profile() {
           id: profileUserId,
           name: name,
           avatar: avatar,
+          avatarVersion: avatarVersion,
           shareSupply: stockInfo.shareSupply,
           sharesOwned: stockInfo.sharesOwned
         } : null}
@@ -2182,6 +2188,7 @@ export default function Profile() {
                           id={poke.from.id}
                           name={poke.from.name}
                           avatar={poke.from.avatar}
+                          avatarVersion={poke.from.avatarVersion}
                         />
                         {poke.count >= 1000000 ? (
                           <span className="poke-streak-badge trophy" title="1,000,000 pokes!">

--- a/react_main/src/pages/User/Settings.jsx
+++ b/react_main/src/pages/User/Settings.jsx
@@ -1258,6 +1258,7 @@ export default function Settings() {
                   {userFamily.avatar && (
                     <FamilyAvatarImage
                       id={userFamily.id}
+                      avatarVersion={userFamily.avatarVersion}
                       size={40}
                       cacheVal={siteInfo.cacheVal}
                     />
@@ -1554,6 +1555,7 @@ export default function Settings() {
                   {userFamily.avatar && (
                     <FamilyAvatarImage
                       id={userFamily.id}
+                      avatarVersion={userFamily.avatarVersion}
                       size={40}
                       cacheVal={siteInfo.cacheVal}
                     />

--- a/react_main/src/pages/User/UserNavSection.jsx
+++ b/react_main/src/pages/User/UserNavSection.jsx
@@ -64,6 +64,7 @@ export default function UserNavSection({
   const familyIcon = userFamily?.avatar ? (
     <FamilyAvatarImage
       id={userFamily.id}
+      avatarVersion={userFamily.avatarVersion}
       size={20}
       cacheVal={cacheVal}
     />
@@ -160,7 +161,7 @@ export default function UserNavSection({
       <NavDropdown
         items={userMenuItems}
         triggerAriaLabel="User menu"
-        customTrigger={<Avatar id={user.id} name={user.name} hasImage={user.avatar} />}
+        customTrigger={<Avatar id={user.id} name={user.name} hasImage={user.avatar} avatarVersion={user.avatarVersion} />}
       />
     </Stack>
   );

--- a/react_main/src/pages/User/UserWidgets.jsx
+++ b/react_main/src/pages/User/UserWidgets.jsx
@@ -381,6 +381,7 @@ export function Avatar(props) {
   const id = props.id;
   const name = props.name;
   const hasImage = props.hasImage;
+  const avatarVersion = props.avatarVersion;
   const imageUrl = props.imageUrl;
   const edit = props.edit;
   const onUpload = props.onUpload;
@@ -409,6 +410,7 @@ export function Avatar(props) {
   const userFileUrl = useAvatarImageUrl(userFileId, {
     cacheVal: siteInfo.cacheVal,
     skipFreeze: !!edit,
+    avatarVersion,
   });
   const style = {};
   const colors = [
@@ -590,6 +592,7 @@ export function NameWithAvatar(props) {
   const id = props.id;
   const name = props.name || "[deleted]";
   const avatar = props.avatar;
+  const avatarVersion = props.avatarVersion;
   const noLink = props.name ? props.noLink : true;
   const color = props.color;
   const newTab = props.newTab;
@@ -695,6 +698,7 @@ export function NameWithAvatar(props) {
           hasImage={avatar}
           id={id}
           avatarId={avatarId}
+          avatarVersion={avatarVersion}
           name={name}
           small={small}
           large={large}

--- a/react_main/src/utils/avatarUrl.js
+++ b/react_main/src/utils/avatarUrl.js
@@ -57,12 +57,13 @@ export function useDisableAnimatedAvatars() {
  */
 export function useAvatarImageUrl(
   id,
-  { cacheVal, family = false, skipFreeze = false } = {}
+  { cacheVal, family = false, skipFreeze = false, avatarVersion } = {}
 ) {
   const freeze = useDisableAnimatedAvatars() && !skipFreeze;
-  const live = avatarUrl(id, { family, freeze: false, cacheVal });
-  const frozen = avatarUrl(id, { family, freeze: true, cacheVal });
-  const cacheKey = probeCacheKey(id, family, cacheVal);
+  const bust = avatarVersion || cacheVal;
+  const live = avatarUrl(id, { family, freeze: false, cacheVal: bust });
+  const frozen = avatarUrl(id, { family, freeze: true, cacheVal: bust });
+  const cacheKey = probeCacheKey(id, family, bust);
   const [useFrozen, setUseFrozen] = useState(
     () => freeze && staticExistsCache.get(cacheKey) === true
   );
@@ -82,21 +83,30 @@ export function useAvatarImageUrl(
       return;
     }
     let cancelled = false;
-    probeStaticAvatar(id, { family, cacheVal }).then((exists) => {
+    probeStaticAvatar(id, { family, cacheVal: bust }).then((exists) => {
       if (!cancelled) setUseFrozen(!!exists);
     });
     return () => {
       cancelled = true;
     };
-  }, [id, family, freeze, cacheVal, cacheKey]);
+  }, [id, family, freeze, bust, cacheKey]);
 
   if (!id) return "";
   return freeze && useFrozen ? frozen : live;
 }
 
-export function useAvatarUrlMap(ids, { cacheVal, family = false } = {}) {
+function bustValue(versions, cacheVal, id) {
+  return (versions && versions[id]) || cacheVal;
+}
+
+export function useAvatarUrlMap(
+  ids,
+  { cacheVal, family = false, versions } = {}
+) {
   const freeze = useDisableAnimatedAvatars();
   const listKey = (ids || []).filter(Boolean).join(",");
+  // Stabilized so a freshly built versions object does not retrigger probes
+  const versionsKey = JSON.stringify(versions || null);
   const [frozenIds, setFrozenIds] = useState(() => new Set());
 
   useEffect(() => {
@@ -108,7 +118,10 @@ export function useAvatarUrlMap(ids, { cacheVal, family = false } = {}) {
     let cancelled = false;
     Promise.all(
       list.map((id) =>
-        probeStaticAvatar(id, { family, cacheVal }).then((ok) => [id, ok])
+        probeStaticAvatar(id, {
+          family,
+          cacheVal: bustValue(versions, cacheVal, id),
+        }).then((ok) => [id, ok])
       )
     ).then((results) => {
       if (cancelled) return;
@@ -121,7 +134,10 @@ export function useAvatarUrlMap(ids, { cacheVal, family = false } = {}) {
     return () => {
       cancelled = true;
     };
-  }, [listKey, freeze, family, cacheVal]);
+    // `versions` is deliberately omitted: versionsKey captures its content,
+    // and including the object itself would retrigger probes every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [listKey, freeze, family, cacheVal, versionsKey]);
 
   return useMemo(() => {
     const map = {};
@@ -130,11 +146,13 @@ export function useAvatarUrlMap(ids, { cacheVal, family = false } = {}) {
       map[id] = avatarUrl(id, {
         family,
         freeze: freeze && frozenIds.has(id),
-        cacheVal,
+        cacheVal: bustValue(versions, cacheVal, id),
       });
     }
     return map;
-  }, [listKey, freeze, frozenIds, family, cacheVal]);
+    // Same rationale as the effect above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [listKey, freeze, frozenIds, family, cacheVal, versionsKey]);
 }
 
 export function AvatarPhoto({ src, alt = "" }) {
@@ -148,10 +166,11 @@ export function FamilyAvatarImage({
   id,
   size = 40,
   cacheVal,
+  avatarVersion,
   extraStyle,
   className,
 }) {
-  const src = useAvatarImageUrl(id, { family: true, cacheVal });
+  const src = useAvatarImageUrl(id, { family: true, cacheVal, avatarVersion });
   return (
     <div
       className={className}

--- a/routes/anonymousDeck.js
+++ b/routes/anonymousDeck.js
@@ -486,7 +486,7 @@ router.get("/featured", async function (req, res) {
         .skip(start)
         .limit(pageSize)
         .select("id name profiles creator coverPhoto voteCount")
-        .populate("creator", "id name avatar -_id")
+        .populate("creator", "id name avatar avatarVersion -_id")
         .lean();
       decks = await attachDeckPreviews(decks);
       decks = await attachUserVotes(decks, userId);

--- a/routes/comment.js
+++ b/routes/comment.js
@@ -55,6 +55,7 @@ router.get("/", async function (req, res) {
           id: "",
           name: "[deleted]",
           avatar: false,
+          avatarVersion: 0,
           groups: [],
           settings: {},
         };

--- a/routes/fame.js
+++ b/routes/fame.js
@@ -25,7 +25,7 @@ router.get("/leaderboard", async function (req, res) {
   res.setHeader("Content-Type", "application/json");
   try {
     let users = await models.User.find({ deleted: false })
-      .select("id name avatar kudos karma achievements -_id")
+      .select("id name avatar avatarVersion kudos karma achievements -_id")
       .sort({ kudos: -1, karma: -1, achievements: -1 })
       .limit(20);
 

--- a/routes/family.js
+++ b/routes/family.js
@@ -44,7 +44,7 @@ router.get("/user/family", async function (req, res) {
 
     // Query family directly and populate leader properly
     const family = await models.Family.findById(familyId)
-      .select("id name avatar banner bannerExt mediaUrl mediaAutoplay mediaCollapse leader members background backgroundRepeatMode perks")
+      .select("id name avatar avatarVersion banner bannerExt mediaUrl mediaAutoplay mediaCollapse leader members background backgroundRepeatMode perks")
       .populate("leader", "_id");
 
     if (!family) {
@@ -63,6 +63,7 @@ router.get("/user/family", async function (req, res) {
         id: family.id,
         name: family.name,
         avatar: family.avatar,
+        avatarVersion: family.avatarVersion || 0,
         banner: family.banner || false,
         bannerExt: family.bannerExt || "webp",
         mediaUrl: family.mediaUrl || "",
@@ -142,6 +143,7 @@ router.post("/create", async function (req, res) {
       leader: user._id,
       members: [user._id],
       avatar: hasAvatar,
+      avatarVersion: hasAvatar ? Date.now() : 0,
       createdAt: Date.now(),
     });
 
@@ -308,7 +310,7 @@ router.post("/avatar", async function (req, res) {
       if (isExistingFamily) {
         await models.Family.updateOne(
           { id: familyId },
-          { $set: { avatar: true } }
+          { $set: { avatar: true, avatarVersion: Date.now() } }
         );
       }
 
@@ -501,10 +503,10 @@ router.get("/:familyId/profile", async function (req, res) {
     var userId = await routeUtils.verifyLoggedIn(req, true);
 
     var family = await models.Family.findOne({ id: familyId })
-      .populate("founder", "id name avatar vanityUrl")
-      .populate("leader", "id name avatar vanityUrl")
-      .populate("members", "id name avatar vanityUrl")
-      .select("id name avatar banner bannerExt mediaUrl mediaAutoplay mediaCollapse background backgroundRepeatMode applicationsOpen joinFee pendingJoinFees treasury perks bio founder leader members trophies createdAt");
+      .populate("founder", "id name avatar avatarVersion vanityUrl")
+      .populate("leader", "id name avatar avatarVersion vanityUrl")
+      .populate("members", "id name avatar avatarVersion vanityUrl")
+      .select("id name avatar avatarVersion banner bannerExt mediaUrl mediaAutoplay mediaCollapse background backgroundRepeatMode applicationsOpen joinFee pendingJoinFees treasury perks bio founder leader members trophies createdAt");
 
     if (!family) {
       res.status(404);
@@ -547,6 +549,7 @@ router.get("/:familyId/profile", async function (req, res) {
       id: member.id,
       name: member.name,
       avatar: member.avatar,
+      avatarVersion: member.avatarVersion || 0,
       vanityUrl: member.vanityUrl,
       isLeader: member.id === leaderId,
       isFounder: member.id === founderId,
@@ -569,7 +572,7 @@ router.get("/:familyId/profile", async function (req, res) {
           ownerId: { $in: memberIds },
           revoked: { $ne: true },
         })
-          .populate("owner", "id name avatar vanityUrl")
+          .populate("owner", "id name avatar avatarVersion vanityUrl")
           .select("id name ownerId owner type createdAt -_id")
           .sort("-createdAt")
           .lean();
@@ -591,6 +594,7 @@ router.get("/:familyId/profile", async function (req, res) {
             id: trophy.owner.id,
             name: trophy.owner.name,
             avatar: trophy.owner.avatar,
+            avatarVersion: trophy.owner.avatarVersion || 0,
             vanityUrl: trophy.owner.vanityUrl,
           }
         : null,
@@ -624,6 +628,7 @@ router.get("/:familyId/profile", async function (req, res) {
       id: family.id,
       name: family.name,
       avatar: family.avatar,
+      avatarVersion: family.avatarVersion || 0,
       banner: family.banner || false,
       bannerExt: family.bannerExt || "webp",
       mediaUrl: family.mediaUrl || "",
@@ -643,12 +648,14 @@ router.get("/:familyId/profile", async function (req, res) {
         id: family.founder.id,
         name: family.founder.name,
         avatar: family.founder.avatar,
+        avatarVersion: family.founder.avatarVersion || 0,
         vanityUrl: family.founder.vanityUrl,
       },
       leader: {
         id: family.leader.id,
         name: family.leader.name,
         avatar: family.leader.avatar,
+        avatarVersion: family.leader.avatarVersion || 0,
         vanityUrl: family.leader.vanityUrl,
       },
       members: members,
@@ -1120,8 +1127,8 @@ router.get("/:familyId/pendingInvite", async function (req, res) {
       familyId: familyId,
       requesterId: userId,
     })
-      .populate("family", "id name avatar")
-      .populate("requester", "id name avatar");
+      .populate("family", "id name avatar avatarVersion")
+      .populate("requester", "id name avatar avatarVersion");
 
     if (!joinRequest) {
       res.send({ hasPendingInvite: false });
@@ -1134,6 +1141,7 @@ router.get("/:familyId/pendingInvite", async function (req, res) {
         id: joinRequest.family.id,
         name: joinRequest.family.name,
         avatar: joinRequest.family.avatar,
+        avatarVersion: joinRequest.family.avatarVersion || 0,
       },
     });
   } catch (e) {
@@ -1538,9 +1546,9 @@ router.get("/discover", async function (req, res) {
 
     const families = await models.Family.find(query)
       .select(
-        "id name avatar avatarUrl leader members treasury pendingJoinFees perks applicationsOpen joinFee createdAt bio"
+        "id name avatar avatarVersion avatarUrl leader members treasury pendingJoinFees perks applicationsOpen joinFee createdAt bio"
       )
-      .populate("leader", "id name avatar vanityUrl")
+      .populate("leader", "id name avatar avatarVersion vanityUrl")
       .populate("members", "id")
       .lean();
 
@@ -1590,11 +1598,13 @@ router.get("/discover", async function (req, res) {
         id: family.id,
         name: family.name,
         avatar: family.avatarUrl || family.avatar,
+        avatarVersion: family.avatarVersion || 0,
         leader: family.leader
           ? {
               id: family.leader.id,
               name: family.leader.name,
               avatar: family.leader.avatar,
+              avatarVersion: family.leader.avatarVersion || 0,
               vanityUrl: family.leader.vanityUrl,
             }
           : null,
@@ -2021,7 +2031,7 @@ router.get("/:familyId/applications", async function (req, res) {
       familyId: familyId,
       status: "pending",
     })
-      .populate("applicant", "id name avatar vanityUrl")
+      .populate("applicant", "id name avatar avatarVersion vanityUrl")
       .sort("createdAt")
       .lean();
 
@@ -2034,6 +2044,7 @@ router.get("/:familyId/applications", async function (req, res) {
             id: application.applicant.id,
             name: application.applicant.name,
             avatar: application.applicant.avatar,
+            avatarVersion: application.applicant.avatarVersion || 0,
             vanityUrl: application.applicant.vanityUrl,
           },
           message: application.message || "",
@@ -2292,7 +2303,7 @@ router.get("/:familyId/ledger", async function (req, res) {
     const maxPage = Math.ceil(totalCount / limit) || 1;
 
     var ledger = await models.FamilyLedger.find({ familyId: familyId })
-      .populate("user", "id name avatar vanityUrl")
+      .populate("user", "id name avatar avatarVersion vanityUrl")
       .sort("-createdAt")
       .skip(skip)
       .limit(limit)
@@ -2310,6 +2321,7 @@ router.get("/:familyId/ledger", async function (req, res) {
               id: entry.user.id,
               name: entry.user.name,
               avatar: entry.user.avatar,
+              avatarVersion: entry.user.avatarVersion || 0,
               vanityUrl: entry.user.vanityUrl,
             }
           : null,

--- a/routes/fanart.js
+++ b/routes/fanart.js
@@ -37,7 +37,7 @@ router.get("/", async function (req, res) {
       deleted: false,
     })
       .select("id roleId title imagePath author createdAt")
-      .populate("author", "id name avatar vanityUrl")
+      .populate("author", "id name avatar avatarVersion vanityUrl")
       .sort("-createdAt")
       .lean();
 
@@ -52,6 +52,7 @@ router.get("/", async function (req, res) {
             id: doc.author.id,
             name: doc.author.name,
             avatar: doc.author.avatar,
+            avatarVersion: doc.author.avatarVersion || 0,
             vanityUrl: doc.author.vanityUrl,
           }
         : null,
@@ -143,7 +144,7 @@ router.post("/", async function (req, res) {
     const authorDoc = await models.User.findOne({
       _id: req.session.user._id,
     })
-      .select("id name avatar vanityUrl")
+      .select("id name avatar avatarVersion vanityUrl")
       .lean();
 
     const item = {
@@ -157,6 +158,7 @@ router.post("/", async function (req, res) {
             id: authorDoc.id,
             name: authorDoc.name,
             avatar: authorDoc.avatar,
+            avatarVersion: authorDoc.avatarVersion || 0,
             vanityUrl: authorDoc.vanityUrl,
           }
         : null,

--- a/routes/forums.js
+++ b/routes/forums.js
@@ -90,7 +90,7 @@ router.get("/categories", async function (req, res) {
             match: { deleted: false },
             populate: {
               path: "author",
-              select: "id name avatar -_id",
+              select: "id name avatar avatarVersion -_id",
             },
           },
           {
@@ -99,7 +99,7 @@ router.get("/categories", async function (req, res) {
             populate: [
               {
                 path: "author",
-                select: "id name avatar -_id",
+                select: "id name avatar avatarVersion -_id",
               },
               {
                 path: "thread",
@@ -166,7 +166,7 @@ router.get("/board/:id", async function (req, res) {
         select: "id author postDate -_id",
         populate: {
           path: "author",
-          select: "id name avatar -_id",
+          select: "id name avatar avatarVersion -_id",
         },
       }
     );
@@ -184,7 +184,7 @@ router.get("/board/:id", async function (req, res) {
         select: "id author postDate -_id",
         populate: {
           path: "author",
-          select: "id name avatar -_id",
+          select: "id name avatar avatarVersion -_id",
         },
       })
       .sort("-bumpDate");
@@ -298,6 +298,7 @@ router.get("/thread/:id", async function (req, res) {
           id: "",
           name: "[deleted]",
           avatar: false,
+          avatarVersion: 0,
           groups: [],
           settings: {},
         };
@@ -316,6 +317,7 @@ router.get("/thread/:id", async function (req, res) {
         id: "",
         name: "[deleted]",
         avatar: false,
+        avatarVersion: 0,
         groups: [],
         settings: {},
       };
@@ -1817,7 +1819,7 @@ router.get("/search", async function (req, res) {
       .select(
         "id author title content postDate bumpDate replyCount voteCount viewCount board -_id"
       )
-      .populate("author", "id name avatar -_id")
+      .populate("author", "id name avatar avatarVersion -_id")
       .populate("board", "id name -_id")
       .sort("-bumpDate")
       .skip(skip)
@@ -1826,7 +1828,7 @@ router.get("/search", async function (req, res) {
     // Get replies
     var replies = await models.ForumReply.find(replyFilter)
       .select("id author thread content postDate voteCount -_id")
-      .populate("author", "id name avatar -_id")
+      .populate("author", "id name avatar avatarVersion -_id")
       .populate({
         path: "thread",
         select: "id title board -_id",

--- a/routes/game.js
+++ b/routes/game.js
@@ -430,7 +430,7 @@ router.get("/:id/review/data", async function (req, res) {
       .populate("setup", "-_id")
       .populate([{
         path: "users",
-        select: "id avatar tag settings customEmotes -_id",
+        select: "id avatar avatarVersion tag settings customEmotes -_id",
         populate: [
           {
             path: "customEmotes",
@@ -441,7 +441,7 @@ router.get("/:id/review/data", async function (req, res) {
       },
     {
         path: "spectatorsUsers",
-        select: "id avatar tag settings customEmotes -_id",
+        select: "id avatar avatarVersion tag settings customEmotes -_id",
         populate: [
           {
             path: "customEmotes",
@@ -538,7 +538,7 @@ router.get("/:id/info", async function (req, res) {
         .select(
           "type users spectatorsUsers players spectators left stateLengths lobbyName ranked competitive anonymousGame anonymousDeck spectating guests readyCheck noVeg startTime endTime gameTypeOptions winners winnersInfo kudosReceiver playerIdMap playerAlignmentMap skillRatingChanges -_id"
         )
-        .populate("users", "id name avatar -_id");
+        .populate("users", "id name avatar avatarVersion -_id");
 
       if (!game) {
         errors.notFound(res, "Game not found");

--- a/routes/mod.js
+++ b/routes/mod.js
@@ -31,7 +31,7 @@ router.get("/groups", async function (req, res) {
     for (let group of visibleGroups) {
       group.members = await models.InGroup.find({ group: group._id })
         .select("user")
-        .populate("user", "id name avatar -_id");
+        .populate("user", "id name avatar avatarVersion -_id");
       group.members = group.members
         .map((member) => member.toJSON().user)
         .filter((member) => member !== null);
@@ -1216,7 +1216,7 @@ router.post("/clearUserContent", async (req, res) => {
 
     switch (contentType) {
       case "avatar":
-        updateQuery = { $set: { avatar: false } };
+        updateQuery = { $set: { avatar: false, avatarVersion: Date.now() } };
         modActionName = "Clear Avatar";
         break;
 
@@ -1369,6 +1369,7 @@ router.post("/clearUserContent", async (req, res) => {
           $set: {
             name: routeUtils.nameGen().slice(0, constants.maxUserNameLength),
             avatar: false,
+            avatarVersion: Date.now(),
             bio: "",
             donorBio: "",
             customEmotes: [],
@@ -1509,6 +1510,7 @@ router.post("/clearFamilyContent", async (req, res) => {
           name: defaultName,
           bio: "",
           avatar: false,
+          avatarVersion: Date.now(),
           background: false,
         },
       }
@@ -1655,6 +1657,7 @@ router.post("/restoreDeletedUser", async (req, res) => {
       userDoc.email.push(rawEmail.toLowerCase());
     }
     userDoc.avatar = false;
+    userDoc.avatarVersion = Date.now();
     userDoc.banner = false;
     userDoc.settings = userDoc.settings || {};
     userDoc.permissions = userDoc.permissions || [];
@@ -2607,7 +2610,7 @@ router.get("/actions", async function (req, res) {
       first,
       "id modId mod name args reason date -_id",
       constants.modActionPageSize,
-      ["mod", "id name avatar -_id"]
+      ["mod", "id name avatar avatarVersion -_id"]
     );
 
     res.send(actions);
@@ -2631,7 +2634,7 @@ router.get("/announcements", async function (req, res) {
       first,
       "id modId mod content date -_id",
       5,
-      ["mod", "id name avatar -_id"]
+      ["mod", "id name avatar avatarVersion -_id"]
     );
 
     res.send(announcements);
@@ -2894,6 +2897,7 @@ router.get("/reports", async (req, res) => {
             id: r.userId,
             name: info?.name || r.userId,
             avatar: info?.avatar || false,
+            avatarVersion: info?.avatarVersion || 0,
           });
         }
         // Backwards compat: first reporter as reporterId/reporterName/reporterAvatar
@@ -2901,11 +2905,13 @@ router.get("/reports", async (req, res) => {
           report.reporterId = report.reporterInfo[0].id;
           report.reporterName = report.reporterInfo[0].name;
           report.reporterAvatar = report.reporterInfo[0].avatar;
+          report.reporterAvatarVersion = report.reporterInfo[0].avatarVersion || 0;
         } else if (report.reporterId) {
           const reporterInfo = await getBasicUserInfo(report.reporterId);
           if (reporterInfo) {
             report.reporterName = reporterInfo.name;
             report.reporterAvatar = reporterInfo.avatar;
+            report.reporterAvatarVersion = reporterInfo.avatarVersion || 0;
           }
         }
 
@@ -2914,6 +2920,7 @@ router.get("/reports", async (req, res) => {
         if (reportedUserInfo) {
           report.reportedUserName = reportedUserInfo.name;
           report.reportedUserAvatar = reportedUserInfo.avatar;
+          report.reportedUserAvatarVersion = reportedUserInfo.avatarVersion || 0;
         }
 
         // Get assignee info
@@ -2926,12 +2933,14 @@ router.get("/reports", async (req, res) => {
                 id: assigneeId,
                 name: assigneeInfo.name,
                 avatar: assigneeInfo.avatar,
+                avatarVersion: assigneeInfo.avatarVersion || 0,
               });
             } else {
               report.assigneeInfo.push({
                 id: assigneeId,
                 name: assigneeId,
                 avatar: false,
+                avatarVersion: 0,
               });
             }
           }
@@ -3027,6 +3036,7 @@ router.get("/reports/:id", async (req, res) => {
           id: r.userId,
           name: info?.name || r.userId,
           avatar: info?.avatar || false,
+          avatarVersion: info?.avatarVersion || 0,
           rule: r.rule,
           description: r.description,
           submittedAt: r.submittedAt,
@@ -3037,11 +3047,13 @@ router.get("/reports/:id", async (req, res) => {
         report.reporterId = report.reporterInfo[0].id;
         report.reporterName = report.reporterInfo[0].name;
         report.reporterAvatar = report.reporterInfo[0].avatar;
+        report.reporterAvatarVersion = report.reporterInfo[0].avatarVersion || 0;
       } else if (report.reporterId) {
         const reporterInfo = await getBasicUserInfo(report.reporterId);
         if (reporterInfo) {
           report.reporterName = reporterInfo.name;
           report.reporterAvatar = reporterInfo.avatar;
+          report.reporterAvatarVersion = reporterInfo.avatarVersion || 0;
         }
       }
 
@@ -3050,6 +3062,7 @@ router.get("/reports/:id", async (req, res) => {
       if (reportedUserInfo) {
         report.reportedUserName = reportedUserInfo.name;
         report.reportedUserAvatar = reportedUserInfo.avatar;
+        report.reportedUserAvatarVersion = reportedUserInfo.avatarVersion || 0;
       }
 
       // Get assignee info
@@ -3062,12 +3075,14 @@ router.get("/reports/:id", async (req, res) => {
               id: assigneeId,
               name: assigneeInfo.name,
               avatar: assigneeInfo.avatar,
+              avatarVersion: assigneeInfo.avatarVersion || 0,
             });
           } else {
             report.assigneeInfo.push({
               id: assigneeId,
               name: assigneeId,
               avatar: false,
+              avatarVersion: 0,
             });
           }
         }

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -266,7 +266,7 @@ router.get("/search", async function (req, res) {
       .select(
         "id gameType name roles closed useRoleGroups roleGroupSizes gameSettings count total featured ranked competitive -_id"
       )
-      .populate("creator", "id name avatar tag -_id");
+      .populate("creator", "id name avatar avatarVersion tag -_id");
     var count = await models.Setup.countDocuments(search);
 
     await markFavSetups(userId, setups);
@@ -577,7 +577,7 @@ router.get("/:id/lineage", async function (req, res) {
     if (setup.copiedFrom) {
       const parent = await models.Setup.findOne({ id: setup.copiedFrom })
         .select("-__v -hash -count")
-        .populate("creator", "id name avatar -_id")
+        .populate("creator", "id name avatar avatarVersion -_id")
         .lean();
       if (parent) {
         parent.roles = parent.roles && JSON.parse(parent.roles);
@@ -587,7 +587,7 @@ router.get("/:id/lineage", async function (req, res) {
 
     const children = await models.Setup.find({ copiedFrom: setupId })
       .select("-__v -hash -count")
-      .populate("creator", "id name avatar -_id")
+      .populate("creator", "id name avatar avatarVersion -_id")
       .sort({ copiedAt: -1 })
       .lean();
 
@@ -608,7 +608,7 @@ router.get("/:id", async function (req, res) {
   try {
     var setup = await models.Setup.findOne({ id: req.params.id })
       .select("-__v -hash")
-      .populate("creator", "id name avatar tag -_id");
+      .populate("creator", "id name avatar avatarVersion tag -_id");
 
     if (setup) {
       setup = setup.toJSON();

--- a/routes/site.js
+++ b/routes/site.js
@@ -15,7 +15,7 @@ router.get("/contributors", async function (req, res) {
       contributorTypes: { $exists: true },
       deleted: false,
     }).select(
-      "id name avatar vanityUrl contributorTypes contributorBio lastActive -_id"
+      "id name avatar avatarVersion vanityUrl contributorTypes contributorBio lastActive -_id"
     );
 
     // Filter to only include users with non-empty contributorTypes array
@@ -36,6 +36,7 @@ router.get("/contributors", async function (req, res) {
         id: userObj.id,
         name: userObj.name,
         avatar: userObj.avatar,
+        avatarVersion: userObj.avatarVersion || 0,
         vanityUrl: userObj.vanityUrl,
         types: userObj.contributorTypes || [],
         bio: userObj.contributorBio || "",
@@ -55,7 +56,7 @@ router.get("/contributors/art", async function (req, res) {
     const users = await models.User.find({
       deleted: false,
       "roleIconCredits.0": { $exists: true },
-    }).select("id name avatar roleIconCredits -_id");
+    }).select("id name avatar avatarVersion roleIconCredits -_id");
 
     const artContributors = users.map((u) => {
       const json = u.toJSON();
@@ -90,7 +91,7 @@ router.get("/donors", async function (req, res) {
     }).populate({
       path: "user",
       match: { deleted: false },
-      select: "id name avatar lastActive donorBio -_id",
+      select: "id name avatar avatarVersion lastActive donorBio -_id",
     });
 
     const users = inDonorGroup
@@ -118,6 +119,7 @@ router.get("/donors", async function (req, res) {
         id: j.id,
         name: j.name,
         avatar: j.avatar,
+        avatarVersion: j.avatarVersion || 0,
         vanityUrl: vanityByUserId[j.id] || "",
         bio: j.donorBio || "",
       };

--- a/routes/siteActivity.js
+++ b/routes/siteActivity.js
@@ -854,6 +854,7 @@ router.get("/feed", async function (req, res) {
         ...r,
         actorName: info?.name || null,
         actorAvatar: info?.avatar ?? false,
+        actorAvatarVersion: info?.avatarVersion || 0,
         actorVanityUrl: info?.vanityUrl || null,
       };
     });

--- a/routes/stampTrades.js
+++ b/routes/stampTrades.js
@@ -95,21 +95,33 @@ async function stampHasCrossFieldConflict(stampId, ownTradeDocId) {
 
 async function populateTradeForDisplay(trade) {
   const initiator = await models.User.findById(trade.initiator).select(
-    "id name avatar"
+    "id name avatar avatarVersion"
   );
   const recipient = trade.recipient
-    ? await models.User.findById(trade.recipient).select("id name avatar")
+    ? await models.User.findById(trade.recipient).select(
+        "id name avatar avatarVersion"
+      )
     : null;
   return {
     id: trade.id,
     status: trade.status,
     initiator: initiator
-      ? { id: initiator.id, name: initiator.name, avatar: initiator.avatar }
+      ? {
+          id: initiator.id,
+          name: initiator.name,
+          avatar: initiator.avatar,
+          avatarVersion: initiator.avatarVersion || 0,
+        }
       : null,
     initiatorGameType: trade.initiatorGameType,
     initiatorRole: trade.initiatorRole,
     recipient: recipient
-      ? { id: recipient.id, name: recipient.name, avatar: recipient.avatar }
+      ? {
+          id: recipient.id,
+          name: recipient.name,
+          avatar: recipient.avatar,
+          avatarVersion: recipient.avatarVersion || 0,
+        }
       : null,
     recipientGameType: trade.recipientGameType,
     recipientRole: trade.recipientRole,

--- a/routes/stockMarket.js
+++ b/routes/stockMarket.js
@@ -408,7 +408,7 @@ router.get("/", async function (req, res) {
     const userIds = stocks.map(s => s.userId);
     const [users, transactionsGrouped] = await Promise.all([
       models.User.find({ id: { $in: userIds } })
-        .select("id name avatar settings.nameColor settings.vanityUrl")
+        .select("id name avatar avatarVersion settings.nameColor settings.vanityUrl")
         .lean()
         .exec(),
       models.StockTransaction.aggregate([
@@ -446,6 +446,7 @@ router.get("/", async function (req, res) {
         userId: stock.userId,
         username: u.name,
         avatar: u.avatar,
+        avatarVersion: u.avatarVersion || 0,
         vanityUrl: u.settings?.vanityUrl || "",
         nameColor: u.settings?.nameColor || "",
         shareSupply: stock.shareSupply,
@@ -522,7 +523,7 @@ router.get("/transactions", async function (req, res) {
       }
 
       const users = await models.User.find({ id: { $in: Array.from(userIds) } })
-        .select("id name avatar settings.nameColor settings.vanityUrl")
+        .select("id name avatar avatarVersion settings.nameColor settings.vanityUrl")
         .lean()
         .exec();
 
@@ -539,11 +540,13 @@ router.get("/transactions", async function (req, res) {
           userId: tx.userId,
           buyerName: buyer.name,
           buyerAvatar: buyer.avatar,
+          buyerAvatarVersion: buyer.avatarVersion || 0,
           buyerNameColor: buyer.settings?.nameColor || "",
           buyerVanityUrl: buyer.settings?.vanityUrl || "",
           subjectId: tx.subjectId,
           subjectName: subject.name,
           subjectAvatar: subject.avatar,
+          subjectAvatarVersion: subject.avatarVersion || 0,
           subjectNameColor: subject.settings?.nameColor || "",
           subjectVanityUrl: subject.settings?.vanityUrl || "",
           type: tx.type,
@@ -606,11 +609,11 @@ router.get("/transactions", async function (req, res) {
 
       const [users, families] = await Promise.all([
         models.User.find({ id: { $in: Array.from(userIds) } })
-          .select("id name avatar settings.nameColor settings.vanityUrl")
+          .select("id name avatar avatarVersion settings.nameColor settings.vanityUrl")
           .lean()
           .exec(),
         models.Family.find({ id: { $in: Array.from(familyIds) } })
-          .select("id name avatar background treasury")
+          .select("id name avatar avatarVersion background treasury")
           .lean()
           .exec()
       ]);
@@ -633,11 +636,13 @@ router.get("/transactions", async function (req, res) {
           userId: tx.userId,
           buyerName: buyer.name,
           buyerAvatar: buyer.avatar,
+          buyerAvatarVersion: buyer.avatarVersion || 0,
           buyerNameColor: buyer.settings?.nameColor || "",
           buyerVanityUrl: buyer.settings?.vanityUrl || "",
           familyId: tx.familyId,
           familyName: family.name,
           familyAvatar: family.avatar,
+          familyAvatarVersion: family.avatarVersion || 0,
           familyBackground: family.background || false,
           type: tx.type,
           shares: tx.shares,
@@ -670,7 +675,7 @@ router.get("/portfolio", async function (req, res) {
     const [stocks, users] = await Promise.all([
       models.PlayerStock.find({ userId: { $in: subjectIds } }).lean().exec(),
       models.User.find({ id: { $in: subjectIds } })
-        .select("id name avatar settings.nameColor settings.vanityUrl")
+        .select("id name avatar avatarVersion settings.nameColor settings.vanityUrl")
         .lean()
         .exec()
     ]);
@@ -700,6 +705,7 @@ router.get("/portfolio", async function (req, res) {
         subjectId,
         username: u.name,
         avatar: u.avatar,
+        avatarVersion: u.avatarVersion || 0,
         vanityUrl: u.settings?.vanityUrl || "",
         nameColor: u.settings?.nameColor || "",
         sharesOwned: h.sharesOwned,
@@ -850,7 +856,7 @@ router.get("/families", async function (req, res) {
 
     const [families, transactionsGrouped] = await Promise.all([
       models.Family.find({ id: { $in: familyIds } })
-        .select("id name avatar background treasury")
+        .select("id name avatar avatarVersion background treasury")
         .lean()
         .exec(),
       models.FamilyStockTransaction.aggregate([
@@ -888,6 +894,7 @@ router.get("/families", async function (req, res) {
         familyId: stock.familyId,
         familyName: f.name,
         avatar: f.avatar,
+        avatarVersion: f.avatarVersion || 0,
         background: f.background,
         shareSupply: stock.shareSupply,
         marketCap,
@@ -921,7 +928,7 @@ router.get("/families/eligible", async function (req, res) {
     const families = await models.Family.find({
       $or: [{ leader: userObj._id }, { founder: userObj._id }]
     })
-      .select("id name avatar")
+      .select("id name avatar avatarVersion")
       .lean()
       .exec();
 
@@ -953,7 +960,7 @@ router.get("/families/portfolio", async function (req, res) {
 
     const [stocks, families] = await Promise.all([
       models.FamilyStock.find({ familyId: { $in: familyIds } }).lean().exec(),
-      models.Family.find({ id: { $in: familyIds } }).select("id name avatar background treasury").lean().exec()
+      models.Family.find({ id: { $in: familyIds } }).select("id name avatar avatarVersion background treasury").lean().exec()
     ]);
 
     const stockMap = {};
@@ -981,6 +988,7 @@ router.get("/families/portfolio", async function (req, res) {
         familyId: h.familyId,
         familyName: f.name,
         avatar: f.avatar,
+        avatarVersion: f.avatarVersion || 0,
         background: f.background,
         sharesOwned: h.sharesOwned,
         liquidValue,
@@ -1015,7 +1023,7 @@ router.get("/families/prices/:familyId", async function (req, res) {
       return errors.notFound(res, "This family has not launched an ETF or does not exist.");
     }
 
-    const family = await models.Family.findOne({ id: familyId }).select("name avatar background treasury").lean().exec();
+    const family = await models.Family.findOne({ id: familyId }).select("name avatar avatarVersion background treasury").lean().exec();
     const buy1 = stockMarket.getBuyPrice(stock.shareSupply, 1);
     const sell1 = stockMarket.getSellPrice(stock.shareSupply, 1);
     const marketCap = stock.shareSupply * stockMarket.calculatePrice(stock.shareSupply);
@@ -1024,6 +1032,7 @@ router.get("/families/prices/:familyId", async function (req, res) {
       familyId: stock.familyId,
       familyName: family ? family.name : "Unknown",
       avatar: family?.avatar,
+      avatarVersion: family?.avatarVersion || 0,
       background: family?.background,
       shareSupply: stock.shareSupply,
       marketCap,

--- a/routes/strategy.js
+++ b/routes/strategy.js
@@ -28,6 +28,7 @@ function formatAuthor(authorDoc) {
     id: authorDoc.id,
     name: authorDoc.name,
     avatar: authorDoc.avatar,
+    avatarVersion: authorDoc.avatarVersion || 0,
     groups: authorDoc.groups,
     vanityUrl: authorDoc.vanityUrl,
     deleted: Boolean(authorDoc.deleted),
@@ -65,7 +66,7 @@ async function getStrategyWithAuthor(strategyId) {
   if (!strategyId) return null;
   return models.Strategy.findOne({ id: strategyId })
     .select(strategyProjection)
-    .populate("author", "id name avatar groups vanityUrl deleted")
+    .populate("author", "id name avatar avatarVersion groups vanityUrl deleted")
     .lean();
 }
 
@@ -115,7 +116,7 @@ router.get("/", async function (req, res) {
 
     const strategies = await models.Strategy.find(strategyFilter)
       .select(strategyProjection)
-      .populate("author", "id name avatar groups vanityUrl deleted")
+      .populate("author", "id name avatar avatarVersion groups vanityUrl deleted")
       .sort({ deleted: 1, voteCount: -1, updatedAt: -1, createdAt: -1 })
       .lean();
 

--- a/routes/user.js
+++ b/routes/user.js
@@ -248,6 +248,7 @@ router.get("/searchName", async function (req, res) {
           id: 1,
           name: 1,
           avatar: 1,
+          avatarVersion: 1,
           _prefixMatch: 1,
           _nameLength: 1,
           _id: 0,
@@ -274,6 +275,7 @@ router.get("/searchName", async function (req, res) {
       id: u.id,
       name: u.name,
       avatar: u.avatar,
+      avatarVersion: u.avatarVersion || 0,
       status: u.status,
     }));
 
@@ -307,7 +309,7 @@ router.get("/newest", async function (req, res) {
       "joined",
       last,
       first,
-      "id name avatar joined -_id",
+      "id name avatar avatarVersion joined -_id",
       constants.newestUsersPageSize
     );
 
@@ -334,7 +336,7 @@ router.get("/flagged", async function (req, res) {
       "joined",
       last,
       first,
-      "id name avatar joined -_id",
+      "id name avatar avatarVersion joined -_id",
       constants.newestUsersPageSize
     );
 
@@ -408,7 +410,7 @@ router.get("/:id/profile", async function (req, res) {
     var isSelf = reqUserId == userId;
     var user = await models.User.findOne({ id: userId, deleted: false })
       .select(
-        "id name avatar profileBackground settings accounts wins losses kudos karma points pointsNegative championshipPoints achievements bio pronouns banner bannerExt setups games numFriends stats lastActive joined favoriteRoles roleIconCredits skillRating _id"
+        "id name avatar avatarVersion profileBackground settings accounts wins losses kudos karma points pointsNegative championshipPoints achievements bio pronouns banner bannerExt setups games numFriends stats lastActive joined favoriteRoles roleIconCredits skillRating _id"
       )
       .populate({
         path: "setups",
@@ -690,7 +692,7 @@ router.get("/:id/profile", async function (req, res) {
         const otherUserId = isInitiator ? t.recipientId : t.initiatorId;
         const otherUser = await models.User.findOne({
           id: otherUserId,
-        }).select("id name avatar");
+        }).select("id name avatar avatarVersion");
         // Whose turn is it?
         // PENDING_RESPONSE: recipient needs to respond.
         // PENDING_CONFIRMATION: depends on whether auto-responded.
@@ -712,6 +714,7 @@ router.get("/:id/profile", async function (req, res) {
                 id: otherUser.id,
                 name: otherUser.name,
                 avatar: otherUser.avatar,
+                avatarVersion: otherUser.avatarVersion || 0,
               }
             : null,
           isInitiator,
@@ -737,7 +740,7 @@ router.get("/:id/profile", async function (req, res) {
       ownerId: userId,
       revoked: { $ne: true },
     })
-      .populate("owner", "id name avatar vanityUrl")
+      .populate("owner", "id name avatar avatarVersion vanityUrl")
       .select("id name ownerId owner type createdAt -_id")
       .sort("-createdAt")
       .lean();
@@ -751,6 +754,7 @@ router.get("/:id/profile", async function (req, res) {
             id: trophy.owner.id,
             name: trophy.owner.name,
             avatar: trophy.owner.avatar,
+            avatarVersion: trophy.owner.avatarVersion || 0,
             vanityUrl: trophy.owner.vanityUrl,
           }
         : null,
@@ -759,7 +763,7 @@ router.get("/:id/profile", async function (req, res) {
     if (isSelf) {
       var friendRequests = await models.FriendRequest.find({ targetId: userId })
         .select("userId user")
-        .populate("user", "id name avatar");
+        .populate("user", "id name avatar avatarVersion");
 
       // Add vanity URLs to friend requests — one indexed $in lookup rather than
       // one query per request.
@@ -824,7 +828,7 @@ router.get("/:id/profile", async function (req, res) {
       .select("loveId type")
       .populate({
         path: "love",
-        select: "id name avatar -_id",
+        select: "id name avatar avatarVersion -_id",
       });
 
     if (user.love !== null) {
@@ -947,7 +951,7 @@ router.get("/:id/profile", async function (req, res) {
       user: userMongoId,
     }).populate({
       path: "family",
-      select: "id name avatar -_id",
+      select: "id name avatar avatarVersion -_id",
     });
 
     if (inFamily && inFamily.family) {
@@ -955,6 +959,7 @@ router.get("/:id/profile", async function (req, res) {
         id: inFamily.family.id,
         name: inFamily.family.name,
         avatar: inFamily.family.avatar,
+        avatarVersion: inFamily.family.avatarVersion || 0,
       };
     } else {
       user.family = null;
@@ -966,10 +971,15 @@ router.get("/:id/profile", async function (req, res) {
       for (const poke of incomingPokes) {
         if (isPokeExpired(poke)) continue;
         const sender = await models.User.findOne({ id: poke.from, deleted: false })
-          .select("id name avatar settings -_id");
+          .select("id name avatar avatarVersion settings -_id");
         if (sender && !sender.settings?.disablePokes) {
           user.incomingPokes.push({
-            from: { id: sender.id, name: sender.name, avatar: sender.avatar },
+            from: {
+              id: sender.id,
+              name: sender.name,
+              avatar: sender.avatar,
+              avatarVersion: sender.avatarVersion || 0,
+            },
             count: poke.count,
             updatedAt: poke.updatedAt,
           });
@@ -1129,7 +1139,7 @@ router.get("/:id/love", async function (req, res) {
       .select("loveId type")
       .populate({
         path: "love",
-        select: "id name avatar -_id",
+        select: "id name avatar avatarVersion -_id",
       });
 
     if (love) {
@@ -1175,7 +1185,7 @@ router.get("/:id/friends", async function (req, res) {
       first,
       "friendId friend lastActive -_id",
       constants.friendsPerPage,
-      ["friend", "id name avatar -_id"]
+      ["friend", "id name avatar avatarVersion -_id"]
     );
 
     friends = friends.map((friend) => friend.toJSON());
@@ -1438,6 +1448,7 @@ router.get("/:id/reports", async function (req, res) {
         if (reportedUserInfo) {
           report.reportedUserName = reportedUserInfo.name;
           report.reportedUserAvatar = reportedUserInfo.avatar;
+          report.reportedUserAvatarVersion = reportedUserInfo.avatarVersion || 0;
         }
 
         const reporterInfo = await getBasicUserInfo(report.reporterId);
@@ -1484,6 +1495,7 @@ router.get("/:id/info", async function (req, res) {
       res.send({
         name: "[not found]",
         avatar: false,
+        avatarVersion: 0,
       });
       return;
     }
@@ -1495,6 +1507,7 @@ router.get("/:id/info", async function (req, res) {
       res.send({
         name: "[not found]",
         avatar: false,
+        avatarVersion: 0,
       });
       return;
     }
@@ -3317,7 +3330,10 @@ router.post("/avatar", async function (req, res) {
         logger.warn(staticErr);
       }
 
-      await models.User.updateOne({ id: userId }, { $set: { avatar: true } });
+      await models.User.updateOne(
+        { id: userId },
+        { $set: { avatar: true, avatarVersion: Date.now() } }
+      );
       await redis.cacheUserInfo(userId, true);
 
       models.SiteActivity.create({
@@ -3356,7 +3372,10 @@ router.post("/avatar/delete", async function (req, res) {
   try {
     var userId = await routeUtils.verifyLoggedIn(req);
 
-    await models.User.updateOne({ id: userId }, { $set: { avatar: false } });
+    await models.User.updateOne(
+      { id: userId },
+      { $set: { avatar: false, avatarVersion: Date.now() } }
+    );
     await redis.cacheUserInfo(userId, true);
 
     // Best-effort delete of uploaded files (default letter avatar when avatar is false)
@@ -3842,7 +3861,7 @@ router.post("/love", async function (req, res) {
         love = love.toJSON();
 
         var userLove = await models.User.findOne({ id: love.loveId }).select(
-          "id name avatar -_id"
+          "id name avatar avatarVersion -_id"
         );
 
         userLove = userLove.toJSON();

--- a/routes/wordDeck.js
+++ b/routes/wordDeck.js
@@ -157,7 +157,7 @@ router.post("/delete", async function (req, res) {
       .populate({
         path: "creator",
         model: "User",
-        select: "id name avatar -_id",
+        select: "id name avatar avatarVersion -_id",
       });
 
     if (!deck) {
@@ -400,7 +400,7 @@ router.get("/featured", async function (req, res) {
         .skip(start)
         .limit(pageSize)
         .select("id name description words creator coverPhoto voteCount isDefault")
-        .populate("creator", "id name avatar -_id")
+        .populate("creator", "id name avatar avatarVersion -_id")
         .lean();
       decks = attachWordPreviews(decks);
       decks = await attachUserVotes(decks, userId);
@@ -524,7 +524,7 @@ router.get("/yours", async function (req, res) {
     }
 
     let user = await models.User.findOne({ id: userId, deleted: false })
-      .select("wordDecks name avatar id")
+      .select("wordDecks name avatar avatarVersion id")
       .populate({
         path: "wordDecks",
         select:
@@ -534,7 +534,7 @@ router.get("/yours", async function (req, res) {
           {
             path: "creator",
             model: "User",
-            select: "id name avatar -_id",
+            select: "id name avatar avatarVersion -_id",
           },
         ],
       })
@@ -597,7 +597,7 @@ router.get("/:id", async function (req, res) {
       .populate({
         path: "creator",
         model: "User",
-        select: "id name avatar -_id",
+        select: "id name avatar avatarVersion -_id",
       });
 
     if (deck) {

--- a/test/hallOfFame.test.js
+++ b/test/hallOfFame.test.js
@@ -74,6 +74,7 @@ describe("modules/hallOfFame - rated-games barrier", function () {
       id,
       name: id,
       avatar: false,
+      avatarVersion: 5,
       deleted: false,
       playedGame: true,
       settings,
@@ -147,6 +148,22 @@ describe("modules/hallOfFame - rated-games barrier", function () {
     should.equal(tooFew.skillMu, null);
     should.equal(tooFew.skillSigma, null);
     tooFew.skillTier.should.equal("Unranked");
+  });
+
+  it("carries avatarVersion through to board rows", async function () {
+    useUsers([mockUser("rated", MIN_RATED_GAMES)]);
+
+    const result = await board();
+
+    result.users[0].avatarVersion.should.equal(5);
+  });
+
+  it("defaults avatarVersion to 0 when absent", async function () {
+    useUsers([{ ...mockUser("legacy", MIN_RATED_GAMES), avatarVersion: undefined }]);
+
+    const result = await board();
+
+    result.users[0].avatarVersion.should.equal(0);
   });
 
   it("leaves players who hide their statistics off the rating leaderboard", async function () {


### PR DESCRIPTION
Avatar changes currently take up to 30 days to reach other users. The upload replaces `/uploads/{userId}_avatar.webp` in place, nginx caches `/uploads/` for 30 days, and the frontend cache-buster `?t=` is a per-browser localStorage timestamp that only changes when the *viewer* changes their own images — so nobody else's URL ever changes when an avatar changes.

**Part A:** `nginx.conf` serves `/uploads/` with `expires 24h` (was 30d). Etag revalidation bounds staleness to a day for surfaces that hold stale user objects (open chat rooms, in-game player snapshots — game user info is frozen at socket auth and has no mid-game refresh).

**Part B:** per-avatar cache busting. `avatarVersion` (ms timestamp, bumped on every upload/delete/clear, including the mod actions that bypass normal upload routes) is added to the User and Family schemas and threaded through the redis user cache, the game engine, chat, and API serializations. The frontend builds `?t=avatarVersion` for user and family avatars instead of the global `cacheVal`, falling back to `cacheVal` when the field is absent (legacy caches, bots, guests). The static-avatar probe cache key includes the effective bust value so it can't serve stale results.

**Verification:** backend suite run in the backend container against clean master with a clean DB, chunk by chunk — identical results on every chunk, plus 2 new passing hallOfFame assertions covering the new field. Frontend lint clean. Two-browser manual verification (uploader sees it instantly, viewer within a day at worst, immediately when their data is fresh) still to be done on a running stack.
