### PR TITLE
fix(site): revalidate uploads on every use instead of caching 30d

### DIFF
--- a/react_main/nginx.conf
+++ b/react_main/nginx.conf
@@ -39,8 +39,10 @@ server {
 	
 	location ^~ /uploads/ {
 		alias /uploads/;
-		expires 30d;
-		add_header Cache-Control "public, no-transform";
+		# Uploads (avatars, banners, etc.) live at stable paths and are replaced
+		# in place, so browsers must revalidate before each use. Unchanged files
+		# cost a tiny 304 via the etag; changed files are seen immediately.
+		add_header Cache-Control "public, no-cache, no-transform";
 	}
 
 	location /chatSocket {


### PR DESCRIPTION
Avatar changes currently take up to 30 days to reach other users: avatar files live at stable `/uploads/{userId}_avatar.webp` paths and are replaced in place, while nginx serves `/uploads/` with `expires 30d`. Combined with the frontend's `?t=` cache-buster being a per-browser localStorage value that doesn't change when *someone else's* avatar changes, other viewers' URLs never change and browsers serve the stale file for up to a month.

This bug never reproduces in dev because dev and prod serve uploads through different stacks with different TTLs:

- **Dev**: Rsbuild proxies `/uploads/` to the backend, where `express.static` serves it with `maxAge: "1h"` (`app.js`, `rsbuild.config.ts`) — worst case 1h staleness, etag revalidation after.
- **Prod**: nginx serves `/uploads/` directly with `expires 30d` — 720× longer.

Fix: serve `/uploads/` with `Cache-Control: public, no-cache, no-transform` instead of `expires 30d`. Browsers store the response but revalidate via the etag (nginx's mtime+size hash, which changes when the upload replaces the file) before every use. Unchanged avatars cost one tiny conditional request (~200 bytes, answered 304); changed avatars are seen by everyone on the next fetch — regardless of how stale a client's user data or `?t=` value is.

Verified: the exact nginx semantics were tested in an nginx 1.29 container — correct `no-cache` header, 304 for unchanged files, 200 with the new file after an in-place replacement. Deploy is a web-container restart (the conf is volume-mounted via docker-compose-prod.yml).
