### PR TITLE
doc: drop Socket.io claim and empty-PR-description rule from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # Ultimafia
 
-Web-based chat mafia game platform (ultimafia.com). Node.js backend with React frontend, real-time gameplay via Socket.io.
+Web-based chat mafia game platform (ultimafia.com). Node.js backend with React frontend, real-time gameplay over WebSockets.
 
 ## Tech Stack
 
-- **Backend:** Node.js 22.17.0, Express, Socket.io, PM2 (3 processes: games, www, chat)
+- **Backend:** Node.js 22.17.0, Express, PM2 (3 processes: games, www, chat)
 - **Frontend:** React 17, Rsbuild, Material-UI, D3.js (in `react_main/`)
 - **Database:** MongoDB 8.0 (Mongoose ODM), Redis 8.0 (sessions, game state, pub/sub)
 - **Auth:** Firebase Auth + Passport.js (Discord, Google, Twitch, Steam)
@@ -132,4 +132,4 @@ Frontend `react_main/.env` — see `docs/client_env` for template. Key vars:
 - **Main branch:** master
 - **Branch naming:** `add-<role-name>` for roles, descriptive names for features
 - **Commit prefixes:** feat, fix, chore, doc
-- **PRs:** Target master branch, require review before merge, always use empty description (`--body ""`)
+- **PRs:** Target master branch, require review before merge


### PR DESCRIPTION
Two corrections to CLAUDE.md:

1. The backend does not use Socket.io — sockets are raw WebSockets via the `ws` library (`lib/sockets.js`), the game server's `socket.send`/`socket.terminate` API, and `socket.on` in `Games/games.js`. `socket.io` and `express-socket.io-session` still sit in package.json but are not required anywhere. The intro and Tech Stack sections claimed Socket.io; the intro now says WebSockets and the tech-stack mention is removed.

2. The "always use empty description (`--body ""`)" PR rule is removed — PRs should carry real descriptions.