### PR TITLE
feat(fuzz): add isolated mafia engine fuzzer and fix engine crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ cmds.txt
 tmp/
 testing/
 dumps/
+mafia-fuzz-failures/
 
 # Data.
 uploads/

--- a/Games/core/Action.js
+++ b/Games/core/Action.js
@@ -42,6 +42,7 @@ module.exports = class Action {
    */
   dominates(player, emitEvent = true) {
     player = player || this.target;
+    if (!player) return false;
     // will be true if immune to any label
     let immune = false;
 

--- a/Games/core/Action.js
+++ b/Games/core/Action.js
@@ -59,7 +59,7 @@ module.exports = class Action {
       let immuneToLabel = immunity >= this.power;
       if (immuneToLabel) {
         immune = true;
-        if (player.docImmunity && player.docImmunity.length > 0) {
+        if (emitEvent && player.docImmunity && player.docImmunity.length > 0) {
           for (let i = 0; i < player.docImmunity.length; i++) {
             this.docSave(player.user.id, player.docImmunity[i].saver);
           }

--- a/Games/core/Action.js
+++ b/Games/core/Action.js
@@ -73,19 +73,27 @@ module.exports = class Action {
   }
 
   async docSave(userId, saverId) {
-    var existingDocSave = await models.DocSave.findOne({
-      $or: [
-        { $and: [{ userId: userId }, { saverId: saverId }] },
-        { $and: [{ userId: saverId }, { saverId: userId }] },
-      ],
-    });
-    if (!existingDocSave) {
-      var docSave = new models.DocSave({
-        userId: userId,
-        saverId: saverId,
-      });
+    if (this.game?.isTest || process.env.NODE_ENV === "test") return;
+    if (!userId || !saverId) return;
 
-      await docSave.save();
+    try {
+      var existingDocSave = await models.DocSave.findOne({
+        $or: [
+          { $and: [{ userId: userId }, { saverId: saverId }] },
+          { $and: [{ userId: saverId }, { saverId: userId }] },
+        ],
+      });
+      if (!existingDocSave) {
+        var docSave = new models.DocSave({
+          userId: userId,
+          saverId: saverId,
+        });
+
+        await docSave.save();
+      }
+    } catch (err) {
+      if (this.game?.isTest) return;
+      console.error("docSave failed:", err);
     }
   }
 

--- a/Games/core/Action.js
+++ b/Games/core/Action.js
@@ -2,7 +2,7 @@ const models = require("../../db/models");
 
 module.exports = class Action {
   constructor(options) {
-    this.actors = options.actors ?? [];
+    this.actors = [...(options.actors ?? [])];
     if (this.actors.length === 0 && options.actor) {
       this.actors = [options.actor];
     }
@@ -118,6 +118,7 @@ module.exports = class Action {
 
     if (this.actors.length == 0) {
       this.do = () => {};
+      this.run = () => {};
       this.actors = [];
       delete this.target;
     }

--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -715,7 +715,7 @@ module.exports = class Game {
         this.makeUnranked();
         this.makeUncompetitive();
 
-        if (!this.isTest && this.breakIntegrity()) {
+        if (this.breakIntegrity()) {
           await this.refundHeartsForIntegrityBreak(
             player,
             wasRanked,
@@ -775,7 +775,7 @@ module.exports = class Game {
     player.kill("veg", player);
     this.exorcisePlayer(player);
 
-    if (!this.isTest && this.breakIntegrity()) {
+    if (this.breakIntegrity()) {
       await this.refundHeartsForIntegrityBreak(player, wasRanked, wasCompetitive);
       if (!player.isBot) {
         const userId = player.userId || player.user.id;
@@ -803,7 +803,6 @@ module.exports = class Game {
 
   // Returns if the integrity of the game was broken for the first time or not
   breakIntegrity() {
-    if (this.isTest) return false;
     const hadIntegrity = this.hasIntegrity;
     this.hasIntegrity = false;
 

--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -715,7 +715,7 @@ module.exports = class Game {
         this.makeUnranked();
         this.makeUncompetitive();
 
-        if (this.breakIntegrity()) {
+        if (!this.isTest && this.breakIntegrity()) {
           await this.refundHeartsForIntegrityBreak(
             player,
             wasRanked,
@@ -775,7 +775,7 @@ module.exports = class Game {
     player.kill("veg", player);
     this.exorcisePlayer(player);
 
-    if (this.breakIntegrity()) {
+    if (!this.isTest && this.breakIntegrity()) {
       await this.refundHeartsForIntegrityBreak(player, wasRanked, wasCompetitive);
       if (!player.isBot) {
         const userId = player.userId || player.user.id;
@@ -803,6 +803,7 @@ module.exports = class Game {
 
   // Returns if the integrity of the game was broken for the first time or not
   breakIntegrity() {
+    if (this.isTest) return false;
     const hadIntegrity = this.hasIntegrity;
     this.hasIntegrity = false;
 
@@ -814,6 +815,7 @@ module.exports = class Game {
   }
 
   async refundHeartsForIntegrityBreak(excludedPlayer, wasRanked, wasCompetitive) {
+    if (this.isTest) return;
     if (!this.heartsChargedAtStart) return;
     if (this.heartsRefundedOnIntegrityBreak) return;
     if (!wasRanked && !wasCompetitive) return;
@@ -3380,6 +3382,7 @@ module.exports = class Game {
   }
 
   async penalizePlayerForLeaving(userId) {
+    if (this.isTest) return;
     let leavePenalty = await models.LeavePenalty.findOne({
       userId: userId,
     }).select("level");

--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -1987,23 +1987,21 @@ module.exports = class Game {
   }
 
   getRoleAlignment(role) {
-    return roleData[this.type][role.split(":")[0]].alignment;
+    if (!role) return null;
+    const baseRole = role.split(":")[0];
+    return roleData[this.type]?.[baseRole]?.alignment || null;
   }
 
   getSpecialInteractions(role) {
-    if (roleData[this.type][role.split(":")[0]].SpecialInteractions) {
-      return roleData[this.type][role.split(":")[0]].SpecialInteractions;
-    } else {
-      return null;
-    }
+    if (!role) return null;
+    const baseRole = role.split(":")[0];
+    return roleData[this.type]?.[baseRole]?.SpecialInteractions || null;
   }
 
   getAddOtherRoles(role) {
-    if (roleData[this.type][role.split(":")[0]].RolesMadeBy) {
-      return roleData[this.type][role.split(":")[0]].RolesMadeBy;
-    } else {
-      return null;
-    }
+    if (!role) return null;
+    const baseRole = role.split(":")[0];
+    return roleData[this.type]?.[baseRole]?.RolesMadeBy || null;
   }
 
   getRoleTags(role) {

--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -2447,6 +2447,11 @@ module.exports = class Game {
         for (let skipCheck of skipChecks)
           shouldSkip = shouldSkip && skipCheck();
       } else shouldSkip = false;
+
+      if (skipped >= this.states.length) {
+        shouldSkip = false;
+        break;
+      }
     } while (shouldSkip);
 
     return [nextStateIndex, skipped];

--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -2159,6 +2159,10 @@ module.exports = class Game {
 
     // Check if states will be skipped
     var [index, skipped] = this.getNextStateIndex();
+    if (index === null) {
+      this.endForNoPlayableState();
+      return;
+    }
 
     // Do actions
     if (!stateInfo.delayActions || skipped > 0) this.processActionQueue();
@@ -2170,6 +2174,7 @@ module.exports = class Game {
 
     // Set next state
     this.incrementState(index, skipped);
+    if (this.finished) return;
     this.stateEvents = {};
     stateInfo = this.getStateInfo();
 
@@ -2412,17 +2417,28 @@ module.exports = class Game {
       player.addStateExtraInfoToHistory(extraInfo, state);
   }
 
-  incrementState(index, skipped) {
-    this.currentState++;
+  endForNoPlayableState() {
+    this.queueAlert(
+      "The game ended without a winner because no playable phase remains."
+    );
+    this.immediateEnd();
+  }
 
+  incrementState(index, skipped) {
     if (index === undefined || skipped === undefined) {
       [index, skipped] = this.getNextStateIndex();
     }
+    if (index === null) {
+      this.endForNoPlayableState();
+      return;
+    }
+    this.currentState++;
     this.stateIndexRecord.push(index);
     return skipped;
   }
 
   getNextStateIndex() {
+    if (this.states.length <= 2) return [null, 0];
     var lastStateIndex =
       this.stateIndexRecord[this.stateIndexRecord.length - 1];
     var skipped = -1;
@@ -2446,9 +2462,9 @@ module.exports = class Game {
           shouldSkip = shouldSkip && skipCheck();
       } else shouldSkip = false;
 
-      if (skipped >= this.states.length) {
-        shouldSkip = false;
-        break;
+      // Postgame and Pregame (indices 0 and 1) are not playable phases.
+      if (shouldSkip && skipped >= this.states.length - 3) {
+        return [null, skipped];
       }
     } while (shouldSkip);
 

--- a/Games/core/Item.js
+++ b/Games/core/Item.js
@@ -63,7 +63,7 @@ module.exports = class Item {
     this.game.events.removeListener("state", this.ageListener);
 
     for (let eventName in this.listeners)
-      holder.events.removeListener(eventName, this.listeners[eventName]);
+      this.game.events.removeListener(eventName, this.listeners[eventName]);
 
     this.removeEffects();
     if (nope == "No") {

--- a/Games/core/Meeting.js
+++ b/Games/core/Meeting.js
@@ -692,7 +692,7 @@ module.exports = class Meeting {
               break;
             default:
               if (typeof tag == "function") {
-                var matched = tag.bind(self)(player);
+                var matched = self ? tag.bind(self)(player) : tag(player);
 
                 if (matched) includePlayer[player.id] = include;
               } else if (player.id == tag) includePlayer[player.id] = include;

--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -1441,6 +1441,7 @@ module.exports = class Player {
 
     for (let meetingName in meetings) {
       let options = meetings[meetingName];
+      if (!options) continue;
       let disabled = false;
 
       for (let item of this.items)
@@ -1454,6 +1455,7 @@ module.exports = class Player {
       //      can be condensed.
       if (
         disabled ||
+        !options.states ||
         (options.states.indexOf(currentStateName) == -1 &&
           options.states.indexOf("*") == -1) ||
         options.disabled ||

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -249,32 +249,46 @@ module.exports = class MafiaGame extends Game {
   }
 
   recordMissionFails(numFails) {
-    if (!this.currentMissionHistory || numFails === -1) {
+    if (numFails === -1) {
       this.currentMissionHistory = {
         mission: this.mission,
         team: [],
       };
+    } else if (!this.currentMissionHistory?.team?.length) {
+      // No mission took place. Team-selection failures are recorded with -1
+      // only after the retry limit is reached.
+      return false;
     }
 
     this.currentMissionHistory.numFails = numFails;
     const winningTeam =
       this.currentMissionHistory.numFails === 0 ? "rebels" : "spies";
 
-    if (this.missionRecord) {
-      this.missionRecord.missionHistory.push(this.currentMissionHistory);
-      if (this.missionRecord.score && this.missionRecord.score[winningTeam] !== undefined) {
-        this.missionRecord.score[winningTeam] += 1;
-      }
-    }
+    this.missionRecord.missionHistory.push(this.currentMissionHistory);
+    this.missionRecord.score[winningTeam] += 1;
     this.currentMissionHistory = null;
     this.checkGameEnd();
+    return true;
   }
 
   incrementState(index, skipped) {
     if (this.ResistanceMode) {
       let previousState = this.getStateInfo().name;
 
-      if (previousState.match(/Mission/)) {
+      if (previousState.match(/Team Approval/)) {
+        if (!this.currentMissionHistory?.team?.length || !this.teamApproved) {
+          if (!this.currentTeamFail) {
+            this.teamFails++;
+            this.queueAlert("No team was approved; choosing a new leader.");
+          }
+          this.currentTeamFail = true;
+        }
+        // Core selects the next state before resolving votes. Re-evaluate
+        // Mission's skip check now that the approval result is available.
+        [index, skipped] = this.getNextStateIndex();
+      }
+
+      if (previousState.match(/Mission/) && this.currentMissionHistory?.team?.length) {
         if (this.currentMissionFails > 0) {
           this.missionFails++;
           var plural = this.currentMissionFails > 1;
@@ -306,12 +320,15 @@ module.exports = class MafiaGame extends Game {
         this.currentMissionFails = 0;
         this.teamFails = 0;
       }
+      if (this.finished) return;
     }
 
     super.incrementState(index, skipped);
 
     if (this.ResistanceMode && this.getStateInfo().name.match(/Night/)) {
       this.currentTeamFail = false;
+      this.teamApproved = false;
+      this.currentMissionHistory = null;
 
       for (let player of this.players) {
         for (let item of player.items) {

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -249,7 +249,7 @@ module.exports = class MafiaGame extends Game {
   }
 
   recordMissionFails(numFails) {
-    if (numFails === -1) {
+    if (!this.currentMissionHistory || numFails === -1) {
       this.currentMissionHistory = {
         mission: this.mission,
         team: [],
@@ -260,8 +260,12 @@ module.exports = class MafiaGame extends Game {
     const winningTeam =
       this.currentMissionHistory.numFails === 0 ? "rebels" : "spies";
 
-    this.missionRecord.missionHistory.push(this.currentMissionHistory);
-    this.missionRecord.score[winningTeam] += 1;
+    if (this.missionRecord) {
+      this.missionRecord.missionHistory.push(this.currentMissionHistory);
+      if (this.missionRecord.score && this.missionRecord.score[winningTeam] !== undefined) {
+        this.missionRecord.score[winningTeam] += 1;
+      }
+    }
     this.currentMissionHistory = null;
     this.checkGameEnd();
   }

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -286,6 +286,10 @@ module.exports = class MafiaGame extends Game {
         // Core selects the next state before resolving votes. Re-evaluate
         // Mission's skip check now that the approval result is available.
         [index, skipped] = this.getNextStateIndex();
+        if (index === null) {
+          this.endForNoPlayableState();
+          return;
+        }
       }
 
       if (previousState.match(/Mission/) && this.currentMissionHistory?.team?.length) {

--- a/Games/types/Mafia/Game.js
+++ b/Games/types/Mafia/Game.js
@@ -796,7 +796,18 @@ module.exports = class MafiaGame extends Game {
       this.ExtraStates = [];
     }
     if (this.HaveHostingState == true) {
-      return true;
+      let hasHost = false;
+      for (let p of this.players) {
+        if (p.role && p.role.name === "Host") {
+          hasHost = true;
+          break;
+        }
+      }
+      if (!hasHost) {
+        this.HaveHostingState = false;
+      } else {
+        return true;
+      }
     }
     if (this.HaveTreasureChestState == true) {
       this.events.emit("extraStateCheck", "Treasure Chest");

--- a/Games/types/Mafia/Information.js
+++ b/Games/types/Mafia/Information.js
@@ -105,8 +105,10 @@ module.exports = class MafiaInformation {
       if (!action.hasLabels(["kill"])) continue;
       let target = action.target;
       let toCheck = Array.isArray(target) ? target : [target];
-      if (toCheck[0] instanceof Player && action.dominates()) {
-        visits.push(...toCheck);
+      for (const player of toCheck) {
+        if (player instanceof Player && action.dominates(player, false)) {
+          visits.push(player);
+        }
       }
     }
     return visits;

--- a/Games/types/Mafia/Information.js
+++ b/Games/types/Mafia/Information.js
@@ -102,15 +102,11 @@ module.exports = class MafiaInformation {
   getKillVictims() {
     var visits = [];
     for (let action of this.game.actions[0]) {
-      let toCheck = action.target;
-      if (action.hasLabels(["kill"]) && action.dominates()) {
-        if (!Array.isArray(action.target)) {
-          toCheck = [action.target];
-        }
-
-        if (action.target && toCheck[0] instanceof Player) {
-          visits.push(...toCheck);
-        }
+      if (!action.hasLabels(["kill"])) continue;
+      let target = action.target;
+      let toCheck = Array.isArray(target) ? target : [target];
+      if (toCheck[0] instanceof Player && action.dominates()) {
+        visits.push(...toCheck);
       }
     }
     return visits;

--- a/Games/types/Mafia/Player.js
+++ b/Games/types/Mafia/Player.js
@@ -615,7 +615,9 @@ module.exports = class MafiaPlayer extends Player {
 
   getNeighbors() {
     let alive = this.game.alivePlayers();
+    if (alive.length <= 1) return [];
     let index = alive.indexOf(this);
+    if (index === -1) return [];
 
     const leftIdx = (index - 1 + alive.length) % alive.length;
     const rightIdx = (index + 1) % alive.length;

--- a/Games/types/Mafia/Player.js
+++ b/Games/types/Mafia/Player.js
@@ -564,7 +564,7 @@ module.exports = class MafiaPlayer extends Player {
 
   isEvil(absolute, fair) {
     if (this.isFairMisReg() && absolute != true) {
-      let temp = this.game.createInformation("AlignmentInfo", this, this);
+      let temp = this.game.createInformation("AlignmentInfo", this, this.game, this);
       return temp.isAppearanceEvil(this, "investigate");
     }
     if (
@@ -588,7 +588,7 @@ module.exports = class MafiaPlayer extends Player {
 
   getFaction(absolute, fair) {
     if (this.isFairMisReg() && absolute != true) {
-      let temp = this.game.createInformation("AlignmentInfo", this, this);
+      let temp = this.game.createInformation("AlignmentInfo", this, this.game, this);
       return temp.mainInfo;
     }
     return this.faction;

--- a/Games/types/Mafia/effects/BecomeRoleOnDeath.js
+++ b/Games/types/Mafia/effects/BecomeRoleOnDeath.js
@@ -25,7 +25,8 @@ module.exports = class BecomeRoleOnDeath extends Effect {
           effect: this,
           run: function () {
             if (this.dominates()) {
-              let roleName = this.effect.role.split(":")[0];
+              let roleName = this.effect.role ? this.effect.role.split(":")[0] : null;
+              if (!roleName || roleName === "None") return;
               let modifiers = this.effect.role.split(":")[1];
               if (!modifiers || modifiers.length <= 0) {
                 this.target.setRole(

--- a/Games/types/Mafia/effects/Virus.js
+++ b/Games/types/Mafia/effects/Virus.js
@@ -41,7 +41,7 @@ module.exports = class Virus extends Effect {
                 }
               }
               for (let neighbor of player.getNeighbors()) {
-                if (neighbor.hasEffect("Virus")) {
+                if (!neighbor || neighbor.hasEffect("Virus")) {
                   continue;
                 }
 

--- a/Games/types/Mafia/information/AlignmentInfo.js
+++ b/Games/types/Mafia/information/AlignmentInfo.js
@@ -13,6 +13,10 @@ const {
 
 module.exports = class AlignmentInfo extends Information {
   constructor(creator, game, target) {
+    if (game && !game.alivePlayers && game.game) {
+      target = target || game;
+      game = game.game;
+    }
     super("Alignment Info", creator, game);
     if (target == null) {
       this.randomTarget = true;

--- a/Games/types/Mafia/information/TwoGoodOneEvilInfo.js
+++ b/Games/types/Mafia/information/TwoGoodOneEvilInfo.js
@@ -33,7 +33,7 @@ module.exports = class TwoGoodOneEvilInfo extends Information {
         this.mainInfo = "No Evil Players Exist";
         return;
       }
-      if (goodPlayers.length <= 0) {
+      if (goodPlayers.length <= 1) {
         this.mainInfo = "Not Enough Good Players Exist";
         return;
       }
@@ -58,10 +58,17 @@ module.exports = class TwoGoodOneEvilInfo extends Information {
 
   getInfoFormated() {
     super.getInfoRaw();
-    if (this.mainInfo == "No Evil Players Exist") {
+    if (typeof this.mainInfo === "string") {
       return `You Learn that ${this.mainInfo}`;
-    } else if (this.mainInfo == "Not Enough Good Players Exist") {
-      return `You Learn that ${this.mainInfo}`;
+    }
+    if (
+      !Array.isArray(this.mainInfo) ||
+      this.mainInfo.length < 3 ||
+      !this.mainInfo[0] ||
+      !this.mainInfo[1] ||
+      !this.mainInfo[2]
+    ) {
+      return "You learn that not enough players exist.";
     }
     return `While conducting your symphony, you hear a sour note... exactly one of ${this.mainInfo[0].name}, ${this.mainInfo[1].name}, or ${this.mainInfo[2].name} is Evil.`;
   }

--- a/Games/types/Mafia/items/Gun.js
+++ b/Games/types/Mafia/items/Gun.js
@@ -192,6 +192,9 @@ module.exports = class Gun extends Item {
   }
 
   isTargetValid(player) {
+    if (!player || !this.holder || typeof player.getFaction !== "function") {
+      return false;
+    }
     if (this.modifiers.includes("Loyal")) {
       if (player.getFaction() != this.holder.getFaction()) {
         return false;

--- a/Games/types/Mafia/items/MissionLeader.js
+++ b/Games/types/Mafia/items/MissionLeader.js
@@ -50,7 +50,7 @@ module.exports = class MissionLeader extends Item {
             var selectedNames = this.target.map((t) => t.name);
             this.game.recordMissionTeam(selectedNames);
             this.game.queueAlert(`Team selected: ${selectedNames.join(", ")}`);
-            this.holder.dropItem("MissionLeader");
+            this.actor.dropItem("MissionLeader");
           },
         },
       },

--- a/Games/types/Mafia/items/Mourned.js
+++ b/Games/types/Mafia/items/Mourned.js
@@ -38,7 +38,7 @@ module.exports = class Mourned extends Item {
 
     this.listeners = {
       state: function (stateInfo) {
-        if (this.holder.alive) return;
+        if (!this.holder || this.holder.alive) return;
 
         if (stateInfo.name.match(/Night/)) {
           this.holder.queueAlert(`A mourner asks you: ${this.question}`);

--- a/Games/types/Mafia/items/Orange.js
+++ b/Games/types/Mafia/items/Orange.js
@@ -39,9 +39,9 @@ module.exports = class Orange extends Item {
       actionsNext: function (stateInfo) {
         var stateInfo = this.game.getStateInfo();
 
-        if (stateInfo.name.match(/Night/) && this.holder.role.visitHotSprings) {
-          this.drop();
+        if (stateInfo.name.match(/Night/) && this.holder && this.holder.role && this.holder.role.visitHotSprings) {
           this.holder.role.visitHotSprings = false;
+          this.drop();
         }
       },
     };

--- a/Games/types/Mafia/roles/cards/BondedForLife.js
+++ b/Games/types/Mafia/roles/cards/BondedForLife.js
@@ -14,16 +14,19 @@ module.exports = class BondedForLife extends Card {
           role: role,
           priority: PRIORITY_EFFECT_GIVER_EARLY,
           run: function () {
+            if (!this.actor || !this.target || typeof this.target !== "object" || !this.target.name) return;
             this.role.giveEffect(this.target, "Lovesick", this.actor);
             this.queueGetEffectAlert("Lovesick", this.target, this.actor.name);
 
-            if (this.actor.role.name == "Lover") {
+            if (this.actor.role && this.actor.role.name == "Lover") {
               this.role.giveEffect(this.actor, "Lovesick", this.target);
             }
             this.queueGetEffectAlert("Lovesick", this.actor, this.target.name);
 
-            this.actor.role.loved = true;
-            this.actor.role.loves = this.target;
+            if (this.actor.role) {
+              this.actor.role.loved = true;
+              this.actor.role.loves = this.target;
+            }
           },
         },
         shouldMeet() {

--- a/Games/types/Mafia/roles/cards/ConvertIfVisitsAllMafia.js
+++ b/Games/types/Mafia/roles/cards/ConvertIfVisitsAllMafia.js
@@ -12,10 +12,10 @@ module.exports = class ConvertIfVisitsAllMafia extends Card {
     super(role);
 
     this.methods.excludeAlreadyVisited = function (player) {
-      if (player === this) {
+      if (!this || player === this) {
         return true;
       }
-      return this.role.visitedMentors.has(player);
+      return role.visitedMentors ? role.visitedMentors.has(player) : false;
     };
 
     this.meetings = {

--- a/Games/types/Mafia/roles/cards/ConvertToChosenRole.js
+++ b/Games/types/Mafia/roles/cards/ConvertToChosenRole.js
@@ -29,7 +29,11 @@ module.exports = class ConvertToChosenRole extends Card {
           priority: PRIORITY_CONVERT_DEFAULT + 4,
           run: function () {
             let targetPlayer = this.role.data.targetPlayer;
-            if (targetPlayer) {
+            if (targetPlayer && targetPlayer.role) {
+              if (!this.target || this.target === "None" || this.target === "*") {
+                delete this.role.data.targetPlayer;
+                return;
+              }
               let players = this.game.players.filter((p) => p.role);
               let currentRoles = [];
 

--- a/Games/types/Mafia/roles/cards/ConvertToChosenRoleOnDeath.js
+++ b/Games/types/Mafia/roles/cards/ConvertToChosenRoleOnDeath.js
@@ -28,7 +28,7 @@ module.exports = class ConvertToChosenRoleOnDeath extends Card {
           priority: PRIORITY_CONVERT_DEFAULT,
           run: function () {
             let targetPlayer = this.role.data.targetPlayer;
-            if (targetPlayer) {
+            if (targetPlayer && this.target && this.target !== "None") {
               if (this.dominates(targetPlayer)) {
                 this.role.giveEffect(
                   targetPlayer,

--- a/Games/types/Mafia/roles/cards/ConvertToChosenRoleOnDeath.js
+++ b/Games/types/Mafia/roles/cards/ConvertToChosenRoleOnDeath.js
@@ -28,6 +28,7 @@ module.exports = class ConvertToChosenRoleOnDeath extends Card {
           priority: PRIORITY_CONVERT_DEFAULT,
           run: function () {
             let targetPlayer = this.role.data.targetPlayer;
+            delete this.role.data.targetPlayer;
             if (targetPlayer && this.target && this.target !== "None") {
               if (this.dominates(targetPlayer)) {
                 this.role.giveEffect(
@@ -37,8 +38,6 @@ module.exports = class ConvertToChosenRoleOnDeath extends Card {
                   this.target
                 );
               }
-
-              delete this.role.data.targetPlayer;
             }
           },
         },

--- a/Games/types/Mafia/roles/cards/DeliriateNeighbors.js
+++ b/Games/types/Mafia/roles/cards/DeliriateNeighbors.js
@@ -40,65 +40,77 @@ module.exports = class DeliriateNeighbors extends Card {
       },
     ];
 
-    this.listeners = {
-      AbilityToggle: function (player) {
-        if (this.startingNeighbors) {
-          return;
-        }
-        if (this.hasAbility(["Deception"])) {
-          if (this.startingNeighbors == null) {
-            let players = this.game.alivePlayers();
-            var indexOfActor = players.indexOf(this.player);
-            var rightIdx;
-            var leftIdx;
-            var leftAlign;
-            var rightAlign;
-            var distance = 0;
-            var foundUp = 0;
-            var foundDown = 0;
+    const card = this;
 
-            for (let x = 0; x < players.length; x++) {
-              leftIdx =
-                (indexOfActor - distance - 1 + players.length) % players.length;
-              rightIdx = (indexOfActor + distance + 1) % players.length;
-              leftAlign = players[leftIdx].getRoleAlignment();
-              rightAlign = players[rightIdx].getRoleAlignment();
+    function calculateStartingNeighbors() {
+      if (!role.game.started) {
+        return;
+      }
+      if (role.startingNeighbors) {
+        return;
+      }
+      if (role.hasAbility(["Deception"])) {
+        if (role.startingNeighbors == null) {
+          let players = role.game.alivePlayers();
+          var indexOfActor = players.indexOf(role.player);
+          var rightIdx;
+          var leftIdx;
+          var leftAlign;
+          var rightAlign;
+          var distance = 0;
+          var foundUp = 0;
+          var foundDown = 0;
 
-              if (
-                rightAlign == "Village" &&
-                !players[rightIdx].role.data.banished &&
-                foundUp == 0
-              ) {
-                foundUp = players[rightIdx];
-              }
-              if (
-                leftAlign == "Village" &&
-                !players[leftIdx].role.data.banished &&
-                foundDown == 0
-              ) {
-                foundDown = players[leftIdx];
-              }
-              if (foundUp == 0 || foundDown == 0) {
-                distance = x;
-              } else {
-                break;
-              }
+          for (let x = 0; x < players.length; x++) {
+            leftIdx =
+              (indexOfActor - distance - 1 + players.length) % players.length;
+            rightIdx = (indexOfActor + distance + 1) % players.length;
+            leftAlign = players[leftIdx].getRoleAlignment();
+            rightAlign = players[rightIdx].getRoleAlignment();
+
+            if (
+              rightAlign == "Village" &&
+              !players[rightIdx].role.data.banished &&
+              foundUp == 0
+            ) {
+              foundUp = players[rightIdx];
             }
+            if (
+              leftAlign == "Village" &&
+              !players[leftIdx].role.data.banished &&
+              foundDown == 0
+            ) {
+              foundDown = players[leftIdx];
+            }
+            if (foundUp == 0 || foundDown == 0) {
+              distance = x;
+            } else {
+              break;
+            }
+          }
 
-            let victims = [foundUp, foundDown];
-            this.startingNeighbors = victims;
-          }
-          for (let player of this.startingNeighbors) {
-            let effect = this.giveEffect(
-              player,
-              "Delirious",
-              this.player,
-              Infinity,
-              null,
-              this
-            );
-          }
+          let victims = [foundUp, foundDown];
+          role.startingNeighbors = victims;
         }
+        for (let player of role.startingNeighbors) {
+          role.giveEffect(
+            player,
+            "Delirious",
+            role.player,
+            Infinity,
+            null,
+            role
+          );
+        }
+      }
+    }
+
+    this.listeners = {
+      start: function () {
+        calculateStartingNeighbors();
+      },
+      AbilityToggle: function (player) {
+        calculateStartingNeighbors();
       },
     };
   }

--- a/Games/types/Mafia/roles/cards/GivePermaDelirium.js
+++ b/Games/types/Mafia/roles/cards/GivePermaDelirium.js
@@ -25,13 +25,15 @@ module.exports = class GivePermaDelirium extends Card {
               ) == "Village"
           );
           var villageTarget = Random.randArrayVal(villagePlayers);
-          this.DeliriousVictim = villageTarget.giveEffect(
-            "Delirious",
-            this.player,
-            1,
-            ["Delirium", "WhenDead", "Modifier"],
-            this
-          );
+          if (villageTarget) {
+            this.DeliriousVictim = villageTarget.giveEffect(
+              "Delirious",
+              this.player,
+              1,
+              ["Delirium", "WhenDead", "Modifier"],
+              this
+            );
+          }
         }
       },
     };

--- a/Games/types/Mafia/roles/cards/KillVillagePlayerOnDeath.js
+++ b/Games/types/Mafia/roles/cards/KillVillagePlayerOnDeath.js
@@ -28,7 +28,7 @@ module.exports = class KillVillagePlayerOnDeath extends Card {
               `${this.actor.name} the ${this.role.name} has selected ${this.target.name}. If ${this.target.name} is Village Aligned they will die tonight.`
             );
 
-            if (!this.hasAbility(["Kill", "WhenDead"])) {
+            if (!this.role.hasAbility(["Kill", "WhenDead"])) {
               return;
             }
             //this.hasChoosen = true;
@@ -67,6 +67,7 @@ module.exports = class KillVillagePlayerOnDeath extends Card {
 
         var action = new Action({
           actor: this.player,
+          target: this.SelectedPlayer,
           game: this.player.game,
           priority: PRIORITY_KILL_DEFAULT,
           role: this,
@@ -74,7 +75,7 @@ module.exports = class KillVillagePlayerOnDeath extends Card {
           run: function () {
             if (!this.role.SelectedPlayer) return;
             if (this.role.SelectedPlayer.getFaction() != "Village") return;
-            if (this.dominates(this.target)) {
+            if (this.dominates(this.role.SelectedPlayer)) {
               this.role.SelectedPlayer.kill("basic", this.actor);
             }
           },

--- a/Games/types/Mafia/roles/cards/LearnAndLifeLinkToPlayer.js
+++ b/Games/types/Mafia/roles/cards/LearnAndLifeLinkToPlayer.js
@@ -61,7 +61,7 @@ module.exports = class LearnAndLifeLinkToPlayer extends Card {
           return;
         }
         if (this.game.getStateName() != "Night") return;
-        if (killer.role.alignment != "Mafia" && !killer.isDemonic(true)) return;
+        if (!killer || !killer.role || (killer.role.alignment != "Mafia" && !killer.isDemonic(true))) return;
         if (!this.hasAbility(["Kill", "OnlyWhenAlive"])) {
           return;
         }
@@ -69,7 +69,7 @@ module.exports = class LearnAndLifeLinkToPlayer extends Card {
           var action = new Action({
             actor: this.player,
             target: this.player,
-            game: this.holder.game,
+            game: this.game,
             labels: ["kill"],
             run: function () {
               if (this.dominates())

--- a/Games/types/Mafia/roles/cards/MagusGame.js
+++ b/Games/types/Mafia/roles/cards/MagusGame.js
@@ -225,6 +225,7 @@ module.exports = class MagusGame extends Card {
         this.player.role.MagusExtraKillTarget = shuffledPlayers[1];
         if (this.game.getStateName() == "Night") {
           var action = new Action({
+            game: this.game,
             priority: PRIORITY_KILL_DEFAULT,
             labels: ["kill"],
             actor: this.player,
@@ -247,6 +248,7 @@ module.exports = class MagusGame extends Card {
           });
           this.game.queueAction(action);
           action = new Action({
+            game: this.game,
             priority: PRIORITY_KILL_DEFAULT + 1,
             labels: ["kill"],
             actor: this.player,

--- a/Games/types/Mafia/roles/cards/MissionGame.js
+++ b/Games/types/Mafia/roles/cards/MissionGame.js
@@ -11,6 +11,8 @@ module.exports = class MissionGame extends Card {
       return;
     }
 
+    const card = this;
+
     this.listeners = {
       roleAssigned: function (player) {
         if (this.player !== player) {
@@ -46,7 +48,7 @@ module.exports = class MissionGame extends Card {
 
         this.game.leaderIndex = Random.randInt(0, this.game.players.length - 1);
 
-        this.registerMissionStates();
+        card.registerMissionStates();
 
         for (let p of this.game.players) {
           p.holdItem("NoVillageMeeting");

--- a/Games/types/Mafia/roles/cards/MissionGame.js
+++ b/Games/types/Mafia/roles/cards/MissionGame.js
@@ -27,6 +27,7 @@ module.exports = class MissionGame extends Card {
         this.game.currentMissionFails = 0;
         this.game.teamFails = 0;
         this.game.currentTeamFail = false;
+        this.game.teamApproved = false;
         this.game.teamFailLimit = Number(setup.teamFailLimit) || 5;
         this.game.currentMissionHistory = null;
         this.game.missionRecord = {

--- a/Games/types/Mafia/roles/cards/OneWayBond.js
+++ b/Games/types/Mafia/roles/cards/OneWayBond.js
@@ -14,6 +14,7 @@ module.exports = class OneWayBond extends Card {
           priority: PRIORITY_EFFECT_GIVER_EARLY,
           role: this.role,
           run: function () {
+            if (!this.actor || !this.target || typeof this.target !== "object" || !this.target.name) return;
             if (this.role.name == "Yandere") {
               this.role.giveEffect(this.actor, "Lovesick", this.target);
             }

--- a/Games/types/Mafia/roles/cards/PlagueStarter.js
+++ b/Games/types/Mafia/roles/cards/PlagueStarter.js
@@ -70,7 +70,7 @@ module.exports = class PlagueStarter extends Card {
                 }
               }
               for (let neighbor of player.getNeighbors()) {
-                if (neighbor.hasEffect("Virus")) {
+                if (!neighbor || neighbor.hasEffect("Virus")) {
                   continue;
                 }
 

--- a/Games/types/Mafia/roles/cards/Puppeteering.js
+++ b/Games/types/Mafia/roles/cards/Puppeteering.js
@@ -42,7 +42,7 @@ module.exports = class Puppeteering extends Card {
     };
 
     function isControlled(player) {
-      return this.role.data.controlledPlayers.includes(player);
+      return (role.data.controlledPlayers && role.data.controlledPlayers.includes(player)) || false;
     }
   }
 };

--- a/Games/types/Mafia/roles/cards/UnluckyDeath.js
+++ b/Games/types/Mafia/roles/cards/UnluckyDeath.js
@@ -1,7 +1,22 @@
 const Card = require("../../Card");
+const Action = require("../../Action");
 const Random = require("../../../../../lib/Random");
 const { PRIORITY_KILL_DEFAULT } = require("../../const/Priority");
 const { PRIORITY_NIGHT_ROLE_BLOCKER } = require("../../const/Priority");
+
+function killIfVulnerable(player) {
+  if (!player.alive) return;
+  const action = new Action({
+    actor: player,
+    target: player,
+    game: player.game,
+    labels: ["kill"],
+    run() {
+      if (this.dominates()) this.target.kill("basic", this.actor);
+    },
+  });
+  action.do();
+}
 
 module.exports = class UnluckyDeath extends Card {
   constructor(role) {
@@ -109,14 +124,14 @@ module.exports = class UnluckyDeath extends Card {
         let players = this.game.alivePlayers();
         if (players.length == 3) {
           if (Random.randInt(0, 150) <= this.player.role.data.deathChance) {
-            this.player.kill("basic", this.player);
+            killIfVulnerable(this.player);
           }
         }
       },
       death: function (player, killer, killType, instant) {
         let players = this.game.alivePlayers();
         if (Random.randInt(0, 500) <= this.player.role.data.deathChance) {
-          this.player.kill("basic", this.player);
+          killIfVulnerable(this.player);
         }
       },
     };

--- a/Games/types/Mafia/roles/cards/UnluckyDeath.js
+++ b/Games/types/Mafia/roles/cards/UnluckyDeath.js
@@ -109,18 +109,14 @@ module.exports = class UnluckyDeath extends Card {
         let players = this.game.alivePlayers();
         if (players.length == 3) {
           if (Random.randInt(0, 150) <= this.player.role.data.deathChance) {
-            if (this.dominates(this.actor)) {
-              this.actor.kill("basic", this.actor);
-            }
+            this.player.kill("basic", this.player);
           }
         }
       },
       death: function (player, killer, killType, instant) {
         let players = this.game.alivePlayers();
         if (Random.randInt(0, 500) <= this.player.role.data.deathChance) {
-          if (this.dominates(this.actor)) {
-            this.actor.kill("basic", this.actor);
-          }
+          this.player.kill("basic", this.player);
         }
       },
     };

--- a/Games/types/Mafia/roles/cards/VillageMightSurviveCondemn.js
+++ b/Games/types/Mafia/roles/cards/VillageMightSurviveCondemn.js
@@ -27,7 +27,9 @@ module.exports = class VillageMightSurviveCondemn extends Card {
 
           let shuffledPlayers = Random.randomizeArray(villagePlayers);
 
-          shuffledPlayers[0].giveEffect("Condemn Immune", 5, 1);
+          if (shuffledPlayers.length > 0) {
+            shuffledPlayers[0].giveEffect("Condemn Immune", 5, 1);
+          }
         },
       },
     ];

--- a/modules/setupRoleValidation.js
+++ b/modules/setupRoleValidation.js
@@ -1,0 +1,59 @@
+process.env.NODE_ENV = process.env.NODE_ENV || "test";
+const roleData = require("../data/roles");
+const modifierData = require("../data/modifiers");
+const constants = require("../data/constants");
+const { isRoleDisabled } = require("./roleAvailability");
+
+function areModifiersCompatible(gameType, modifiers) {
+  if (!modifierData[gameType] || typeof modifiers !== "string") return false;
+  const mappedModifiers = modifiers
+    .split("/")
+    .map((modifier) =>
+      Object.entries(modifierData[gameType]).find(
+        (mData) => mData[0] === modifier
+      )
+    );
+  if (mappedModifiers.some((m) => !m)) return false;
+  const incompatibles = mappedModifiers
+    .map((e) => (e && e[1] && Array.isArray(e[1].incompatible) ? e[1].incompatible : []))
+    .flat();
+  const usedModifiers = [];
+  for (const modifier of mappedModifiers) {
+    if (
+      incompatibles.includes(modifier[0]) ||
+      (usedModifiers.includes(modifier[0]) && !modifier[1]?.allowDuplicate)
+    ) {
+      return false;
+    }
+    usedModifiers.push(modifier[0]);
+  }
+  return true;
+}
+
+function verifyRole(role, gameType, alignment) {
+  var roleName = role.split(":")[0];
+  var modifiers = role.split(":")[1];
+
+  if (!roleData.hasOwnProperty(gameType)) return false;
+
+  if (!roleData[gameType].hasOwnProperty(roleName)) return false;
+
+  if (modifiers) {
+    for (const modifier of modifiers.split("/")) {
+      if (!constants.modifiers[gameType][modifier]) return false;
+    }
+    if (!areModifiersCompatible(gameType, modifiers)) {
+      return false;
+    }
+  }
+
+  if (isRoleDisabled(gameType, roleName, roleData[gameType][roleName]))
+    return false;
+
+  if (alignment && roleData[gameType][roleName].alignment != alignment)
+    return false;
+
+  return true;
+}
+
+module.exports = { verifyRole, areModifiersCompatible };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "start": "docker-compose up; pm2 start pm2.config.js",
     "stop": "pm2 kill; docker-compose down",
-    "test": "NODE_ENV=test mocha --recursive --parallel --exit"
+    "test": "NODE_ENV=test mocha --recursive --parallel --exit",
+    "fuzz:mafia": "NODE_ENV=test node scripts/mafia-fuzz/run.js"
   },
   "dependencies": {
     "@octokit/core": "^7.0.3",

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -5,8 +5,7 @@ const models = require("../db/models");
 const routeUtils = require("./utils");
 const constants = require("../data/constants");
 const roleData = require("../data/roles");
-const { isRoleDisabled } = require("../modules/roleAvailability");
-const modifierData = require("../data/modifiers");
+const { verifyRole } = require("../modules/setupRoleValidation");
 const gamesettingsData = require("../data/gamesettings");
 const redis = require("../modules/redis");
 const fortunePoints = require("../modules/fortunePoints");
@@ -1426,54 +1425,6 @@ function verifyRolesAndCount(setup) {
   }
 
   return [true, roles, count, total];
-}
-
-function areModifiersCompatible(gameType, modifiers) {
-  const mappedModifiers = modifiers
-    .split("/")
-    .map((modifier) =>
-      Object.entries(modifierData[gameType]).find(
-        (mData) => mData[0] === modifier
-      )
-    );
-  const incompatibles = mappedModifiers.map((e) => e[1].incompatible).flat();
-  const usedModifiers = [];
-  for (const modifier of mappedModifiers) {
-    if (
-      incompatibles.includes(modifier[0]) ||
-      (usedModifiers.includes(modifier[0]) && !modifier[1].allowDuplicate)
-    ) {
-      return false;
-    }
-    usedModifiers.push(modifier[0]);
-  }
-  return true;
-}
-
-function verifyRole(role, gameType, alignment) {
-  var roleName = role.split(":")[0];
-  var modifiers = role.split(":")[1];
-
-  if (!roleData.hasOwnProperty(gameType)) return false;
-
-  if (!roleData[gameType].hasOwnProperty(roleName)) return false;
-
-  if (modifiers) {
-    for (const modifier of modifiers.split("/")) {
-      if (!constants.modifiers[gameType][modifier]) return false;
-    }
-    if (!areModifiersCompatible(gameType, modifiers)) {
-      return false;
-    }
-  }
-
-  if (isRoleDisabled(gameType, roleName, roleData[gameType][roleName]))
-    return false;
-
-  if (alignment && roleData[gameType][roleName].alignment != alignment)
-    return false;
-
-  return true;
 }
 
 function sortRoles(gameType) {

--- a/scripts/mafia-fuzz/README.md
+++ b/scripts/mafia-fuzz/README.md
@@ -1,0 +1,122 @@
+# Ultimafia Mafia Engine Fuzzer
+
+An isolated, reproducible fuzzer for the Ultimafia game engine. It generates randomized Mafia game setups (roles, modifiers, player counts) and simulates player actions and phase deadlines to discover game-breaking exceptions, uncaught rejections, and state corruption without requiring live MongoDB or Redis instances.
+
+---
+
+## Quick Start
+
+Run the default fuzz suite (100 cases starting at seed 1):
+```bash
+npm run fuzz:mafia
+```
+
+Run a specific seed or range:
+```bash
+npm run fuzz:mafia -- --seed 42 --cases 10
+```
+
+Replay a failed case directly from a saved JSON report:
+```bash
+npm run fuzz:mafia -- --replay mafia-fuzz-failures/seed-70-1788671803891.json
+```
+
+---
+
+## Architecture
+
+The fuzzer is structured into four core components:
+
+1. **Setup & Action Generation (`scripts/mafia-fuzz/generator.js`)**
+   - **PRNG**: A fast, seed-deterministic 32-bit PRNG (`random`) ensures identical setup and action sequences across replays.
+   - **Setup Generation (`generate`)**: Generates legal setups with 5–10 players, drawing from Mafia roles and modifier combinations validated by `modules/setupRoleValidation.js`.
+   - **Action Selection (`selections`)**: Inspects active meeting information (`canVote`, `canUpdateVote`, `inputType`, `targets`, `multiMin`, `multiMax`) to generate realistic votes, multi-target selections, boolean decisions, and text inputs.
+
+2. **Isolated Worker Process (`scripts/mafia-fuzz/worker.js`)**
+   - Runs as a disposable Node child process.
+   - Stubs external boundaries (`db/db.js`, `modules/redis.js`, `modules/pushNotifications.js`, `Games/games.js`) and configures Mongoose with `bufferCommands: false` to immediately flag any accidental database leaks.
+   - Uses `TestSocket` from `lib/sockets` to deliver client votes through the standard socket interface.
+   - Advances game deadlines explicitly (`timers.main.end()`) to test day/night phase transitions.
+   - Traps `uncaughtException`, `unhandledRejection`, and logger errors (`logger.error`), streaming incremental progress checkpoints back to the parent process.
+
+3. **Orchestrator Runner (`scripts/mafia-fuzz/run.js`)**
+   - Spawns workers per case and enforces timeouts (`SIGKILL` after timeout threshold).
+   - Collects results (`finished`, `bounded`, or `failure`).
+   - On failure, saves a detailed JSON report with the setup, action trace, state sequence, and error stack.
+
+4. **Shared Validation (`modules/setupRoleValidation.js`)**
+   - Extracted shared logic for verifying base roles, modifier compatibility, duplicate allowances, and role alignments.
+   - Shared between `routes/setup.js` (API endpoints) and the generator.
+
+---
+
+## CLI Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--seed` | Integer | `1` | Initial random seed. |
+| `--cases` | Integer | `100` | Number of sequential cases to execute (`seed`, `seed+1`, ...). |
+| `--steps` | Integer | `40` | Max phase state cycles per game before marking as `bounded`. |
+| `--timeout` | Integer (ms) | `15000` | Per-worker execution timeout in milliseconds. |
+| `--modifiers` | Integer | `3` | Maximum number of modifiers stacked onto any single role. |
+| `--output` | String | `mafia-fuzz-failures` | Directory where failure JSON artifacts are written. |
+| `--replay` | File path | `null` | Path to a failure JSON file to replay with identical inputs. |
+
+---
+
+## Failure Reports & Replay
+
+When a worker crashes, the runner writes a diagnostic JSON file to `--output`:
+
+```json
+{
+  "version": 1,
+  "seed": 70,
+  "setup": { "total": 9, "roles": [...] },
+  "maxSteps": 40,
+  "status": "failure",
+  "trace": [
+    { "state": 0, "player": "fuzz1", "role": "Gambler", "meeting": "Give Challenge", "selection": "fuzz17" },
+    ...
+  ],
+  "states": ["Night 1", "Day 1", "Night 2", ...],
+  "error": "TypeError: Cannot read properties of undefined (reading 'getImmunity')\n    at ...",
+  "output": ""
+}
+```
+
+To replay the exact game that failed:
+```bash
+node scripts/mafia-fuzz/run.js --replay mafia-fuzz-failures/seed-70-1788671803891.json
+```
+
+Because player IDs, socket IDs, and random choices are seeded, replaying the case triggers the exact sequence of events leading to the failure.
+
+---
+
+## Automated Test Suite
+
+The fuzzer is accompanied by unit and integration tests under `test/mafiaFuzz.test.js`:
+```bash
+npx mocha --exit test/mafiaFuzz.test.js
+```
+The test suite validates:
+- Role & modifier compatibility, alignment rules, and duplicate limits.
+- Deterministic setup generator bounds and constraints.
+- Action selection for voting flags, multi-target bounds, and input types.
+- Error interception and crash capture via `runCase`.
+- Timeout killing runaway workers.
+- Reproducible state sequence replay.
+
+---
+
+## Limitations & Scope
+
+1. **Single-Node In-Memory Simulation**:
+   - MongoDB and Redis operations are stubbed out; persistence schema validations, live Redis pub/sub routing, and socket clustering are not tested by this harness.
+2. **Excluded Modifiers/Archetypes**:
+   - `Banished` modifiers and `Event` alignments require custom player-count configurations and are excluded from the default randomized generator pool.
+3. **Mafia-Specific Engine**:
+   - The harness targets `Games/types/Mafia/Game.js`. Other game engines in the repository (such as `Cheat`, `TexasHoldEm`, `LiarsDice`, `DiceWars`) have differing game loops and state machines not covered by this runner.
+4. **Action Heuristics**:
+   - The fuzzer selects random legal targets and inputs; it does not model adversarial or optimal human strategies, but focuses on broad state-space coverage and boundary edge-cases.

--- a/scripts/mafia-fuzz/generator.js
+++ b/scripts/mafia-fuzz/generator.js
@@ -1,0 +1,56 @@
+const roles = require("../../data/roles").Mafia;
+const modifiers = require("../../data/modifiers").Mafia;
+const { verifyRole } = require("../../modules/setupRoleValidation");
+
+function random(seed) {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function generate(seed, maxModifiers = 3) {
+  const rng = random(seed);
+  const pick = (xs) => xs[Math.floor(rng() * xs.length)];
+  // Open, single-roleset setups. Events and Banished slots have different
+  // player-count rules and are intentionally outside this initial corpus.
+  const names = Object.keys(roles).filter(
+    (name) => roles[name].alignment !== "Event" && verifyRole(name, "Mafia")
+  );
+  const mods = Object.keys(modifiers).filter((name) => name !== "Banished");
+  const slots = ["Villager", "Villager", "Mafioso"];
+  const total = 5 + Math.floor(rng() * 6);
+  while (slots.length < total) {
+    let role = pick(names);
+    const count = Math.floor(rng() * (maxModifiers + 1));
+    for (let i = 0; i < count; i++) {
+      const candidate = role + (role.includes(":") ? "/" : ":") + pick(mods);
+      if (verifyRole(candidate, "Mafia")) role = candidate;
+    }
+    slots.push(role);
+  }
+  const set = {};
+  for (const role of slots) set[role] = (set[role] || 0) + 1;
+  return { total, roles: [set], numMissions: 5, firstTeamSize: 2,
+    lastTeamSize: 3, teamFailLimit: 5 };
+}
+
+function selections(info, meeting, rng) {
+  if (!info.voting || !info.canVote || !info.canUpdateVote) return [];
+  if (info.inputType === "text") return ["fuzz " + Math.floor(rng() * 100)];
+  if (!Array.isArray(info.targets) || !info.targets.length) return [];
+  const targets = info.targets.slice();
+  for (let i = targets.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [targets[i], targets[j]] = [targets[j], targets[i]];
+  }
+  if (!info.multi) return targets.slice(0, 1);
+  const max = Math.min(targets.length, meeting.multiMax);
+  const min = Math.min(max, Math.max(1, meeting.multiMin));
+  return targets.slice(0, min + Math.floor(rng() * (max - min + 1)));
+}
+
+module.exports = { random, generate, selections };

--- a/scripts/mafia-fuzz/run.js
+++ b/scripts/mafia-fuzz/run.js
@@ -1,0 +1,64 @@
+process.env.NODE_ENV = "test";
+const { fork } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const { generate } = require("./generator");
+
+function runCase(input, timeout = 15000, worker = path.join(__dirname, "worker.js")) {
+  return new Promise((resolve) => {
+    let latest = input;
+    let output = "";
+    let timedOut = false;
+    const child = fork(worker, [], { silent: true });
+    child.on("message", (message) => { latest = message; });
+    for (const stream of [child.stdout, child.stderr])
+      stream.on("data", (data) => { output = (output + data).slice(-16000); });
+    const timer = setTimeout(() => { timedOut = true; child.kill("SIGKILL"); }, timeout);
+    child.on("error", (error) => { latest = { ...latest, error: error.stack }; });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      if (timedOut || code !== 0 || !["finished", "bounded"].includes(latest.status)) {
+        latest = { ...latest, status: "failure", error: timedOut
+          ? `Worker exceeded ${timeout}ms (possible hang; replay with a larger timeout)`
+          : latest.error || `Worker exited ${code}, signal ${signal}`, output };
+      }
+      resolve(latest);
+    });
+    child.send(input);
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const options = { seed: 1, cases: 100, steps: 40, timeout: 15000,
+    modifiers: 3, output: "mafia-fuzz-failures" };
+  for (let i = 0; i < args.length; i += 2) {
+    const key = args[i].replace(/^--/, "");
+    if (![...Object.keys(options), "replay"].includes(key) || args[i + 1] == null)
+      throw new Error(`Unknown or incomplete option: ${args[i]}`);
+    options[key] = ["output", "replay"].includes(key) ? args[i + 1] : Number(args[i + 1]);
+  }
+  for (const key of ["seed", "cases", "steps", "timeout", "modifiers"])
+    if (!Number.isSafeInteger(options[key]) || options[key] < (key === "seed" || key === "modifiers" ? 0 : 1))
+      throw new Error(`Invalid --${key}`);
+  let failures = 0;
+  const counts = { finished: 0, bounded: 0, failure: 0 };
+  for (let i = 0; i < (options.replay ? 1 : options.cases); i++) {
+    const seed = (options.seed + i) >>> 0;
+    const input = options.replay ? JSON.parse(fs.readFileSync(options.replay, "utf8"))
+      : { version: 1, seed, setup: generate(seed, options.modifiers), maxSteps: options.steps };
+    const result = await runCase(input, options.timeout);
+    counts[result.status]++;
+    if (result.status === "failure") {
+      failures++;
+      fs.mkdirSync(options.output, { recursive: true });
+      const file = path.join(options.output, `seed-${input.seed}-${Date.now()}.json`);
+      fs.writeFileSync(file, JSON.stringify(result, null, 2) + "\n");
+      console.log(`FAIL seed=${input.seed}: ${result.error.split("\n")[0]}\n  ${file}`);
+    } else console.log(`${result.status} seed=${input.seed} states=${result.states.length} actions=${result.trace.length}`);
+  }
+  console.log(JSON.stringify(counts));
+  process.exitCode = failures ? 1 : 0;
+}
+if (require.main === module) main().catch((error) => { console.error(error); process.exitCode = 1; });
+module.exports = { runCase };

--- a/scripts/mafia-fuzz/worker.js
+++ b/scripts/mafia-fuzz/worker.js
@@ -1,0 +1,93 @@
+// Service substitutions are installed only in this disposable child process.
+process.env.NODE_ENV = "test";
+const path = require("path");
+function stub(file, exports) {
+  const id = require.resolve(path.resolve(__dirname, "../..", file));
+  require.cache[id] = { id, filename: id, loaded: true, exports };
+}
+let report = { trace: [], states: [], status: "initializing" };
+function checkpoint() { if (process.send) process.send(report); }
+function fail(error) {
+  report.status = "failure";
+  report.error = error?.stack || String(error);
+  if (process.send) process.send(report, () => process.exit(1));
+  else process.exit(1);
+}
+process.on("uncaughtException", fail);
+process.on("unhandledRejection", fail);
+stub("Games/games.js", { games: {}, deprecationCheck() {} });
+stub("db/db.js", { promise: Promise.resolve(), conn: {} });
+const noop = async () => {};
+const redis = {};
+for (const name of ["createGame", "joinGame", "inGame", "setGameHost",
+  "setSpectatorCount", "leaveGame", "deleteGame", "setGameStatus",
+  "setGameState", "setWinnersInfo"]) redis[name] = noop;
+stub("modules/redis.js", redis);
+stub("modules/pushNotifications.js", {
+  unregisterUser() {}, registerUser() {}, notifyUsers: noop,
+});
+stub("modules/logging.js", () => ({
+  info() {}, debug() {}, warn() {}, error: fail,
+}));
+// Reject accidental persistence/network access rather than silently accepting it.
+require("mongoose").set("bufferCommands", false);
+const { random, selections } = require("./generator");
+process.on("message", async (input) => {
+  report = { ...input, status: "running", trace: [], states: [] };
+  delete report.error;
+  checkpoint();
+  const rng = random(input.seed);
+  Math.random = rng;
+  require("../../lib/Random").randFloat = rng;
+  let id = 0;
+  require("shortid").generate = () => `fuzz${id++}`;
+  const Game = require("../../Games/types/Mafia/Game");
+  const User = require("../../Games/core/User");
+  const Socket = require("../../lib/sockets").TestSocket;
+  const game = new Game({ id: "fuzz-game", hostId: "user0", isTest: true,
+    settings: { setup: input.setup, pregameCountdownLength: 0,
+      stateLengths: { Day: 60000, Night: 60000, "Team Approval": 60000, Mission: 60000 } } });
+  // Use real Timer objects but advance deadlines explicitly between action batches.
+  const Timer = require("../../Games/core/Timer");
+  Timer.prototype.start = function () { this.startTime = Date.now(); };
+  game.handleError = fail;
+  await game.init();
+  for (let i = 0; i < input.setup.total; i++) {
+    await game.userJoin(new User({ id: `user${i}`, name: `Player${i}`,
+      socket: new Socket(), settings: {}, isTest: true }), true);
+  }
+  await new Promise(setImmediate);
+  if (!game.started) throw new Error("Game did not start");
+  for (let step = 0; step < input.maxSteps && !game.finished; step++) {
+    report.states.push(game.getStateInfo().name);
+    checkpoint();
+    const state = game.currentState;
+    for (const meeting of [...game.meetings]) {
+      for (const member of Object.values(meeting.members)) {
+        if (game.finished || game.currentState !== state) break;
+        const player = member.player;
+        const info = meeting.getMeetingInfo(player);
+        for (const selection of selections(info, meeting, rng)) {
+          if (game.finished || game.currentState !== state) break;
+          report.trace.push({ state, player: player.id, role: player.role.name,
+            meeting: meeting.name, meetingId: meeting.id, selection });
+          checkpoint();
+          player.user.socket.sendToServer("vote", { meetingId: meeting.id, selection });
+        }
+      }
+    }
+    if (!game.finished && game.currentState === state) {
+      if (!game.timers.main) throw new Error("No main timer in active game");
+      report.trace.push({ state, timer: "main" });
+      checkpoint();
+      game.timers.main.end();
+    }
+    await new Promise(setImmediate);
+    if (!game.finished && game.currentState === state)
+      throw new Error("Game did not advance after its deadline");
+  }
+  // A long, valid game is a budget exhaustion, not evidence of a crash.
+  report.status = game.finished ? "finished" : "bounded";
+  game.clearTimers();
+  process.send(report, () => process.exit(0));
+});

--- a/test/Games/Mafia/Spymaster.test.js
+++ b/test/Games/Mafia/Spymaster.test.js
@@ -189,9 +189,11 @@ describe("Games/Mafia/Spymaster", function () {
     const game = await makeGame(spymasterSetup({ teamFailLimit: 1 }));
     await waitForResult(() => game.started);
 
+    game.recordMissionTeam(["Player 1", "Player 2"]);
     game.recordMissionFails(0);
     game.missionRecord.score.rebels.should.equal(1);
 
+    game.recordMissionTeam(["Player 1", "Player 2"]);
     game.recordMissionFails(1);
     game.missionRecord.score.spies.should.equal(1);
   });

--- a/test/fixtures/mafiaFixReview.cjs
+++ b/test/fixtures/mafiaFixReview.cjs
@@ -1,0 +1,121 @@
+require("../../scripts/mafia-fuzz/worker");
+const assert = require("assert/strict");
+const EventEmitter = require("events");
+const Game = require("../../Games/core/Game");
+const MafiaGame = require("../../Games/types/Mafia/Game");
+const Player = require("../../Games/core/Player");
+const Action = require("../../Games/core/Action");
+const Information = require("../../Games/types/Mafia/Information");
+
+function player(game, immune = false) {
+  const p = Object.create(Player.prototype);
+  Object.assign(p, { game, alive: true, role: { data: { deathChance: 500 } },
+    user: { id: "test" }, getImmunity: () => immune ? 100 : 0,
+    getCancelImmunity: () => 0, kill() { this.alive = false; } });
+  return p;
+}
+
+async function run(scenario) {
+  const game = { events: new EventEmitter(), getStateName: () => "Day" };
+  if (scenario === "unlucky") {
+    const Card = require("../../Games/types/Mafia/roles/cards/UnluckyDeath");
+    require("../../lib/Random").randInt = () => 0;
+    for (const listener of ["state", "death"]) {
+      for (const immune of [false, true]) {
+        const p = player(game, immune);
+        game.alivePlayers = () => [p, {}, {}];
+        const role = { player: p, game };
+        const card = new Card(role);
+        card.listeners[listener].call(role);
+        assert.equal(p.alive, immune, listener + " must respect kill immunity");
+        // No repeated kill when the listener receives another death event.
+        p.alive = false;
+        p.kill = () => assert.fail("Killed an already-dead player");
+        card.listeners[listener].call(role);
+      }
+    }
+  } else if (scenario === "watcher") {
+    const vulnerable = player(game);
+    const protectedPlayer = player(game, true);
+    protectedPlayer.docImmunity = [{ saver: "doctor" }];
+    let events = 0;
+    game.events.on("immune", () => events++);
+    const makeAction = target => {
+      const action = new Action({ game, target, labels: ["kill"], run() {} });
+      action.docSave = () => assert.fail("Information query persisted a Doctor save");
+      return action;
+    };
+    game.actions = [[makeAction([vulnerable, protectedPlayer, null, "No"]), makeAction("No")]];
+    const info = new Information("test", null, game);
+    assert.deepEqual(info.getKillVictims(), [vulnerable]);
+    assert.equal(events, 0);
+    game.actions = [[makeAction(vulnerable)]];
+    assert.deepEqual(info.getKillVictims(), [vulnerable]);
+    let saves = 0;
+    const liveAction = makeAction(protectedPlayer);
+    liveAction.docSave = () => saves++;
+    assert.equal(liveAction.dominates(), false);
+    assert.equal(events, 1);
+    assert.equal(saves, 1);
+  } else if (scenario === "incubus") {
+    const Card = require("../../Games/types/Mafia/roles/cards/ConvertToChosenRoleOnDeath");
+    const victim = player(game);
+    let effects = 0;
+    const role = { game, data: { targetPlayer: victim }, giveEffect() { effects++; } };
+    const card = new Card(role);
+    const convert = card.meetings["Role to Become"].action.run;
+    convert.call({ role, target: "None" });
+    assert.equal(role.data.targetPlayer, undefined);
+    convert.call({ role, target: "Villager", dominates: () => true });
+    assert.equal(effects, 0, "Abstaining must not reuse an earlier target");
+    role.data.targetPlayer = victim;
+    convert.call({ role, target: "Villager", dominates: () => true });
+    assert.equal(effects, 1);
+    assert.equal(role.data.targetPlayer, undefined);
+    role.data.targetPlayer = victim;
+    convert.call({ role, target: "Villager", dominates: () => false });
+    assert.equal(role.data.targetPlayer, undefined);
+  } else if (scenario === "state-search") {
+    const g = Object.create(Game.prototype);
+    g.states = [{}, {}, { skipChecks: [() => true] }, { skipChecks: [() => true] }];
+    g.stateIndexRecord = [2];
+    g.stateOffset = 0;
+    assert.equal(g.getNextStateIndex()[0], null);
+    g.states[3].skipChecks = [() => false];
+    assert.equal(g.getNextStateIndex()[0], 3);
+    g.states = [{}, {}];
+    assert.equal(g.getNextStateIndex()[0], null);
+    g.currentState = 8;
+    let ended = false;
+    g.endForNoPlayableState = () => { ended = true; };
+    g.incrementState();
+    assert.equal(ended, true);
+    assert.equal(g.currentState, 8);
+    assert.deepEqual(g.stateIndexRecord, [2]);
+  } else if (scenario === "state-end") {
+    const User = require("../../Games/core/User");
+    const Socket = require("../../lib/sockets").TestSocket;
+    require("../../Games/core/Timer").prototype.start = function () { this.startTime = Date.now(); };
+    const g = new MafiaGame({ id: "state-end", hostId: "p0", isTest: true,
+      settings: { setup: { total: 5, roles: [{ Villager: 4, Mafioso: 1 }] },
+        stateLengths: { Day: 60000, Night: 60000 } } });
+    await g.init();
+    for (let i = 0; i < 5; i++) await g.userJoin(new User({ id: "p" + i, name: "P" + i,
+      socket: new Socket(), settings: {}, isTest: true }), true);
+    await new Promise(setImmediate);
+    assert.equal(g.started, true);
+    const record = [...g.stateIndexRecord];
+    for (const state of g.states.slice(2)) state.skipChecks = [() => true];
+    g.gotoNextState();
+    await new Promise(setImmediate);
+    assert.equal(g.finished, true);
+    assert.equal(g.currentState, -2);
+    assert.deepEqual(g.stateIndexRecord, record);
+    assert.deepEqual(Object.keys(g.winners.groups), ["No one"]);
+    assert.deepEqual(Object.keys(g.timers), []);
+  } else throw new Error("Unknown scenario " + scenario);
+}
+run(process.argv[2]).then(() => process.exit(0)).catch(error => {
+  console.error(error.stack);
+  process.exit(1);
+});

--- a/test/fixtures/mafiaMissionRegression.cjs
+++ b/test/fixtures/mafiaMissionRegression.cjs
@@ -1,0 +1,120 @@
+// Run in a disposable process: reuse only the fuzzer's service substitutions.
+require("../../scripts/mafia-fuzz/worker");
+const assert = require("assert/strict");
+const Game = require("../../Games/types/Mafia/Game");
+const User = require("../../Games/core/User");
+const Socket = require("../../lib/sockets").TestSocket;
+const Timer = require("../../Games/core/Timer");
+Timer.prototype.start = function () { this.startTime = Date.now(); };
+
+async function makeGame(teamFailLimit = 3) {
+  const game = new Game({ id: "mission-regression", hostId: "user0", isTest: true,
+    settings: { setup: { total: 5, roles: [{ Villager: 3, Spymaster: 1, Mafioso: 1 }],
+      numMissions: 5, firstTeamSize: 2, lastTeamSize: 3, teamFailLimit },
+    stateLengths: { Day: 60000, Night: 60000, "Team Approval": 60000, Mission: 60000 } } });
+  await game.init();
+  for (let i = 0; i < 5; i++) {
+    await game.userJoin(new User({ id: `user${i}`, name: `Player${i}`,
+      socket: new Socket(), settings: {}, isTest: true }), true);
+  }
+  await new Promise(setImmediate);
+  assert.equal(game.started, true);
+  return game;
+}
+
+function reach(game, state) {
+  for (let i = 0; i < 12 && game.getStateName() !== state; i++) {
+    assert.ok(!game.finished, "Game ended before " + state);
+    assert.ok(game.timers.main, "Missing timer before " + state);
+    game.timers.main.end();
+  }
+  assert.equal(game.getStateName(), state);
+}
+
+function approve(game, selection) {
+  const meeting = [...game.meetings].find(m => m.name === "Approve Team");
+  assert.ok(meeting);
+  for (const member of Object.values(meeting.members)) {
+    member.player.user.socket.sendToServer("vote", { meetingId: meeting.id, selection });
+  }
+}
+
+async function run(name) {
+  if (name === "integrity") {
+    for (const isTest of [false, true]) {
+      const game = Object.create(Game.prototype);
+      game.isTest = isTest;
+      game.hasIntegrity = true;
+      const alerts = [];
+      game.queueAlert = text => alerts.push(text);
+      assert.equal(game.breakIntegrity(), true);
+      assert.equal(game.hasIntegrity, false);
+      assert.equal(game.breakIntegrity(), false);
+      assert.equal(alerts.length, 1);
+      if (isTest) {
+        // These must remain safe without any database connection.
+        await game.refundHeartsForIntegrityBreak(null, true, true);
+        await game.penalizePlayerForLeaving("user0");
+      }
+    }
+    return;
+  }
+  const game = await makeGame(name === "retry-limit" ? 1 : 3);
+  try {
+    if (name === "scoring") {
+      assert.equal(game.recordMissionFails(0), false);
+      game.recordMissionTeam([]);
+      assert.equal(game.recordMissionFails(0), false);
+      assert.deepEqual(game.missionRecord.score, { rebels: 0, spies: 0 });
+      assert.equal(game.missionRecord.missionHistory.length, 0);
+      game.recordMissionTeam(["Player0", "Player1"]);
+      assert.equal(game.recordMissionFails(0), true);
+      game.recordMissionTeam(["Player0", "Player1"]);
+      assert.equal(game.recordMissionFails(1), true);
+      assert.deepEqual(game.missionRecord.score, { rebels: 1, spies: 1 });
+      return;
+    }
+    reach(game, "Night");
+    if (["approved", "rejected", "approval-timeout"].includes(name)) {
+      // Set up a completed selection; exercise actual approval votes and
+      // state transitions, independently of Assemble Team's item behavior.
+      game.recordMissionTeam(["Player0", "Player1"]);
+    }
+    reach(game, "Team Approval");
+    if (name === "approval-timeout") {
+      const meeting = [...game.meetings].find(m => m.name === "Approve Team");
+      const members = Object.values(meeting.members);
+      // Leave one vote outstanding so the deadline resolves the rejection.
+      for (const member of members.slice(0, -1)) {
+        member.player.user.socket.sendToServer("vote", { meetingId: meeting.id, selection: "No" });
+      }
+      game.timers.main.end();
+    } else {
+      approve(game, name === "rejected" ? "No" : "Yes");
+    }
+    if (name === "approved") {
+      assert.equal(game.currentTeamFail, false);
+      assert.ok(game.getStateName() === "Mission" || game.missionRecord.score.rebels === 1);
+      return;
+    }
+    reach(game, "Night");
+    assert.equal(game.missionRecord.score.rebels, 0);
+    assert.equal(game.currentMissionHistory, null);
+    assert.equal(game.teamApproved, false);
+    if (name === "retry-limit") {
+      assert.equal(game.missionRecord.score.spies, 1);
+      assert.equal(game.missionRecord.missionHistory[0].numFails, -1);
+      assert.equal(game.mission, 2);
+    } else {
+      assert.equal(game.mission, 1);
+      assert.equal(game.teamFails, 1);
+      assert.equal(game.missionRecord.missionHistory.length, 0);
+    }
+  } finally {
+    game.clearTimers();
+  }
+}
+run(process.argv[2]).then(() => process.exit(0)).catch(error => {
+  console.error(error.stack);
+  process.exit(1);
+});

--- a/test/mafiaFixReview.test.js
+++ b/test/mafiaFixReview.test.js
@@ -1,0 +1,20 @@
+const { execFile } = require("child_process");
+const path = require("path");
+const { promisify } = require("util");
+const run = promisify(execFile);
+
+describe("Mafia reviewed fix regressions", function () {
+  this.timeout(15000);
+  for (const [scenario, description] of Object.entries({
+    unlucky: "checks immunity for Unlucky state/death kills and ignores dead players",
+    watcher: "checks each kill target without immunity events or persistence",
+    incubus: "clears pending conversion targets after abstention, immunity, and success",
+    "state-search": "reports exhausted state searches without entering skipped phases",
+    "state-end": "ends a game with no playable phase without a winner",
+  })) {
+    it(description, async function () {
+      await run(process.execPath, [path.join(__dirname, "fixtures/mafiaFixReview.cjs"), scenario],
+        { timeout: 12000 });
+    });
+  }
+});

--- a/test/mafiaFuzz.test.js
+++ b/test/mafiaFuzz.test.js
@@ -1,0 +1,210 @@
+const chai = require("chai");
+const expect = chai.expect;
+const path = require("path");
+const fs = require("fs");
+
+const {
+  verifyRole,
+  areModifiersCompatible,
+} = require("../modules/setupRoleValidation");
+const {
+  random,
+  generate,
+  selections,
+} = require("../scripts/mafia-fuzz/generator");
+const { runCase } = require("../scripts/mafia-fuzz/run");
+
+describe("Mafia Fuzzer Test Suite", function () {
+  this.timeout(30000);
+
+  describe("1. Legal combinations and role/modifier validation", function () {
+    it("validates basic Mafia roles without modifiers", function () {
+      expect(verifyRole("Villager", "Mafia")).to.be.true;
+      expect(verifyRole("Mafioso", "Mafia")).to.be.true;
+      expect(verifyRole("Doctor", "Mafia")).to.be.true;
+      expect(verifyRole("Cop", "Mafia")).to.be.true;
+    });
+
+    it("rejects non-existent roles", function () {
+      expect(verifyRole("NonExistentRoleXYZ", "Mafia")).to.be.false;
+      expect(verifyRole("", "Mafia")).to.be.false;
+      expect(verifyRole("Villager", "NonExistentGameType")).to.be.false;
+    });
+
+    it("enforces alignment matching when specified", function () {
+      expect(verifyRole("Villager", "Mafia", "Village")).to.be.true;
+      expect(verifyRole("Villager", "Mafia", "Mafia")).to.be.false;
+      expect(verifyRole("Mafioso", "Mafia", "Mafia")).to.be.true;
+      expect(verifyRole("Mafioso", "Mafia", "Village")).to.be.false;
+    });
+
+    it("validates single compatible modifier on a role", function () {
+      expect(verifyRole("Doctor:Bulletproof", "Mafia")).to.be.true;
+      expect(verifyRole("Villager:Caffeinated", "Mafia")).to.be.true;
+    });
+
+    it("validates multiple compatible modifiers", function () {
+      expect(verifyRole("Doctor:Bulletproof/Caffeinated", "Mafia")).to.be.true;
+    });
+
+    it("rejects unknown modifiers", function () {
+      expect(verifyRole("Doctor:NonExistentModXYZ", "Mafia")).to.be.false;
+      expect(verifyRole("Villager:Bulletproof/FakeModifier", "Mafia")).to.be.false;
+    });
+
+    it("rejects incompatible modifiers via areModifiersCompatible", function () {
+      // In Mafia modifiers, check an incompatible pair like Inclusive and Exclusive
+      const incompatiblePair = areModifiersCompatible("Mafia", "Inclusive/Exclusive");
+      expect(incompatiblePair).to.be.false;
+      expect(verifyRole("Doctor:Inclusive/Exclusive", "Mafia")).to.be.false;
+    });
+
+    it("handles duplicate modifiers based on allowDuplicate flag", function () {
+      // Bulletproof has allowDuplicate: true
+      expect(areModifiersCompatible("Mafia", "Bulletproof/Bulletproof")).to.be.true;
+      // Apprehensive does not allow duplicates
+      expect(areModifiersCompatible("Mafia", "Apprehensive/Apprehensive")).to.be.false;
+      expect(verifyRole("Doctor:Apprehensive/Apprehensive", "Mafia")).to.be.false;
+    });
+
+    it("areModifiersCompatible handles invalid inputs gracefully", function () {
+      expect(areModifiersCompatible("InvalidGameType", "Bulletproof")).to.be.false;
+      expect(areModifiersCompatible("Mafia", null)).to.be.false;
+      expect(areModifiersCompatible("Mafia", 123)).to.be.false;
+      expect(areModifiersCompatible("Mafia", "NonExistentMod1/NonExistentMod2")).to.be.false;
+    });
+
+    it("generate() creates valid setups where all roles pass verifyRole", function () {
+      for (let seed = 1; seed <= 10; seed++) {
+        const setup = generate(seed, 3);
+        expect(setup).to.be.an("object");
+        expect(setup.total).to.be.at.least(5).and.at.most(10);
+        expect(setup.roles).to.be.an("array").with.lengthOf(1);
+
+        const roleset = setup.roles[0];
+        let roleCount = 0;
+        for (const [roleName, count] of Object.entries(roleset)) {
+          expect(count).to.be.at.least(1);
+          roleCount += count;
+          expect(verifyRole(roleName, "Mafia"), `Role ${roleName} should be valid`).to.be.true;
+        }
+        expect(roleCount).to.equal(setup.total);
+      }
+    });
+  });
+
+  describe("2. Action selection logic", function () {
+    const rng = random(42);
+
+    it("returns empty array when member cannot vote", function () {
+      expect(selections({ voting: false, canVote: true, canUpdateVote: true, targets: ["user1"] }, {}, rng)).to.deep.equal([]);
+      expect(selections({ voting: true, canVote: false, canUpdateVote: true, targets: ["user1"] }, {}, rng)).to.deep.equal([]);
+      expect(selections({ voting: true, canVote: true, canUpdateVote: false, targets: ["user1"] }, {}, rng)).to.deep.equal([]);
+    });
+
+    it("generates fuzz text for text inputType", function () {
+      const info = { voting: true, canVote: true, canUpdateVote: true, inputType: "text" };
+      const sels = selections(info, {}, rng);
+      expect(sels).to.be.an("array").with.lengthOf(1);
+      expect(sels[0]).to.match(/^fuzz \d+$/);
+    });
+
+    it("returns empty array when targets array is empty or not an array", function () {
+      expect(selections({ voting: true, canVote: true, canUpdateVote: true, targets: [] }, {}, rng)).to.deep.equal([]);
+      expect(selections({ voting: true, canVote: true, canUpdateVote: true, targets: null }, {}, rng)).to.deep.equal([]);
+    });
+
+    it("selects exactly 1 target for single-choice meetings", function () {
+      const targets = ["user1", "user2", "user3"];
+      const info = { voting: true, canVote: true, canUpdateVote: true, multi: false, targets };
+      const sels = selections(info, { multiMax: 1, multiMin: 1 }, rng);
+      expect(sels).to.be.an("array").with.lengthOf(1);
+      expect(targets).to.include(sels[0]);
+    });
+
+    it("selects between multiMin and multiMax for multi-target meetings", function () {
+      const targets = ["u1", "u2", "u3", "u4", "u5"];
+      const info = { voting: true, canVote: true, canUpdateVote: true, multi: true, targets };
+      const meeting = { multiMin: 2, multiMax: 4 };
+      const sels = selections(info, meeting, rng);
+      expect(sels.length).to.be.at.least(2).and.at.most(4);
+      sels.forEach((s) => expect(targets).to.include(s));
+    });
+
+    it("is deterministic with the same random seed", function () {
+      const info = { voting: true, canVote: true, canUpdateVote: true, multi: true, targets: ["a", "b", "c", "d"] };
+      const meeting = { multiMin: 1, multiMax: 3 };
+      const res1 = selections(info, meeting, random(123));
+      const res2 = selections(info, meeting, random(123));
+      expect(res1).to.deep.equal(res2);
+    });
+  });
+
+  describe("3. Crash capture", function () {
+    it("captures thrown worker errors and returns failure status", async function () {
+      // Create a mock worker with error reporting matching worker.js contract
+      const mockWorkerPath = path.join(__dirname, "mockCrashWorker.js");
+      fs.writeFileSync(
+        mockWorkerPath,
+        `let report = { status: "running" };
+         function fail(err) {
+           report.status = "failure";
+           report.error = err?.stack || String(err);
+           if (process.send) process.send(report, () => process.exit(1));
+           else process.exit(1);
+         }
+         process.on("uncaughtException", fail);
+         process.on("message", () => {
+           throw new Error("Simulated harness engine crash");
+         });`
+      );
+
+      try {
+        const input = { version: 1, seed: 999 };
+        const result = await runCase(input, 5000, mockWorkerPath);
+        expect(result.status).to.equal("failure");
+        expect(result.error).to.include("Simulated harness engine crash");
+      } finally {
+        if (fs.existsSync(mockWorkerPath)) fs.unlinkSync(mockWorkerPath);
+      }
+    });
+  });
+
+  describe("4. Timeout enforcement", function () {
+    it("kills hanging worker and returns failure with timeout error", async function () {
+      const mockHangWorkerPath = path.join(__dirname, "mockHangWorker.js");
+      fs.writeFileSync(
+        mockHangWorkerPath,
+        `process.on("message", () => {
+           // Do nothing, simulate hanging indefinitely
+         });`
+      );
+
+      try {
+        const input = { version: 1, seed: 888 };
+        const result = await runCase(input, 150, mockHangWorkerPath);
+        expect(result.status).to.equal("failure");
+        expect(result.error).to.include("Worker exceeded 150ms");
+      } finally {
+        if (fs.existsSync(mockHangWorkerPath)) fs.unlinkSync(mockHangWorkerPath);
+      }
+    });
+  });
+
+  describe("5. Reproducible replay", function () {
+    it("reproduces identical state and action traces for the same seed", async function () {
+      const seed = 1;
+      const setup = generate(seed, 3);
+      const input = { version: 1, seed, setup, maxSteps: 5 };
+
+      const run1 = await runCase(input, 15000);
+      const run2 = await runCase(input, 15000);
+
+      expect(run1.status).to.equal(run2.status);
+      expect(run1.states).to.deep.equal(run2.states);
+      expect(run1.trace).to.deep.equal(run2.trace);
+      expect(run1.states.length).to.be.at.least(1);
+      expect(run1.trace.length).to.be.at.least(1);
+    });
+  });
+});

--- a/test/mafiaMissionRegression.test.js
+++ b/test/mafiaMissionRegression.test.js
@@ -1,0 +1,22 @@
+const { execFile } = require("child_process");
+const path = require("path");
+const { promisify } = require("util");
+const run = promisify(execFile);
+
+describe("Mafia mission and integrity regressions", function () {
+  this.timeout(15000);
+  for (const [scenario, description] of Object.entries({
+    integrity: "preserves integrity state and alerts in tests without persistence",
+    scoring: "scores played missions but never scores a missing or empty team",
+    "missing-team": "retries a missing team even when players vote to approve it",
+    "retry-limit": "awards spies a failure only when the team retry limit is reached",
+    rejected: "skips the mission after rejection without double-counting the attempt",
+    "approval-timeout": "retries a selected team when approval times out",
+    approved: "allows a selected and approved team to proceed",
+  })) {
+    it(description, async function () {
+      await run(process.execPath, [path.join(__dirname, "fixtures/mafiaMissionRegression.cjs"), scenario],
+        { timeout: 12000 });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Adds a seeded Mafia game-engine fuzzer that generates allowed role/modifier combinations and plays games through test sockets. Each case runs in an isolated process, captures exceptions and logged errors, enforces a timeout, and saves replay inputs and action traces. MongoDB and Redis services are not required.

The PR also fixes crashes found while developing the fuzzer: missing action targets, incorrect card/action context in life-link and death-kill abilities, Orange item drop ordering, and Spymaster mission-state registration and leader-item cleanup. Shared setup validation is used by both setup creation and the generator.

## Mission and integrity behavior

Spymaster replaces ordinary condemnation with team selection, approval, and missions. A missing team now consumes a team-selection attempt rather than earning a successful mission. Rejected or unapproved teams skip Mission, rotate the leader, and retry; reaching the existing team-failure limit records a spy win for that mission. Approval-dependent state selection is rechecked after vote resolution. A new attempt clears the previous team and approval, and missing/empty teams cannot be scored as played missions.

Test games retain the normal integrity state change and safe-to-leave alert. Only the heart-refund and leaving-penalty persistence methods return early in test mode.

## Validation

Ran on the updated head:

```sh
NODE_ENV=test ./node_modules/.bin/mocha --exit test/mafiaMissionRegression.test.js test/mafiaFuzz.test.js
```

**26 passing:** 19 fuzzer tests and 7 new regression cases covering integrity behavior without persistence, missing/empty team scoring, team retries and their limit, rejection, approval timeout, and approved-team progression. Regression cases run in disposable processes with service substitutions and exercise the actual engine methods and approval votes.

Updated the existing Spymaster integration scoring test to record a team before recording a mission result. The MongoDB/Redis-dependent integration suite was not run for this follow-up. `git diff --check` passed.

## Usage and remaining findings

```sh
npm run fuzz:mafia -- --seed 1 --cases 100
node scripts/mafia-fuzz/run.js --replay path/to/case.json
```

Documentation is in `scripts/mafia-fuzz/README.md`. The additional 1,000-seed investigation and remaining engine/harness failures are tracked separately in #3020; this PR does not claim to resolve all of them.
