### PR TITLE
perf(chat): reduce message rendering work in long games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ logs/
 
 # Build files.
 react_main/build/
+react_main/build-chat-perf/
 build_public/
 
 # Dev files.

--- a/docs/testing-mobile-chat.md
+++ b/docs/testing-mobile-chat.md
@@ -1,0 +1,82 @@
+# Test game chat performance on a phone
+
+The standalone fixture uses the real `TextMeetingLayout`, `SpeechInput`, message
+components, and history reducer. Messages are generated locally, and an in-memory
+transport echoes what you type. No login, Docker, Firebase configuration, or game
+server is required. Nothing is sent to other players.
+
+## Start in WSL
+
+From the repository root:
+
+```bash
+cd react_main
+npm run perf:chat
+```
+
+This builds an optimized production bundle and serves it on port **3002**.
+Leave the terminal running. Dependencies must already be installed in
+`react_main/node_modules`; otherwise run `npm ci` there first. This test uses a
+separate build directory and is not included in the ordinary site build.
+
+Open http://localhost:3002 on Windows to check that it is running.
+Re-run the command after changing source code; this is not a live-reloading server.
+
+## Reach it from the iPhone
+
+For WSL 2's default NAT networking, run this in **Windows PowerShell as
+Administrator**, not in WSL. Change `Ubuntu` if your distribution has another name.
+
+```powershell
+$chatWslIp = ((wsl -d Ubuntu hostname -I).Trim() -split '\s+')[0]
+netsh interface portproxy add v4tov4 listenaddress=0.0.0.0 listenport=3002 connectaddress=$chatWslIp connectport=3002
+New-NetFirewallRule -DisplayName "Ultimafia chat test 3002" -Direction Inbound -Action Allow -Protocol TCP -LocalPort 3002 -RemoteAddress LocalSubnet -Profile Any
+Get-NetIPAddress -AddressFamily IPv4 -InterfaceAlias "Wi-Fi" | Select-Object IPAddress
+```
+
+On the phone, open **http://YOUR-WINDOWS-WIFI-IP:3002** in Safari. Use the Windows
+Wi-Fi address, not `localhost` or WSL's `172.x` address. Both devices must be on a
+network that allows devices to communicate; guest Wi-Fi isolation can block this.
+
+The WSL IP may change after WSL restarts. Re-run the first two commands if it does;
+the firewall rule only needs creating once. If Windows itself cannot open
+localhost:3002, fix the test server before investigating the phone connection.
+
+This follows Microsoft's [WSL LAN access instructions](https://learn.microsoft.com/en-us/windows/wsl/networking#accessing-a-wsl-2-distribution-from-your-local-area-network-lan).
+Mirrored networking or Docker Desktop port publishing may already provide LAN
+access; if the Wi-Fi URL works directly, no port proxy is needed.
+
+## Test sequence
+
+1. Start with **Load 100**, type a sentence, and press the keyboard's Return/Done
+   key. Check typing responsiveness and how quickly the input clears.
+2. Repeat with **Load 1,000**, **Load 5,000**, and optionally **Load 10,000**. Wait
+   for each bulk load to settle first. Bulk creation is deliberately expensive;
+   the important measurement is sending *after* the history has loaded.
+3. Send several messages at each size. The **Append → next frame** number is a
+   rough local rendering/frame-delay measurement; it includes two animation-frame
+   waits and is not network latency or a precise browser paint measurement.
+4. Try **Stream 2/sec** while typing, then stop it. Scroll up and check that incoming
+   messages do not pull you back to the bottom. Scroll back down and check that
+   following new messages resumes.
+5. Match your usual message layout. Long-press a message on a phone to toggle its
+   pin (the counter changes); double-click a message on desktop to append a quote.
+
+Record device/browser, layout, history size, several frame-delay readings, and
+whether typing or input clearing visibly pauses. A screenshot of the controls is
+enough to share the readings; a Mac debugger is unnecessary.
+
+The fixture isolates the transcript and input. It does not reproduce other game
+panels, real server delays, spam limits, or custom/animated avatars. A smooth result
+here does not prove the full game is smooth, but a slowdown here gives us a local
+reproduction to investigate. It tests the current source, not an A/B comparison
+with the old implementation.
+
+## Stop and remove forwarding
+
+Stop the WSL server with Ctrl+C. In Administrator PowerShell:
+
+```powershell
+netsh interface portproxy delete v4tov4 listenaddress=0.0.0.0 listenport=3002
+Remove-NetFirewallRule -DisplayName "Ultimafia chat test 3002"
+```

