### PR TITLE
Confirm leaving a game from the home page

### DIFF
--- a/react_main/src/Main.jsx
+++ b/react_main/src/Main.jsx
@@ -17,6 +17,7 @@ import { AlertList, useErrorAlert } from "./components/Alerts";
 import { Nav } from "./components/Nav";
 import UserNavSection from "./pages/User/UserNavSection";
 import CookieBanner from "./components/CookieBanner";
+import LeaveGameDialog from "./components/LeaveGameDialog";
 import NavDropdown from "./components/NavDropdown";
 import { Loading } from "./components/Loading";
 import "css/main.css";
@@ -428,8 +429,14 @@ function Header({ setShowAnnouncementTemporarily }) {
 function InGameWarning() {
   const user = useContext(UserContext);
   const errorAlert = useErrorAlert();
+  const [leaveDialogOpen, setLeaveDialogOpen] = useState(false);
+
+  useEffect(() => {
+    setLeaveDialogOpen(false);
+  }, [user.inGame]);
 
   function onGameLeave() {
+    setLeaveDialogOpen(false);
     axios
       .post("/api/game/leave")
       .then(() => {
@@ -439,36 +446,44 @@ function InGameWarning() {
   }
 
   return (
-    <Snackbar
-      open={user.inGame !== null}
-      sx={{ maxWidth: "calc(100vw - 16px)" }}
-    >
-      <Alert
-        severity="warning"
-        variant="outlined"
-        sx={{
-          width: "100%",
-          backgroundColor: "background.paper",
-        }}
-        slotProps={{
-          message: {
-            sx: {
-              flex: "1",
-            },
-          },
-        }}
+    <>
+      <Snackbar
+        open={user.inGame !== null}
+        sx={{ maxWidth: "calc(100vw - 16px)" }}
       >
-        <AlertTitle>You are in a game in progress.</AlertTitle>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Button href={`/game/${user.inGame}`} size="small" sx={{ flex: "1" }}>
-            Return
-          </Button>
-          <Button onClick={() => onGameLeave()} size="small" sx={{ flex: "1" }}>
-            Leave
-          </Button>
-        </Stack>
-      </Alert>
-    </Snackbar>
+        <Alert
+          severity="warning"
+          variant="outlined"
+          sx={{
+            width: "100%",
+            backgroundColor: "background.paper",
+          }}
+          slotProps={{
+            message: {
+              sx: {
+                flex: "1",
+              },
+            },
+          }}
+        >
+          <AlertTitle>You are in a game in progress.</AlertTitle>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Button href={`/game/${user.inGame}`} size="small" sx={{ flex: "1" }}>
+              Return
+            </Button>
+            <Button onClick={() => setLeaveDialogOpen(true)} size="small" sx={{ flex: "1" }}>
+              Leave
+            </Button>
+          </Stack>
+        </Alert>
+      </Snackbar>
+      <LeaveGameDialog
+        open={leaveDialogOpen && user.inGame !== null}
+        onClose={() => setLeaveDialogOpen(false)}
+        onConfirm={onGameLeave}
+        warningMessage="Leaving while your participation is still required may result in a penalty."
+      />
+    </>
   );
 }
 

--- a/react_main/src/components/LeaveGameDialog.jsx
+++ b/react_main/src/components/LeaveGameDialog.jsx
@@ -23,6 +23,7 @@ export default function LeaveGameDialog({
   isParticipationRequired = false,
   lockSeconds = DEFAULT_LOCK_SECONDS,
   isPenaltyEnforced = true,
+  warningMessage = null,
 }) {
   const [alertOpen, setAlertOpen] = useState(false);
   const [lockRemaining, setLockRemaining] = useState(
@@ -103,14 +104,14 @@ export default function LeaveGameDialog({
           <Typography variant="body2">
             Are you sure you want to leave?
           </Typography>
-          {isParticipationRequired && (
+          {(isParticipationRequired || warningMessage) && (
             <Typography
               variant="body2"
               sx={{ color: "error.main", fontWeight: 700, mt: 1 }}
             >
-              {isPenaltyEnforced
+              {warningMessage || (isPenaltyEnforced
                 ? "YOU WILL BE PENALISED FOR LEAVING"
-                : "Your participation is still required"}
+                : "Your participation is still required")}
             </Typography>
           )}
         </DialogContent>


### PR DESCRIPTION
Clicking Leave in the home page's game-in-progress banner immediately left the game, making a misclick next to Return costly. Reuse the in-game confirmation dialog so the leave request is sent only after confirmation, with a warning that leaving while participation is required may result in a penalty. Stay or dismissing the dialog cancels.

Validation: manually tested successfully by the reporter; targeted ESLint passed with no errors (existing warnings only); `git diff --check` passed.

![Home page leave confirmation](https://raw.githubusercontent.com/UE2020/Ultimafia/14ba54299744123712f4ae01eebd019a3d2bcf1c/home-page-leave-confirmation.png)
