### PR TITLE
fix(audio): keep game sounds and music out of system media controls

### DIFF
--- a/react_main/src/audio/AudioManager.ts
+++ b/react_main/src/audio/AudioManager.ts
@@ -1,19 +1,4 @@
-/**
- * AudioManager — imperative wrapper around HTMLAudioElement instances.
- *
- * Manages loading, playing, pausing and per-channel volume for all in-game
- * audio.
- *
- * Elements are created on first play, not at load time. `load()` used to
- * construct an HTMLAudioElement and call `.load()` for every entry it was given,
- * which for Mafia is 66 of them in one go. That costs almost no JavaScript --
- * both calls return immediately -- but it hands 66 media resources to the
- * platform at once, and iOS keeps a low ceiling on how many it will carry.
- * Measured on an iPhone 16, the resulting stall blocked painting for anywhere
- * between 2 and 88 seconds after React had already committed the DOM, so the
- * page sat there showing stale pixels. Creating them on demand takes a typical
- * Mafia game from 66 elements down to the handful it actually plays.
- */
+import WebAudioSound from "./WebAudioSound";
 
 export type AudioChannel = "sfx" | "music" | "pregameMusic" | "important";
 
@@ -23,22 +8,12 @@ export interface AudioEntry {
   volume?: number;
   overrides?: boolean;
   channel?: AudioChannel;
-  /**
-   * Build and buffer this track at load time instead of on first play.
-   *
-   * Defaults to true for every channel except music, which is where the weight
-   * is -- all 26 effect files together are 1.5MB against 82MB of music. Set it
-   * explicitly for anything that does not fit that shape: a short cue filed
-   * under music/ needs `preload: true` or it will be inaudible when something
-   * stops it shortly after it starts, and a heavy effect outside music/ wants
-   * `preload: false` so it is not handed to the platform up front.
-   */
+  /** Buffer short cues ahead of playback. Long music loads on demand. */
   preload?: boolean;
 }
 
 export interface LoadedTrack {
-  /** Null until the track is created -- at load time if preloaded, else on first play. */
-  el: HTMLAudioElement | null;
+  sound: WebAudioSound;
   fileName: string;
   loop: boolean;
   volume: number;
@@ -47,281 +22,112 @@ export interface LoadedTrack {
   preload: boolean;
 }
 
-interface ChannelVolumes {
-  sfx: number;
-  music: number;
-  pregameMusic: number;
-  important: number;
-}
-
 export default class AudioManager {
   tracks: Record<string, LoadedTrack> = {};
-
-  /**
-   * Last volumes applied via syncVolume, so an element created later can be set
-   * up correctly without waiting for the next sync.
-   */
-  private volumes: ChannelVolumes = {
-    sfx: 1,
-    music: 1,
-    pregameMusic: 1,
-    important: 1,
+  private transientSounds = new Set<WebAudioSound>();
+  private generation = 0;
+  private volumes: Record<AudioChannel, number> = {
+    sfx: 1, music: 1, pregameMusic: 1, important: 1,
   };
 
-  constructor() {
-    // Without this, iOS Safari treats every HTMLAudioElement as exclusive
-    // "playback" audio and pauses other tabs' media (YouTube, Spotify, etc.)
-    // when we play a UI sound — e.g. the ready-check ping silencing a video
-    // the user was watching. "ambient" lets our sounds mix in instead.
-    const nav = navigator as Navigator & {
-      audioSession?: { type?: string };
-    };
-    if (nav.audioSession) {
-      try {
-        nav.audioSession.type = "ambient";
-      } catch {}
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Helpers
-  // ---------------------------------------------------------------------------
-
-  /** Infer a default channel from a filename when none is provided. */
   static inferChannel(fileName: string): AudioChannel {
     if (fileName.includes("music/Pregame")) return "pregameMusic";
     if (fileName.includes("music")) return "music";
     return "sfx";
   }
 
-  /** Clamp a number to [0, 1], returning `fallback` for non-finite input. */
-  static clamp(value: unknown, fallback: number = 1): number {
+  static clamp(value: unknown, fallback = 1): number {
     const parsed = Number(value);
-    if (!Number.isFinite(parsed)) return fallback;
-    if (parsed < 0) return 0;
-    if (parsed > 1) return 1;
-    return parsed;
+    return Number.isFinite(parsed) ? Math.max(0, Math.min(1, parsed)) : fallback;
   }
 
-  private sliderFor(channel: AudioChannel): number {
-    if (channel === "music") return this.volumes.music;
-    if (channel === "pregameMusic") return this.volumes.pregameMusic;
-    if (channel === "important") return this.volumes.important;
-    return this.volumes.sfx;
-  }
-
-  /** Default preload policy: everything except the long music tracks. */
-  private static defaultPreload(channel: AudioChannel): boolean {
-    return channel !== "music" && channel !== "pregameMusic";
-  }
-
-  /**
-   * Create the element for a track if it does not exist yet.
-   *
-   * `buffer` asks the browser to fetch ahead, which is what makes a sound audible
-   * the instant it is played rather than once the fetch lands.
-   */
-  private ensureElement(
-    track: LoadedTrack,
-    buffer: boolean = false
-  ): HTMLAudioElement | null {
-    if (track.el) return track.el;
-
-    try {
-      const el = new Audio(`/audio/${track.fileName}.mp3`);
-      el.preload = buffer ? "auto" : "metadata";
-      el.loop = track.loop;
-      el.volume = track.volume * this.sliderFor(track.channel);
-      track.el = el;
-      return el;
-    } catch (e) {
-      return null;
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Loading
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Register (or re-register) a set of audio entries. This only records their
-   * configuration; the element itself is built on first play.
-   */
   load(entries: AudioEntry[]): void {
-    if (!Array.isArray(entries) || entries.length === 0) return;
-
+    if (!Array.isArray(entries)) return;
     for (const entry of entries) {
-      const {
-        fileName,
-        loop = false,
-        volume = 1,
-        overrides = false,
-        channel,
-        preload,
-      } = entry;
-
-      if (!fileName) continue;
-
-      const resolvedChannel = channel || AudioManager.inferChannel(fileName);
-      const resolvedPreload =
-        preload ?? AudioManager.defaultPreload(resolvedChannel);
-      const existing = this.tracks[fileName];
-
-      if (existing) {
-        // Pause before changing loop to make sure the change applies.
-        if (existing.el) {
-          existing.el.pause();
-          existing.el.loop = loop;
-        }
-        existing.loop = loop;
-        existing.volume = volume;
-        existing.overrides = overrides;
-        existing.channel = resolvedChannel;
-        existing.preload = resolvedPreload;
-
-        // The track may have been disposed since it was last loaded, leaving the
-        // record without its element. Rebuild it, or the track stays silent
-        // until something plays it -- which is the lazy behaviour preloading
-        // exists to avoid.
-        if (resolvedPreload && !existing.el) {
-          this.ensureElement(existing, true);
-        }
-      } else {
-        const track: LoadedTrack = {
-          el: null,
-          fileName,
-          loop,
-          volume,
-          overrides,
-          channel: resolvedChannel,
-          preload: resolvedPreload,
-        };
-        this.tracks[fileName] = track;
-
-        // Sound effects are built and buffered up front; music is left until it
-        // is first played.
-        //
-        // The split is by weight, not by principle: all 26 effect files together
-        // are 1.5MB, while the 62 music tracks are 82MB. Handing the platform the
-        // music up front is what stalled iOS, and effects are cheap enough that
-        // there is no reason to make them lazy -- doing so made short cues
-        // inaudible, because a sound that is stopped shortly after it starts (the
-        // ready-check alarm, which ends as soon as everyone readies) was still
-        // fetching when the stop arrived and never made a sound at all.
-        if (resolvedPreload) {
-          this.ensureElement(track, true);
-        }
+      if (!entry.fileName) continue;
+      const channel = entry.channel || AudioManager.inferChannel(entry.fileName);
+      const preload = entry.preload ?? (channel !== "music" && channel !== "pregameMusic");
+      const existing = this.tracks[entry.fileName];
+      existing?.sound.stop();
+      const sound = existing && existing.preload === preload
+        ? existing.sound
+        : new WebAudioSound(`/audio/${entry.fileName}.mp3`, preload);
+      if (existing && existing.sound !== sound) existing.sound.dispose();
+      const track: LoadedTrack = {
+        fileName: entry.fileName,
+        loop: entry.loop ?? false,
+        volume: AudioManager.clamp(entry.volume),
+        overrides: entry.overrides ?? false,
+        channel, preload, sound,
+      };
+      this.tracks[entry.fileName] = track;
+      sound.volume = track.volume * this.volumes[channel];
+      if (preload) {
+        try { void sound.preload().catch(() => {}); } catch {}
       }
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // Playback
-  // ---------------------------------------------------------------------------
-
-  /** Play a single audio file by name.  Pauses other overriding tracks first. */
   play(audioName: string): void {
     const track = this.tracks[audioName];
     if (!track) return;
-
-    // If this file is marked as overriding, pause all other override tracks.
-    // Only ones that exist can be playing.
     if (track.overrides) {
-      for (const name in this.tracks) {
-        const other = this.tracks[name];
-        if (other.overrides && other.el) other.el.pause();
+      for (const other of Object.values(this.tracks)) {
+        if (other.overrides) other.sound.stop();
       }
     }
-
-    const el = this.ensureElement(track, true);
-    if (!el) return;
-
-    // Assigning currentTime forces a seek, which on iOS can block on a track
-    // that is not buffered. A freshly created element is already at zero.
-    if (el.currentTime > 0) el.currentTime = 0;
-
-    el.play().catch(() => {});
+    try { void track.sound.play(track.loop).catch(() => {}); } catch {}
   }
 
-  /**
-   * Stop a single audio file, or *all* audio files when called without an
-   * argument.
-   */
   stop(audioName?: string): void {
-    if (audioName != null) {
-      const track = this.tracks[audioName];
-      if (track && track.el) track.el.pause();
-    } else {
-      for (const name in this.tracks) {
-        const track = this.tracks[name];
-        if (track.channel === "important") continue;
-        if (track.el) track.el.pause();
+    if (audioName != null) this.tracks[audioName]?.sound.stop();
+    else {
+      for (const track of Object.values(this.tracks)) {
+        if (track.channel !== "important") track.sound.stop();
       }
     }
   }
 
-  /** Stop a list of audio files by name. */
   stopMany(audioNames: string[]): void {
-    if (!Array.isArray(audioNames)) return;
-    for (const name of audioNames) {
-      const track = this.tracks[name];
-      if (track && track.el) track.el.pause();
+    if (Array.isArray(audioNames)) audioNames.forEach((name) => this.stop(name));
+  }
+
+  async playUrls(urls: string[], volume: () => number): Promise<void> {
+    const generation = this.generation;
+    for (const url of urls) {
+      if (generation !== this.generation) return;
+      if (typeof url !== "string" || !url.length) continue;
+      const sound = new WebAudioSound(url, false);
+      sound.volume = volume();
+      this.transientSounds.add(sound);
+      // Invalid files or suspended mobile playback must not stall the queue.
+      const timeout = setTimeout(() => sound.dispose(), 6000);
+      try { await sound.play(); } catch {}
+      finally {
+        clearTimeout(timeout);
+        sound.dispose();
+        this.transientSounds.delete(sound);
+      }
     }
   }
 
-  /**
-   * Release every element. Without this the elements outlive the game they were
-   * created for, since nothing else drops the references.
-   */
   dispose(): void {
-    for (const name in this.tracks) {
-      const track = this.tracks[name];
-      if (!track.el) continue;
-
-      try {
-        track.el.pause();
-        track.el.removeAttribute("src");
-        track.el.load();
-      } catch (e) {
-        // Element may already be torn down by the browser.
-      }
-      track.el = null;
-    }
-
-    // Reset to the constructed state. Keeping the records around would leave the
-    // manager in a state a later load() has to repair rather than simply build.
+    this.generation++;
+    for (const track of Object.values(this.tracks)) track.sound.dispose();
+    for (const sound of this.transientSounds) sound.dispose();
+    this.transientSounds.clear();
     this.tracks = {};
   }
 
-  // ---------------------------------------------------------------------------
-  // Volume
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Synchronise every loaded element's actual volume with the current slider
-   * values.
-   */
-  syncVolume(
-    sfxVolume: number,
-    musicVolume: number,
-    pregameMusicVolume: number,
-    importantVolume: number
-  ): void {
+  syncVolume(sfx: number, music: number, pregameMusic: number, important: number): void {
     this.volumes = {
-      sfx: AudioManager.clamp(sfxVolume),
-      music: AudioManager.clamp(musicVolume),
-      pregameMusic: AudioManager.clamp(pregameMusicVolume),
-      important: AudioManager.clamp(importantVolume),
+      sfx: AudioManager.clamp(sfx), music: AudioManager.clamp(music),
+      pregameMusic: AudioManager.clamp(pregameMusic), important: AudioManager.clamp(important),
     };
-
-    for (const name in this.tracks) {
-      const { el, volume, channel } = this.tracks[name];
-      if (!el) continue;
-      el.volume = volume * this.sliderFor(channel);
+    for (const track of Object.values(this.tracks)) {
+      track.sound.volume = track.volume * this.volumes[track.channel];
     }
   }
 
-  get loadedNames(): string[] {
-    return Object.keys(this.tracks);
-  }
+  get loadedNames(): string[] { return Object.keys(this.tracks); }
 }

--- a/react_main/src/audio/WebAudioSound.ts
+++ b/react_main/src/audio/WebAudioSound.ts
@@ -1,0 +1,130 @@
+// Use buffer sources directly: HTML media elements expose game audio through
+// OS media controls, even when connected to a Web Audio graph.
+let context: AudioContext | undefined;
+
+export function getAudioContext(): AudioContext {
+  if (!context || context.state === "closed") {
+    const AudioContextClass = window.AudioContext ||
+      (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextClass) throw new Error("Web Audio is unavailable");
+    context = new AudioContextClass();
+    const nav = navigator as Navigator & { audioSession?: { type: string } };
+    try {
+      if (nav.audioSession) nav.audioSession.type = "ambient";
+    } catch {}
+  }
+  return context;
+}
+
+// Resume synchronously from a gesture, including after mobile interruptions.
+if (typeof document !== "undefined") {
+  const unlock = () => {
+    if (context && context.state !== "running") void context.resume().catch(() => {});
+  };
+  for (const event of ["pointerdown", "touchend", "keydown", "click"]) {
+    document.addEventListener(event, unlock, { capture: true, passive: true });
+  }
+}
+
+export default class WebAudioSound {
+  private buffer?: AudioBuffer;
+  private loading?: Promise<AudioBuffer>;
+  private controller?: AbortController;
+  private source?: AudioBufferSourceNode;
+  private gain?: GainNode;
+  private finish?: () => void;
+  private version = 0;
+  private level = 1;
+
+  constructor(private input: string | AudioBuffer, private retainBuffer = true) {
+    if (typeof input !== "string") this.buffer = input;
+  }
+
+  set volume(value: number) {
+    this.level = Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 1;
+    if (this.gain) this.gain.gain.value = this.level;
+  }
+
+  preload(): Promise<AudioBuffer> {
+    if (this.buffer) return Promise.resolve(this.buffer);
+    if (this.loading) return this.loading;
+    const ctx = getAudioContext();
+    const controller = new AbortController();
+    this.controller = controller;
+    const loading = fetch(this.input as string, { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) throw new Error(`Audio request failed: ${response.status}`);
+        return response.arrayBuffer();
+      })
+      .then((bytes) => ctx.decodeAudioData(bytes))
+      .then((buffer) => {
+        if (controller.signal.aborted) throw new Error("Audio load cancelled");
+        this.buffer = buffer;
+        return buffer;
+      })
+      .finally(() => {
+        if (this.loading === loading) this.loading = undefined;
+      });
+    this.loading = loading;
+    return loading;
+  }
+
+  // Resolves when playback ends or is stopped, for sequential death sounds.
+  play(loop = false): Promise<void> {
+    this.stop();
+    const version = this.version;
+    const ctx = getAudioContext();
+    // Call resume before any await so a caller's user activation is retained.
+    const resumed = ctx.state === "running" ? Promise.resolve() : ctx.resume();
+    return new Promise<void>((resolve, reject) => {
+      this.finish = resolve;
+      Promise.all([this.preload(), resumed]).then(([buffer]) => {
+        if (version !== this.version) return;
+        const source = ctx.createBufferSource();
+        const gain = ctx.createGain();
+        source.buffer = buffer;
+        source.loop = loop;
+        gain.gain.value = this.level;
+        source.connect(gain);
+        gain.connect(ctx.destination);
+        this.source = source;
+        this.gain = gain;
+        source.onended = () => {
+          if (this.source === source) this.stop();
+        };
+        source.start();
+      }).catch((error) => {
+        if (version !== this.version) return;
+        this.finish = undefined;
+        this.stop();
+        reject(error);
+      });
+    });
+  }
+
+  stop(): void {
+    this.version++;
+    if (this.source) {
+      this.source.onended = null;
+      this.source.stop();
+      this.source.disconnect();
+      this.source = undefined;
+    }
+    this.gain?.disconnect();
+    this.gain = undefined;
+    this.finish?.();
+    this.finish = undefined;
+    if (!this.retainBuffer) {
+      this.controller?.abort();
+      this.loading = undefined;
+      this.buffer = undefined;
+    }
+  }
+
+  dispose(): void {
+    this.stop();
+    this.controller?.abort();
+    this.loading = undefined;
+    this.buffer = undefined;
+  }
+}

--- a/react_main/src/audio/audioConfigs.ts
+++ b/react_main/src/audio/audioConfigs.ts
@@ -14,8 +14,8 @@ import type { AudioEntry } from "./AudioManager";
 // ---------------------------------------------------------------------------
 // Core — loaded for every game
 // ---------------------------------------------------------------------------
-// Tracks are built and buffered at load time unless they are music, which is
-// created on first play instead -- see `preload` on AudioEntry. If you add a
+// Tracks are decoded at load time unless they are music, which is
+// decoded on first play instead -- see `preload` on AudioEntry. If you add a
 // short cue under music/, or a heavy file outside it, set `preload` explicitly.
 export const coreAudioConfig: AudioEntry[] = [
   { fileName: "bell", channel: "important" },

--- a/react_main/src/components/DeathSoundUpload.jsx
+++ b/react_main/src/components/DeathSoundUpload.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import WebAudioSound from "../audio/WebAudioSound";
 import {
   Alert,
   Box,
@@ -276,7 +277,7 @@ export default function DeathSoundUpload({
       if (objectUrl) URL.revokeObjectURL(objectUrl);
       if (previewRef.current) {
         try {
-          previewRef.current.pause();
+          previewRef.current.dispose();
         } catch {
           /* ignore */
         }
@@ -338,8 +339,7 @@ export default function DeathSoundUpload({
   const stopPreview = () => {
     if (previewRef.current) {
       try {
-        previewRef.current.pause();
-        previewRef.current.src = "";
+        previewRef.current.dispose();
       } catch {
         /* ignore */
       }
@@ -587,17 +587,8 @@ export default function DeathSoundUpload({
         setError("Select a non-empty trim range.");
         return;
       }
-      const blob = audioBufferToWavBlob(processed);
-      const url = URL.createObjectURL(blob);
-      const audio = new Audio(url);
+      const audio = new WebAudioSound(processed);
       previewRef.current = audio;
-      audio.addEventListener(
-        "ended",
-        () => {
-          URL.revokeObjectURL(url);
-        },
-        { once: true }
-      );
       await audio.play();
     } catch (err) {
       setError(err.message || "Preview failed.");
@@ -691,7 +682,7 @@ export default function DeathSoundUpload({
             onClick={async () => {
               try {
                 stopPreview();
-                const audio = new Audio(existingUrl);
+                const audio = new WebAudioSound(existingUrl, false);
                 previewRef.current = audio;
                 await audio.play();
               } catch {

--- a/react_main/src/hooks/useAudio.ts
+++ b/react_main/src/hooks/useAudio.ts
@@ -14,6 +14,7 @@ interface UseAudioReturn {
   loadAudioFiles: (entries: AudioEntry[]) => void;
   stopAudio: (audioName?: string) => void;
   stopAudios: (audioNames: string[]) => void;
+  playDeathSounds: (urls: string[], volume: () => number) => Promise<void>;
 }
 
 /**
@@ -35,9 +36,7 @@ export function useAudio(settings: AudioSettings): UseAudioReturn {
 
   const manager = managerRef.current;
 
-  // Release every element when the game page unmounts. Nothing else drops these
-  // references, so without it a session accumulates the elements of every game
-  // played in it.
+  // Stop sources, cancel pending playback and release buffers on unmount.
   useEffect(() => {
     return () => {
       manager.dispose();
@@ -113,5 +112,10 @@ export function useAudio(settings: AudioSettings): UseAudioReturn {
     [manager]
   );
 
-  return { playAudio, loadAudioFiles, stopAudio, stopAudios };
+  const playDeathSounds = useCallback(
+    (urls: string[], volume: () => number) => manager.playUrls(urls, volume),
+    [manager]
+  );
+
+  return { playAudio, loadAudioFiles, stopAudio, stopAudios, playDeathSounds };
 }

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -213,7 +213,7 @@ export default function Game() {
   const ignoreDeathSoundsRef = useRef(!!user?.settings?.ignoreDeathSounds);
   const deathSoundVolumeRef = useRef(1);
 
-  const { playAudio, loadAudioFiles, stopAudio, stopAudios } = useAudio(settings);
+  const { playAudio, loadAudioFiles, stopAudio, stopAudios, playDeathSounds } = useAudio(settings);
   const siteInfo = useContext(SiteInfoContext);
   const errorAlert = useErrorAlert();
   const isPhoneDevice = useIsPhoneDevice();
@@ -767,33 +767,7 @@ export default function Game() {
       // User preference: skip all custom death sounds (ref stays current mid-game)
       if (ignoreDeathSoundsRef.current) return;
 
-      let chain = Promise.resolve();
-      for (const url of urls) {
-        if (typeof url !== "string" || !url.length) continue;
-        chain = chain.then(
-          () =>
-            new Promise((resolve) => {
-              try {
-                const audio = new Audio(url);
-                // Dedicated local slider (gameSettings.deathSoundVolume)
-                audio.volume = deathSoundVolumeRef.current;
-                const done = () => resolve();
-                audio.addEventListener("ended", done, { once: true });
-                audio.addEventListener("error", done, { once: true });
-                // Cap hang if metadata is bad (sounds are max 5s)
-                const timeout = setTimeout(done, 6000);
-                audio.addEventListener(
-                  "ended",
-                  () => clearTimeout(timeout),
-                  { once: true }
-                );
-                audio.play().catch(done);
-              } catch {
-                resolve();
-              }
-            })
-        );
-      }
+      void playDeathSounds(urls, () => deathSoundVolumeRef.current);
     });
 
     socket.on("revival", (playerId) => {
@@ -6389,4 +6363,3 @@ export function useActivity() {
 
   return [activity, updateActivity];
 }
-

--- a/test/webAudio.test.js
+++ b/test/webAudio.test.js
@@ -1,0 +1,190 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const ts = require("../react_main/node_modules/typescript");
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => { resolve = done; });
+  return { promise, resolve };
+}
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+function harness() {
+  const sources = [];
+  const gains = [];
+  const requests = [];
+  const listeners = {};
+  const ctx = {
+    state: "running", destination: {},
+    resume: async () => { ctx.state = "running"; },
+    decodeAudioData: async () => ({ duration: 2 }),
+    createBufferSource: () => {
+      const source = {
+        connect() {}, disconnect() {},
+        start() { this.started = true; },
+        stop() { this.stopped = true; },
+      };
+      sources.push(source);
+      return source;
+    },
+    createGain: () => {
+      const gain = { gain: { value: 1 }, connect() {}, disconnect() {} };
+      gains.push(gain);
+      return gain;
+    },
+  };
+  const globals = {
+    window: { AudioContext: function () { return ctx; } },
+    navigator: { audioSession: {} },
+    document: { addEventListener: (event, fn) => { listeners[event] = fn; } },
+    AbortController, setTimeout, clearTimeout,
+    fetch: (url, options) => {
+      const request = deferred();
+      requests.push({ url, options, ...request });
+      return request.promise;
+    },
+  };
+  const modules = {};
+  function load(name) {
+    const filename = path.join(__dirname, "../react_main/src/audio", `${name}.ts`);
+    const code = ts.transpileModule(fs.readFileSync(filename, "utf8"), {
+      compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+    }).outputText;
+    const exports = {};
+    vm.runInNewContext(code, { ...globals, exports, require: (id) => modules[id] }, { filename });
+    modules[`./${name}`] = exports;
+    return exports.default;
+  }
+  const Sound = load("WebAudioSound");
+  const Manager = load("AudioManager");
+  const respond = (index) => requests[index].resolve({ ok: true, arrayBuffer: async () => new ArrayBuffer(1) });
+  return { Sound, Manager, ctx, sources, gains, requests, respond, listeners };
+}
+
+describe("Web Audio game playback", function () {
+  it("cancels a stopped sound while decoding and never starts it late", async function () {
+    const h = harness();
+    const decode = deferred();
+    h.ctx.decodeAudioData = () => decode.promise;
+    const sound = new h.Sound("/ping.mp3");
+    const playing = sound.play();
+    h.respond(0);
+    await flush();
+    sound.stop();
+    await playing;
+    decode.resolve({ duration: 2 });
+    await flush();
+    assert.equal(h.sources.length, 0);
+  });
+
+  it("only starts the latest replay and applies live volume and looping", async function () {
+    const h = harness();
+    const sound = new h.Sound("/ping.mp3");
+    const first = sound.play();
+    const second = sound.play(true);
+    await first;
+    assert.equal(h.requests.length, 1);
+    h.respond(0);
+    await flush();
+    assert.equal(h.sources.length, 1);
+    assert.equal(h.sources[0].loop, true);
+    sound.volume = 0.25;
+    assert.equal(h.gains[0].gain.value, 0.25);
+    sound.stop();
+    await second;
+    assert.equal(h.sources[0].stopped, true);
+  });
+
+  it("rejects failures and allows retry", async function () {
+    const h = harness();
+    const sound = new h.Sound("/bad.mp3");
+    const failed = assert.rejects(sound.play(), /Audio request failed/);
+    h.requests[0].resolve({ ok: false, status: 404 });
+    await failed;
+    const playing = sound.play();
+    h.respond(1);
+    await flush();
+    h.sources[0].onended();
+    await playing;
+  });
+
+  it("resumes on gestures and cancels pending playback before unlock", async function () {
+    const h = harness();
+    const resumed = deferred();
+    h.ctx.state = "suspended";
+    let resumes = 0;
+    h.ctx.resume = () => { resumes++; return resumed.promise; };
+    const sound = new h.Sound("/ping.mp3");
+    const playing = sound.play();
+    h.respond(0);
+    h.listeners.pointerdown();
+    assert.equal(resumes, 2);
+    sound.stop();
+    await playing;
+    resumed.resolve();
+    await flush();
+    assert.equal(h.sources.length, 0);
+  });
+
+  it("loads music lazily, honors overrides, and releases music on stop", async function () {
+    const h = harness();
+    const manager = new h.Manager();
+    manager.load([
+      { fileName: "ping" },
+      { fileName: "music/one", loop: true, overrides: true },
+      { fileName: "music/two", overrides: true },
+    ]);
+    assert.equal(h.requests.length, 1);
+    manager.syncVolume(1, 0.4, 1, 1);
+    manager.play("music/one");
+    h.respond(1);
+    await flush();
+    assert.equal(h.gains[0].gain.value, 0.4);
+    manager.play("music/two");
+    assert.equal(h.sources[0].stopped, true);
+    manager.stop("music/two");
+    h.respond(2);
+    await flush();
+    assert.equal(h.sources.length, 1);
+    manager.play("music/one");
+    assert.equal(h.requests.length, 4);
+    manager.dispose();
+  });
+
+  it("preserves important alerts on stop-all but cancels everything on disposal", async function () {
+    const h = harness();
+    const manager = new h.Manager();
+    manager.load([{ fileName: "bell", channel: "important" }, { fileName: "ping" }]);
+    manager.play("bell");
+    manager.play("ping");
+    h.respond(0);
+    h.respond(1);
+    await flush();
+    manager.stop();
+    assert.equal(h.sources[0].stopped, undefined);
+    assert.equal(h.sources[1].stopped, true);
+    manager.dispose();
+    assert.equal(h.sources[0].stopped, true);
+  });
+
+  it("sequences custom sounds and cancels the remaining queue on unmount", async function () {
+    const h = harness();
+    const manager = new h.Manager();
+    const playing = manager.playUrls(["/a", "/b", "/c"], () => 0.3);
+    h.respond(0);
+    await flush();
+    assert.equal(h.requests.length, 1);
+    assert.equal(h.gains[0].gain.value, 0.3);
+    h.sources[0].onended();
+    await flush();
+    assert.equal(h.requests.length, 2);
+    manager.dispose();
+    await playing;
+    h.respond(1);
+    await flush();
+    assert.equal(h.sources.length, 1);
+    assert.equal(h.requests.length, 2);
+  });
+});


### PR DESCRIPTION
Ultimafia's sound effects and background music currently use HTML audio elements, which browsers expose through operating-system media controls. Play game audio through a shared Web Audio context and buffer sources so a competitive lobby or game sound no longer registers as a media player.

This covers game effects, all background music, custom death-sound sequences, and death-sound previews. Preserve channel volumes, looping, override behavior, short-effect preloading, and lazy music loading. Cancel pending playback and release buffers on disposal; release music buffers on stop. User-profile media embeds retain their existing playback controls.

Validation:

- User verified the competitive music works on KDE without the unwanted system playback controls.
- Seven playback regression tests pass (`./node_modules/.bin/mocha test/webAudio.test.js`).
- Targeted audio TypeScript checks pass.
- The local Docker frontend compiled successfully after installing declared dependencies; API and game/chat WebSocket checks passed.
- The host production-build attempt was blocked by missing installed `qrcode.react`. Targeted lint reports two existing errors in `Game.jsx` (`onLeaveGameClick` and `history`).

iOS performance remains unverified. This preserves #3000's lazy music policy and removes HTML media elements, but fully decodes each requested music track into PCM memory. Competitive pregame music requires roughly 56–61 MB of sample storage. Stopped music is decoded again on replay, and decoding concurrency is not bounded; stopping does not cancel an already-running decode. The tests mock decoding and do not establish device performance. Repeat the iPhone transition benchmarks from #3000 before merging, and verify Android/iOS media controls and background alerts.