--- a/react_main/package.json
+++ b/react_main/package.json
@@ -48,6 +48,7 @@
     }
   },
   "scripts": {
+    "perf:chat": "rsbuild build --config rsbuild.chat-perf.config.ts && rsbuild preview --config rsbuild.chat-perf.config.ts",
     "start": "rsbuild dev",
     "build": "rsbuild build",
     "preview": "rsbuild preview",

--- a/react_main/perf/chat.css
+++ b/react_main/perf/chat.css
@@ -1,0 +1,8 @@
+html, body, #root { height: 100%; margin: 0; }
+.chat-perf { height: 100dvh; display: flex; flex-direction: column; color: #eee; background: #181a1b; }
+.perf-controls { padding: 10px; flex: none; font: 14px system-ui, sans-serif; }
+.perf-buttons { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0; }
+.perf-controls button, .perf-controls select { font: inherit; padding: 6px; }
+.perf-controls output, .perf-controls small { display: block; margin-top: 6px; }
+.chat-perf .perf-game { flex: 1; min-height: 0; height: auto; background-image: none; }
+.chat-perf .speech-wrapper { min-height: 0; }

--- a/react_main/perf/chat.jsx
+++ b/react_main/perf/chat.jsx
@@ -1,0 +1,180 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import ReactDOM from "react-dom";
+import { BrowserRouter } from "react-router-dom";
+import { CssBaseline, ThemeProvider } from "@mui/material";
+import { GameContext, SiteInfoContext, UserContext } from "../src/Contexts";
+import {
+  IsPhoneDeviceContext,
+  TextMeetingLayout,
+  useHistoryReducer,
+  useSettingsReducer,
+} from "../src/pages/Game/Game";
+import { getSiteTheme } from "../src/constants/themes";
+import { useIsPhoneDevice } from "../src/hooks/useIsPhoneDevice";
+import "../src/css/main.css";
+import "./chat.css";
+
+const theme = getSiteTheme();
+const noop = () => {};
+const user = { settings: {}, autoContrastColor: (color) => color };
+const siteInfo = { roles: {}, showAlert: noop };
+const spectators = {};
+const isolatedPlayers = new Set();
+const options = {};
+const players = Object.fromEntries(Array.from({ length: 12 }, (_, i) => [
+  `test-${i}`, { id: `test-${i}`, name: i === 0 ? "You" : `Player${i}`, alive: true },
+]));
+let nextId = 0;
+const phrases = [
+  "I think we should hear everyone's reasoning before voting.",
+  "That matches what happened yesterday :)",
+  "Can you explain why you changed your vote?",
+  "> taking notes while the rest of the village argues",
+  "I'm going back through the earlier messages. There are a few claims that don't quite match, especially the timing of the votes and who was present for each discussion.",
+  "/me rereads the chat",
+];
+
+function makeMessage(content, senderId, time = Date.now()) {
+  const id = nextId++;
+  return {
+    id: `perf-${id}`, senderId: senderId || `test-${Math.floor(id / 3) % 12}`,
+    meetingId: "village", time, content: content || `${phrases[id % phrases.length]} (${id})`,
+    alive: true, quotable: true,
+  };
+}
+
+function makeState(count) {
+  nextId = 0;
+  const start = Date.now() - count * 1000;
+  return {
+    0: {
+      name: "Day 1", selTab: "village", alerts: [], obituaries: {},
+      meetings: {
+        village: {
+          id: "village", name: "Village", speech: true, amMember: true, canTalk: true,
+          members: Object.keys(players), speechAbilities: [], voteRecord: [],
+          messages: Array.from({ length: count }, (_, i) => makeMessage(null, null, start + i * 1000)),
+        },
+      },
+    },
+  };
+}
+
+function ChatPerformance() {
+  const [history, updateHistory] = useHistoryReducer();
+  const [settings, updateSettings] = useSettingsReducer();
+  const [pinnedMessages, setPinnedMessages] = useState({});
+  const [streaming, setStreaming] = useState(false);
+  const status = useRef();
+  const isPhone = useIsPhoneDevice();
+
+  useEffect(() => {
+    updateHistory({ type: "set", history: makeState(100) });
+  }, [updateHistory]);
+
+  // This replaces only the transport. The real reducer, transcript, text input,
+  // echo-to-clear behavior, formatting, and scroll handling run unchanged.
+  const append = useCallback((message) => {
+    const start = performance.now();
+    updateHistory({ type: "addMessage", message });
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      if (status.current) {
+        status.current.textContent = `Append → next frame: ${Math.round(performance.now() - start)} ms`;
+      }
+    }));
+  }, [updateHistory]);
+
+  const socket = useMemo(() => ({
+    send(event, data) {
+      if (event === "speak") {
+        // Deliver asynchronously like an echoed socket message, without network
+        // delay or spam limits. Typing events intentionally have no recipient.
+        setTimeout(() => append(makeMessage(data.content, "test-0")), 0);
+      }
+    },
+  }), [append]);
+
+  useEffect(() => {
+    if (!streaming) return;
+    const timer = setInterval(() => append(makeMessage()), 500);
+    return () => clearInterval(timer);
+  }, [streaming, append]);
+
+  const isMessagePinned = useCallback((message) => Boolean(pinnedMessages[message.id]), [pinnedMessages]);
+  const onPinMessage = useCallback((message) => {
+    setPinnedMessages((previous) => {
+      const next = { ...previous };
+      if (next[message.id]) delete next[message.id];
+      else next[message.id] = message;
+      return next;
+    });
+  }, []);
+  const onMessageQuote = useCallback((message) => {
+    if (message.isQuote) return;
+    append({ ...makeMessage("quote", "test-0"), isQuote: true,
+      fromState: 0, fromMeetingId: "village", messageId: message.id });
+  }, [append]);
+
+  const state = history.states[0];
+  const count = state?.meetings.village.messages.length || 0;
+  const game = {
+    history, updateHistory, players, spectators, settings, options,
+    stateViewing: 0, self: "test-0", socket, review: false,
+    isolationEnabled: false, isolatedPlayers, isSpectator: false,
+    pinnedMessages, isMessagePinned, onPinMessage, onMessageQuote,
+    getSetupGameSetting: noop, playAudio: noop, setup: { total: 12 },
+  };
+
+  function load(count) {
+    setStreaming(false);
+    setPinnedMessages({});
+    updateHistory({ type: "set", history: makeState(count) });
+    status.current.textContent = "Ready. Type a message below and press Return.";
+  }
+
+  return (
+    <main className="chat-perf dark-mode">
+      <div className="perf-controls">
+        <strong>Chat test · {count.toLocaleString()} messages</strong>
+        <div className="perf-buttons">
+          {[0, 100, 1000, 5000, 10000].map((size) => (
+            <button key={size} onClick={() => load(size)}>Load {size.toLocaleString()}</button>
+          ))}
+          <button onClick={() => append(makeMessage())}>Add one</button>
+          <button onClick={() => setStreaming(!streaming)}>{streaming ? "Stop stream" : "Stream 2/sec"}</button>
+        </div>
+        <label>Layout: <select value={settings.messageLayout}
+          onChange={(e) => updateSettings({ type: "setProp", propName: "messageLayout", propval: e.target.value })}>
+          <option value="default">Default</option>
+          <option value="defaultLarge">Large avatars</option>
+          <option value="compactInline">Compact inline</option>
+          <option value="compactAligned">Compact aligned</option>
+        </select></label>
+        <span> · {Object.keys(pinnedMessages).length} pinned</span>
+        <output ref={status}>Ready. Type a message below and press Return.</output>
+        <small>Local simulation. Frame timing includes rendering and frame waits, not server/network latency. Reload to reset.</small>
+      </div>
+      <GameContext.Provider value={game}>
+        <IsPhoneDeviceContext.Provider value={isPhone}>
+          <div className="game perf-game">
+            {state && <TextMeetingLayout />}
+          </div>
+        </IsPhoneDeviceContext.Provider>
+      </GameContext.Provider>
+    </main>
+  );
+}
+
+ReactDOM.render(
+  <BrowserRouter>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <SiteInfoContext.Provider value={siteInfo}>
+        <UserContext.Provider value={user}>
+          <ChatPerformance />
+        </UserContext.Provider>
+      </SiteInfoContext.Provider>
+    </ThemeProvider>
+  </BrowserRouter>,
+  document.getElementById("root")
+);

