### PR TITLE
fix: sort family members by rank

### DIFF
--- a/react_main/src/pages/User/Family.jsx
+++ b/react_main/src/pages/User/Family.jsx
@@ -249,7 +249,11 @@ export default function Family() {
 
   const hasTrophySpotlight = family.perks?.some((p) => p.key === "trophySpotlight" && p.owned);
 
-  const membersList = family.members.map((member) => (
+  const rankOrder = { leader: 0, officer: 1, member: 2 };
+  const sortedMembers = [...family.members].sort(
+    (a, b) => (rankOrder[a.role] ?? 2) - (rankOrder[b.role] ?? 2)
+  );
+  const membersList = sortedMembers.map((member) => (
     <Box
       key={member.id}
       sx={{


### PR DESCRIPTION
Family pages now list the leader first, followed by officers and members. Members with the same rank retain their existing order, and sorting leaves the original member array unchanged.

Validation: ESLint passed for `react_main/src/pages/User/Family.jsx` with six existing warnings and no errors; `git diff --check` passed.