--- a/react_main/rsbuild.chat-perf.config.ts
+++ b/react_main/rsbuild.chat-perf.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "@rsbuild/core";
+import { pluginReact } from "@rsbuild/plugin-react";
+
+// Separate entry and output: the fixture is never included in the site build.
+// Use a production build so React's development checks do not skew phone tests.
+export default defineConfig({
+  plugins: [pluginReact()],
+  source: {
+    entry: { index: "./perf/chat.jsx" },
+    tsconfigPath: "./jsconfig.json",
+  },
+  html: { title: "Ultimafia chat performance test" },
+  output: {
+    distPath: { root: "build-chat-perf" },
+    dataUriLimit: { image: 0, media: 0 },
+  },
+  server: { host: "0.0.0.0", port: 3002, strictPort: true },
+});

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -378,11 +378,11 @@ export default function Game() {
     }
   }, []);
 
-  function isMessagePinned(message) {
+  const isMessagePinned = useCallback((message) => {
     return message && message.id in persistentGameData.pinnedMessages;
-  }
+  }, [persistentGameData.pinnedMessages]);
 
-  function onPinMessage(message) {
+  const onPinMessage = useCallback((message) => {
     if (isMessagePinned(message)) {
       updatePersistentGameData({
         type: "removePinnedMessage",
@@ -394,7 +394,7 @@ export default function Game() {
         message: message,
       });
     }
-  }
+  }, [isMessagePinned]);
 
   const togglePlayerIsolation = (playerId) => {
     const newIsolatedPlayers = new Set(isolatedPlayers);
@@ -1056,7 +1056,8 @@ export default function Game() {
     setLeave(true);
   }
 
-  function onMessageQuote(message) {
+  const quoteMeetingId = history.states[history.currentState]?.selTab;
+  const onMessageQuote = useCallback((message) => {
     if (
       !review &&
       message.senderId !== "server" &&
@@ -1065,13 +1066,13 @@ export default function Game() {
     ) {
       socket.send("quote", {
         messageId: message.id,
-        toMeetingId: history.states[history.currentState].selTab,
+        toMeetingId: quoteMeetingId,
         fromMeetingId: message.meetingId,
         fromState: message.fromState ? message.fromState : stateViewing,
         messageContent: message.content,
       });
     }
-  }
+  }, [review, socket, quoteMeetingId, stateViewing]);
 
   function getSetupGameSetting(gameSetting) {
     if (setup && setup.gameSettings && gameSetting in setup.gameSettings) {
@@ -1681,6 +1682,8 @@ function getDefaultSpeechMeetingId(speechMeetings) {
   return meeting?.id;
 }
 
+const EMPTY_CHAT_STATE = { meetings: {}, alerts: [], obituaries: {} };
+
 export function TextMeetingLayout() {
   const game = useContext(GameContext);
   const { singleState } = useContext(GameTypeContext);
@@ -1689,9 +1692,9 @@ export function TextMeetingLayout() {
     game;
 
   const stateInfo = history.states[stateViewing];
-  const meetings = stateInfo ? stateInfo.meetings : {};
-  const alerts = stateInfo ? stateInfo.alerts : [];
-  const obituaries = stateInfo ? stateInfo.obituaries : {};
+  const meetings = stateInfo ? stateInfo.meetings : EMPTY_CHAT_STATE.meetings;
+  const alerts = stateInfo ? stateInfo.alerts : EMPTY_CHAT_STATE.alerts;
+  const obituaries = stateInfo ? stateInfo.obituaries : EMPTY_CHAT_STATE.obituaries;
   const winners = stateInfo ? stateInfo.winners : null;
   const selTab = stateInfo && stateInfo.selTab;
 
@@ -1711,8 +1714,6 @@ export function TextMeetingLayout() {
     });
     setAutoScroll(true);
   }
-
-  useEffect(() => doAutoScroll());
 
   useEffect(() => {
     if (stateViewing == null || !speechMeetings.length) return;
@@ -1871,16 +1872,36 @@ export function TextMeetingLayout() {
       );
     });
   }, [
-    /* MEMO DEPENDENCIES: These variables can affect the messages that are rendered in the game.
-       This is a performance improvement for preventing unnecessary re-renders caused by GameWrapper.
-    */
-    stateInfo,
+    history,
+    meetings,
+    alerts,
+    obituaries,
+    winners,
+    selTab,
+    stateViewing,
+    singleState,
+    players,
+    spectators,
     settings,
     filters,
     isolationEnabled,
     isolatedPlayers,
-    game.pinnedMessages,
+    game.review,
+    game.onMessageQuote,
+    game.onPinMessage,
+    game.isMessagePinned,
   ]);
+
+  // Typing and unrelated game updates must not repeatedly measure the entire
+  // transcript. Cancel pending work when the user scrolls away or changes tabs.
+  useEffect(() => {
+    const container = speechDisplayRef.current;
+    if (!autoScroll || !container) return;
+    const frame = requestAnimationFrame(() => {
+      container.scrollTo(0, container.scrollHeight);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [messages, autoScroll]);
 
   const activeMeeting = selTab ? meetings[selTab] : null;
 
@@ -2208,9 +2229,25 @@ function getContentClasses(message) {
  * PinnedMessages, because nothing makes a render site supply it. A context is
  * read the same way from anywhere, so a new render site cannot forget.
  */
-const IsPhoneDeviceContext = createContext(false);
+export const IsPhoneDeviceContext = createContext(false);
 
 function Message(props) {
+  const { history, isMessagePinned, ...rowProps } = props;
+  const { message, stateViewing } = props;
+  // History changes on every append. Only quotes and summary rows need it;
+  // ordinary rows depend on the meeting's name, not its growing message array.
+  return (
+    <MessageRow
+      {...rowProps}
+      pinned={isMessagePinned(message)}
+      meetingName={history.states[stateViewing]?.meetings?.[message.meetingId]?.name}
+      quoteState={message.isQuote ? history.states[message.fromState] : undefined}
+      history={message.obituaries || message.winners ? history : undefined}
+    />
+  );
+}
+
+const MessageRow = React.memo(function MessageRow(props) {
   const isPhoneDevice = useContext(IsPhoneDeviceContext);
   const user = useContext(UserContext);
   const theme = useTheme();
@@ -2263,7 +2300,7 @@ function Message(props) {
     (chainToPrevious || isServerMessage) && !isRightAligned && !denseMessages;
   const showThumbtack =
     !props.review && !message.isQuote && isHovering && props.stateViewing >= 0;
-  const thumbtackFaClass = props.isMessagePinned(message)
+  const thumbtackFaClass = props.pinned
     ? "fas fa-thumbtack"
     : "fas fa-thumbtack fa-rotate-270";
 
@@ -2303,7 +2340,7 @@ function Message(props) {
     message.customStickers || (player && player.customStickers) || null;
 
   if (message.isQuote) {
-    var state = history.states[message.fromState];
+    var state = props.quoteState;
 
     if (!state) return <></>;
 
@@ -2361,13 +2398,7 @@ function Message(props) {
     messageStyle.justifyContent = "flex-end";
   }
 
-  const stateMeetings = history.states[props.stateViewing].meetings;
-  const stateMeetingDefined =
-    stateMeetings !== undefined &&
-    stateMeetings[message.meetingId] !== undefined;
-  const isGraveyardMessage =
-    stateMeetingDefined &&
-    stateMeetings[message.meetingId].name === "Graveyard";
+  const isGraveyardMessage = props.meetingName === "Graveyard";
 
   const playerDead =
     props.stateViewing >= 0 &&
@@ -2383,8 +2414,7 @@ function Message(props) {
     if (playerDead) {
       contentClass += "dead ";
     } else if (
-      stateMeetingDefined &&
-      stateMeetings[message.meetingId].name === "Party!"
+      props.meetingName === "Party!"
     ) {
       contentClass += "party ";
     } else if (
@@ -2409,27 +2439,28 @@ function Message(props) {
   }
 
   let avatarId;
+  let nameColor = message.nameColor;
+  let textColor = message.textColor;
 
   if (player !== undefined) {
-    if (Object.keys(message.textColor ?? {}).length === 2) {
-      message.textColor = message.textColor["darkTheme"];
+    if (Object.keys(textColor ?? {}).length === 2) {
+      textColor = textColor["darkTheme"];
     }
 
     avatarId = player.anonId === undefined ? player.userId : player.anonId;
     if (player.anonId !== undefined) {
-      // message.textColor = (player.textColor !== undefined && player.textColor !== "") ? player.textColor : "";
-      message.nameColor = "";
+      nameColor = "";
     }
 
-    if (Object.keys(message.nameColor ?? {}).length === 2) {
-      message.nameColor = message.nameColor["darkTheme"];
+    if (Object.keys(nameColor ?? {}).length === 2) {
+      nameColor = nameColor["darkTheme"];
     }
   }
 
   const rawNameColor =
-    message.nameColor && message.nameColor !== "" ? message.nameColor : null;
+    nameColor && nameColor !== "" ? nameColor : null;
   const rawTextColor =
-    message.textColor && message.textColor !== "" ? message.textColor : null;
+    textColor && textColor !== "" ? textColor : null;
 
   let contentStyle = {};
   const resolvedTextColor = resolveDisplayTextColor({
@@ -2616,7 +2647,7 @@ function Message(props) {
       )}
     </div>
   );
-}
+});
 
 function WinnersMessage(props) {
   const game = useContext(GameContext);
@@ -5726,7 +5757,7 @@ export function Notes() {
   );
 }
 
-function useHistoryReducer() {
+export function useHistoryReducer() {
   return useReducer(
     (history, action) => {
       switch (action.type) {


### PR DESCRIPTION
Game chat becomes increasingly expensive to update as the displayed history grows. An incoming message invalidated the transcript's memoized element list and rerendered every existing message row. This matched the reported progressive send slowdown on Safari (iOS 26, iPhone 16e), and on Chrome in very long games.

This change lets ordinary, unchanged message rows skip rendering when another message arrives. **The input still waits for a matching server echo before clearing.** There is no optimistic clearing or change to message delivery, cooldowns, or spam handling; the improvement comes from reducing the work triggered by the incoming message.

## Changes

- Split the lightweight `Message` adapter from a memoized `MessageRow`. Ordinary rows receive their meeting name and pin state instead of the entire growing history object. Quotes still receive their source state, and summary rows retain history access.
- Stabilize quote and pin callbacks with their actual dependencies, so an unrelated game update does not invalidate every row or restart every row's long-press effect.
- Complete the transcript memo dependencies so player/spectator changes, review mode, quote targets, and single-state history updates remain visible. Use stable empty-state fallbacks.
- Schedule automatic scrolling when the rendered transcript or follow-scroll state changes, rather than after every render/keystroke. Cancel pending animation frames on effect cleanup.
- Resolve message colors into local variables instead of mutating message objects during rendering.

## Reproduce on a phone

Run `cd react_main && npm run perf:chat`. The separate production-built fixture serves on port 3002 and uses the real chat layout, message components, input, and history reducer with a local asynchronous echo. It requires no login, Docker, or game server and sends no messages to other players.

The page can load 0/100/1,000/5,000/10,000 fake messages, append one message, stream two per second, and switch layouts. It also displays an approximate append-to-frame delay. `docs/testing-mobile-chat.md` includes WSL-to-Windows forwarding, iPhone access, a test sequence, and cleanup commands. The fixture has its own entry and output directory and is excluded from the ordinary site build.

## Validation

- Production site build and standalone fixture build.
- Fixture ESLint passes. `Game.jsx` retains the same two pre-existing lint errors as the upstream base; this change removes one hook-dependency warning and adds no lint diagnostics.
- Isolated React render-count check with 100, 1,000, and 5,000 existing ordinary messages: appending one changed text-component renders from 101/1,001/5,001 to 1. This used stubbed leaf components to count renders; it is not an iPhone latency measurement.
- Isolated checks covered immutable colors, settings and player updates, updated quote callbacks, pins, meeting styles, and quote-source updates.
- Browser testing covered sending and clearing the input with 5,000 messages, a phone-sized viewport, layout switching, and streaming while scrolled back. The reporter tested the standalone page and reported that it felt good.

The transcript is not virtualized. Building/reconciling the list and laying out a very large DOM can still grow with history length, and quotes whose source state changes can still rerender. The fixture isolates chat rendering; it does not measure real network/server latency, other game panels, or custom/animated-avatar costs. No iOS performance trace was available.
